### PR TITLE
Make Python Great Again: open the gates to 3.12, beautiful README, version 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,28 +25,161 @@ harnesses and iterate faster.
 See [PRIOR_ART.md](PRIOR_ART.md) for a detailed review of existing alternatives,
 and why none are good enough for practical use.
 
-Holoso is under active development and as such it has no burden of backward compatibility.
-Breaking changes will occur regularly without notice until v1.0 is out.
-Many critical features are missing which may limit applicability beyond applications that we are immediately involved with.
+Holoso is under active development and many of the features we aspire to deliver are currently missing.
+Holoso is not yet stable; breaking changes will occur regularly without notice until v1.0 is out.
 Contributions of any kind are emphatically welcome!
 
 <img src="docs/hero.png" width="900px">
 
-## Design
+## 🎓 Crash course
+
+### Install
+
+```
+pip install holoso
+```
+
+Also have your low-level synthesis/simulation tools available.
+
+### Define your kernel
+
+The *kernel* is a Python function or method that implements a given computation,
+which is translated into a Verilog module.
+
+Crucially, the kernel is just an *ordinary Python entity* that doesn't require (nontrivial) adaptation for hardware
+synthesis; this is a key feature of Holoso -- just take your existing code that has been validated and
+verified in simulation and use it as-is, no error-prone porting is required,
+not necessary to maintain two parallel implementations.
+
+The `examples/` directory contains a number of kernels that show the current capabilities of Holoso.
+Here, we will define a very simple one to keep things compact; let's say it's going to be a classical PID controller:
+
+```python
+class PID:
+    def __init__(self, *, kp: float, ki: float, kd: float, limit: float) -> None:
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self.limit = limit
+        self.integral = 0.0
+        self.prev_error = 0.0
+        self._started = False
+
+    def update(self, setpoint: float, measurement: float, dt: float, /) -> float:
+        error = setpoint - measurement
+        candidate = self.integral + self.ki * error * dt
+        derivative = (self.kd * (error - self.prev_error) / dt) if self._started else 0.0
+        self.prev_error = error
+        self._started = True
+        u = self.kp * error + candidate + derivative
+        if u > self.limit:
+            u = self.limit
+        elif u < -self.limit:
+            u = -self.limit
+        else:
+            self.integral = candidate
+        return u
+```
+
+Gee this looks exceptionally ordinary!
+No sophisticated scaffolding is required to simulate and verify this!
+The kernel can also be a standalone function (see examples).
+
+### Configure the hardware
+
+To construct the synthesizable RTL out of this, we need to pass our kernel to Holoso.
+But Holoso does not know the limits of the target hardware, such as the longest combinational path.
+Some tools provide fully automatic pipelining where the user specifies some target clock frequency and the synthesizer
+attempts to automatically cut circuits into pipeline stages relying on combinational path delay heuristics
+(e.g., see [Google XLS docs](https://google.github.io/xls/scheduling/)).
+Holoso does not do that; instead, it provides explicit tuning knobs that enable insertion of predefined optional stages.
+This makes pipeline tuning a somewhat more manual process but it also appears to deliver better results across various
+target chips and flows.
+
+Holoso constructs a specialized zero instruction set computer (ZISC) tightly optimized for the given kernel
+with fully statically scheduled microcode. That ZISC machine has a simple static controller at its core
+and a number of numerical and logical operators taking the place of ALU found in a conventional computer.
+Most of the chip fabric is spent on the operators while the controller is typically comparatively simple;
+most of the pipeline tuning is therefore also happening inside the operators.
+
+The user specifies which optional operator stages to enable by specifying them before Holoso synthesis is invoked.
+This is also where the *operand width* is selected: Holoso supports arbitrary-precision floating-point numbers
+with configurable exponent and mantissa width; its floating point format is based on IEEE-754 with a number of
+intentional deviations (no NaN, no subnormals).
+Custom floating point is a very important feature for FPGA targets because their DSP tiles have specific operand
+widths which are usually very different from the standard IEEE 754 binary16/32/64/etc,
+meaning that those standard representations are rarely the optimal choice for an FPGA target.
+
+The full configuration might look as follows:
+
+```python
+import holoso
+
+# Select the floating-point format you wish to use.
+# Ideally, wman (mantissa width) should be a multiple of DSP tile operand width.
+fmt_f = holoso.FloatFormat(wexp=6, wman=18)
+
+# Define the numerical operators. This is where you can configure additional stages to close timings.
+operators = holoso.OpConfig(
+    holoso.FAddOperator(fmt_f, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1, stage_output=1),
+    holoso.FMulOperator(fmt_f, stage_input=1, stage_product=1, stage_pack=1, stage_output=1),
+    holoso.FDivOperator(fmt_f, stage_input=1, stage_pack=1, stage_output=1),
+    holoso.FMulILog2OperatorFamily(fmt_f),
+    holoso.FCmpOperator(fmt_f),
+)
+```
+
+### Construct the RTL
+
+Having set up the kernel and the hardware options, we can launch synthesis.
+
+If the kernel is a function, it is simply passed to Holoso as-is.
+Classes are different because they are stateful: to synthesize a class method,
+we instantiate the class as we normally do, then we can optionally tweak the object's state as needed,
+and then we pass its bound method to Holoso.
+Holoso will inspect the current state of the class and use it as the module's reset state.
+The passed bound method will be converted into the stateful RTL module.
+
+```python
+# Construct the stateful object with its initial state.
+pid = PID(kp=0.5, ki=0.0625, kd=0.25, limit=4.0)
+
+# Run Holoso -- construct the machine and schedule the microcode.
+# The results are returned in-memory; you can write them to disk where you want.
+# They include the generated Verilog module, the fixed holoso_support.v/.vh, testbench, and the reports.
+result = holoso.synthesize(pid.update, operators)
+
+# Write the files -- this is usually what you want.
+out = result.write("outputs")
+
+# Show what's been written.
+for filename, path in out.items():
+    print(f"{filename}: {path}")
+```
+
+### Inspect the results
+
+The main backend is the one that emits Verilog RTL (unlike most other tools, this RTL is pretty human-readable), but
+Holoso also generates human-friendly HTML reports that reveal the operation of the generated machine in great detail,
+including the register liveness, operator pipeline occupancy, etc.
+
+## ⚙️ Design
 
 Holoso implements essentially a separate programming language whose syntax is a strict subset of Python,
 and whose semantics is largely equivalent to Python with minor deviations that make sense in chip design context.
 Save for the minor differences in semantics, Holoso ensures that one can execute the original Python code
 and run the generated circuit (RTL) side by side, and obtain equivalent results (bit-exact unless floating points
-are used, in which case small errors may creep up, due to the inherent limitations of floating points).
+are used, in which case small errors may creep up inherent to floats).
 
-Unlike most (all known to us) HLS engines out there, Holoso does not generate a straight-line II=1 pipeline
-because this is rarely what you actually need in practice; instead, it designs a narrowly specialized
-computing core (a zero-instruction-set processor) with custom microcode, and statically schedules a program for the
-designed core. Being in control of both the core synthesis and the program compilation, Holoso tends to generate
+Holoso designs a narrowly specialized computing core (a zero-instruction-set computer, ZISC)
+with custom statically scheduled microcode that implements the behavior of the original Python kernel.
+Being in control of both the core synthesis and the program compilation, Holoso tends to generate
 extremely efficient designs in terms of cycle latency and chip area utilization compared to the state of the art.
+This ZISC-based approach has a greater initiation interval (II) compared to pure-pipeline approach
+(at most one transaction in flight at any moment), but it results in significant chip area savings in complex cores.
+From our experience, this choice is defensible in a large subset of practical control/DSP applications.
 
-Holoso outputs a purely portable and vendor-agnostic Verilog that can be fed into thid-party synthesis tools as-is,
+Holoso outputs portable and purely vendor-agnostic Verilog that can be fed into thid-party synthesis tools as-is,
 along with its support library implementing various arithmetic operators. So far it has been tested at least with
 Yosys (ECP5), Diamond (ECP5), and Vivado (Artix-7).
 
@@ -54,16 +187,13 @@ By default, Holoso is tuned for the minimum cycle latency and minimum $f_\max$.
 If timing closure fails, one needs to locate the critical path and enable the staging knob that inserts a
 register stage into the offending path; then re-synthesize and repeat until timings close.
 
-Holoso has its own efficient floating point engine that is a subset of IEEE-754, omitting support for subnormals and NaN.
-Arbitrary exponent and significand bit widths are supported (the IEEE-754 defaults map poorly onto FPGA DSP tiles).
-
 Along with the synthesized Verilog, Holoso produces a Cocotb co-simulation testbench and a detailed and beautiful HTML
 report that provides a human-friendly view of the processor and the microcode sequence constructed by the synthesizer.
 
 >*You can SEE the pipeline — every cycle, every landing, every spill. It's gorgeous. People love it.*
 >*They come up to me with tears in their eyes, they say sir, that schedule report, it's the most beautiful report we have ever seen.*
 
-For a detailed review of the design and trade-offs, please refer to `DESIGN.md`.
+For a detailed technical review of the design and trade-offs, please refer to `DESIGN.md`.
 
 ### Semantics
 
@@ -122,49 +252,14 @@ and thus requires careful selection to achieve best resource utilization.
 Narrower WMAN is rarely practical for computation due to low precision and fast error accumulation,
 although they can still be useful for storage/exchange. One notable exception is neural networks though.
 
-## Usage
-
-Unlike most tools in this domain, Holoso is trivial to set up and get started with; it is not a framework.
-
-Install: `pip install holoso`.
-
-```python
-# Select the floating-point format you wish to use.
-# Ideally, wman (mantissa width) should be a multiple of DSP tile operand width.
-float_format = holoso.FloatFormat(wexp=6, wman=18)
-
-# Define the numerical operators. This is where you can configure additional stages to close timings.
-ops = holoso.OpConfig(
-    holoso.FAddOperator(float_format),
-    holoso.FMulOperator(float_format),
-    holoso.FDivOperator(float_format),
-    holoso.FMulILog2OperatorFamily(float_format),
-    holoso.FCmpOperator(float_format),
-)
-
-# Run Holoso -- construct the processor and the microcode.
-# The results are returned in-memory; you can write them to disk where you want.
-# They include the generated Verilog module, the fixed holoso_support.v/.vh, testbench, and the reports.
-result = holoso.synthesize(your_function_or_method_here)
-
-# Write the files -- this is usually what you want.
-out = result.write(Path(__file__).resolve().parent)
-
-# Show what's been written.
-for filename, path in out.items():
-    print(f"{filename}: {path}")
-```
-
-See the `examples/` directory for self-contained usage examples.
-
-## Verification
+## 🛡️ Verification
 
 Just say `nox`. Read the `noxfile.py` and `DESIGN.md` for details.
 
 You may find the [zubax-fpga-toolchain](https://github.com/Zubax/fpga-toolchain-docker/pkgs/container/zubax-fpga-toolchain)
 container useful as it comes with all of the required tools out of the box.
 
-## License
+## ⚖️ License
 
 Holoso is licensed under the [Apache License 2.0](LICENSE).
 What you produce with it is yours: the Verilog this tool generates, together with the bundled support RTL it stitches

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -44,5 +44,5 @@ from ._operators import (
     OpConfig as OpConfig,
 )
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __url__ = "https://holoso.digital"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ markers = [
 
 [tool.black]
 line-length = 120
-target-version = ["py314"]
+target-version = ["py312"]
 
 [tool.mypy]
 python_version = "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "holoso"
 dynamic = ["version"]
-requires-python = ">=3.14"
+requires-python = ">=3.12"  # Verification targets Python 3.14+; earlier versions supported on a best-effort basis.
 description = "A simple Python-to-Verilog synthesizer for numeric kernels, control systems, and DSP."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "Apache-2.0"

--- a/tests/_fuzz.py
+++ b/tests/_fuzz.py
@@ -1282,7 +1282,7 @@ def _reference_outputs(
             kwargs[name] = float(value)
     try:
         result = fn(**kwargs)
-    except ZeroDivisionError, OverflowError, ValueError:
+    except (ZeroDivisionError, OverflowError, ValueError):
         return None
     return [value for _, value in flatten_value(result)]
 

--- a/tests/_importguard.py
+++ b/tests/_importguard.py
@@ -49,7 +49,7 @@ def _source_and_anchor(module: str) -> tuple[Path | None, str]:
     """The module's source path and the package to resolve its relative imports against (itself if it is a package)."""
     try:
         spec = importlib.util.find_spec(module)
-    except ImportError, ValueError:
+    except (ImportError, ValueError):
         return None, module
     if spec is None or spec.origin is None or not spec.origin.endswith(".py"):
         return None, module


### PR DESCRIPTION
Folks, let me tell you, this is a tremendous pull request. Maybe the best Python compatibility update anybody has ever seen. People are saying it. Believe me.

## We're Making Python 3.12 Great Again

For years — many years, too many — Holoso said you need Python 3.14. Only 3.14! Very exclusive, very fancy, but a lot of great people couldn't get in the door. Sad! So we opened it up. Now the minimum is Python 3.12, and let me tell you, the people are thrilled.

- Lowered `requires-python` from `>=3.14` to `>=3.12`. Tremendous.
- Verification still targets 3.14 and up — that's the gold standard, the best — but 3.12 and 3.13 are now welcome on a best-effort basis. Nobody gets left behind.
- Black target moved to `py312` so the formatting is beautiful. Perfectly formatted. The best code you've ever seen.

## We Found Some Bad Syntax. Very Bad.

There were these `except` clauses, total disaster, written like `except A, B:` — that doesn't even work on the great Python versions. A catastrophe. We fixed them, fast, with the parentheses they always needed:

- `tests/_fuzz.py` — fixed.
- `tests/_importguard.py` — fixed.

Now they catch their exceptions like champions.

## A Beautiful New README

The README? We rebuilt it. Bigger, classier, easier to understand. Almost 200 lines, and every one of them a winner. People are going to read this and say "wow, now I finally get it." Kernels, operators, stateful classes, the whole thing — explained tremendously.

## And Yes, A Brand New Version

Bumped from 0.1.2 to 0.1.3. A small number, but a very powerful number. The best 0.1.3 in the business.

---

In summary: more Pythons, cleaner code, a gorgeous README, and a fresh version. We're going to synthesize so much Verilog, you're going to be tired of synthesizing Verilog. Thank you.
