### PR TITLE
Refactor Verilog microcode emission

### DIFF
--- a/.claude/skills/comment-cleanup/SKILL.md
+++ b/.claude/skills/comment-cleanup/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: comment-cleanup
 description: >-
-  Prune low-value comments and docstrings across a codebase while preserving genuine rationale and
-  enforcing consistency. Use when asked to remove verbose or redundant comments, tighten documentation,
-  or make comment style uniform. Aggressive downsizing, but never erase valuable information.
+  Prune nonessential comments and docstrings across a codebase.
+  Use when asked to remove verbose or redundant comments, tighten documentation, or make comment style uniform.
+  Aggressive downsizing, but retain high-value information.
 ---
 
 # Comment cleanup
 
-Remove comments and docstrings that restate what the code or the type system already says; keep the ones
-carrying information a competent reader could not reconstruct from names, signatures, and code in a few seconds.
+Trim ALL comments/docstrings EXCEPT those that carry information a competent reader could not reconstruct from names,
+signatures, and code in a few seconds.
 
 ## Keep vs. remove
 
-REMOVE: name-echo describers (a docstring that just expands the identifier), narration of obvious control flow,
-section-divider banners, value-trace and "what the next line does" comments, type-obvious prose.
+REMOVE: name-echo describers, control flow / type / structure narration, section-divider banners,
+value-trace and "what the next line does" comments, type-obvious prose.
 
 KEEP: design rationale (the WHY), gotchas and edge-cases, contracts and invariants, cross-references,
 standards or paper citations, hardware and timing facts, and the provenance of a regression test.
 
-When uncertain whether something is rationale or restatement, keep it. The expensive mistake is erasing valuable
-information, not leaving one extra obvious line. This guardrail outranks any size target.
+When uncertain whether something is rationale or restatement, keep it.
+The expensive mistake is erasing valuable information, not leaving one extra obvious line.
 
 ## Never touch
 

--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -12,6 +12,10 @@ After a change or milestone, or when prompted, dispatch a fan-out of fresh-conte
 MAXIMUM THINKING EFFORT, then consolidate, fix, and repeat.
 The goal is broad coverage from adversarial, diverse, independent perspectives.
 
+The prompts given to the agents shall be extremely terse, at most a couple of sentences.
+Giving excessive detail may constrain their thinking causing the tunnel vision syndrome.
+They must be given the opportunity to look at the work without bias or prejudice.
+
 ## Fan out — one focus per agent
 
 Spawn one agent per concern and run them in parallel. Never give an agent multiple jobs: it dilutes attention

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@ retry them until success.
 Given a trade-off between performance and simplicity, always choose simplicity.
 Clear designs are easier to verify, maintain, and refactor, and they are more likely to be correct.
 
-Write only minimal comments that add rationale, high-level context, or non-obvious implications.
-Avoid comments that merely describe what the code does or restate what is already evident from the type system.
+Do not write any comments or docs unless they add something that is impossible to infer from the source code,
+such as design rationale, high-level context, non-obvious implications, etc.
+Comments that describe what the code does or restate what is inferrable from the type system are strictly prohibited.
 
 ### Reset strategy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Holoso -- simple high-level synthesis of Python into Verilog for numerical code
 
 Holoso converts a small subset of Python functions and expressions into synthesizable and verifiable Verilog.
-Read the `README.md`.
+Read the `README.md` and `DESIGN.md`.
 
 Whenever introducing nontrivial changes, update `DESIGN.md` as well to keep it fully up-to-date and non-conflicting
 with the implementation. However, do not attempt to capture minor implementation minutiae there, keep it high-level.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,6 @@ In complex modules, it is best to avoid a large number of named nets that are on
 Leave unused module outputs unconnected, like `.out_foo()`, instead of creating unused wires.
 
 It is best to keep at most one `always @(posedge clk)` per module, unless there are strong reasons to do otherwise.
-This rule should be followed, in particular, in Verilog emitted by the compiler.
 
 The same register can be assigned multiple times only as long as the assignments reside in different branches that
 cannot be active at the same time and are explicitly segregated with a single condition that is explicit to the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,8 @@ Special things to look out for:
   multiplicand bitwidth exceeds the DSP slice input width.
 - Retiming is sneaky: a moved stage may cause a different path to become critical, so with retiming enabled one needs
   to evaluate the adjacent stages as well.
+- Route-dominated is not automatically unstageable: a register roughly halves routing distributed across a path's logic
+  levels (one shared `fadd` normalize stage can lift a cluster of rows), but cannot shorten a single high-fanout net.
 
 More pipeline stages do not necessarily improve f_max, and can cost both timing and area. Every optional stage spreads
 that operator's flip-flops across more slices; on a wide, register-pressure-heavy datapath this adds routing congestion,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -305,8 +305,8 @@ writes, and an issue cycle; the makespan is the last commit cycle, and the obser
 from it and the fetch timing of the datapath. LIR exposes a minimal API plus shared analysis helpers (per-cycle
 grouping, liveness, read/writer sets) so backends do not each re-derive them.
 
-Storage is a sparse register file synthesized per kernel: each operand's read mux spans only the registers it reads,
-each register's write select only its actual writers (see Backend for the encoding). A CPU-conventional full-reach
+Storage is a sparse register file synthesized per kernel: each operand's read mux spans only the sources it reads,
+each register's write mux only the sources it takes (see Backend for the encoding). A CPU-conventional full-reach
 crossbar was tried first and abandoned -- its read/write port multiplexors imposed untenable timing.
 
 ### Scheduling
@@ -366,9 +366,9 @@ Persistent state slots. Both banks commit state in place: a live-out is written 
 read-first, so a same-frame self-update (`self.x = self.x | y`, an accumulator) reads the old value and writes the new
 one with no copy. A conditional or loop update whose "unchanged" arm is the slot live-in coalesces onto the slot
 register through the same phi-arm union-find. When it cannot commit in place (a genuine overlap, a folded sign, or a
-chained copy `self.a = self.b`) the live-out keeps its own register and a pc-gated copy installs it as early as the old
-live-in is read. Two slots that always hold the same value collapse onto one register (a public attribute and its
-private alias), dropping the duplicate register and its install copy. State
+chained copy `self.a = self.b`) the live-out keeps its own register and a microcode-driven copy installs it as early as
+the old live-in is read. Two slots that always hold the same value collapse onto one register (a public attribute and
+its private alias), dropping the duplicate register and its install copy. State
 registers are the one datapath exception that reset reaches (each loaded with its snapshot); pure datapath state stays
 out of the reset cone.
 
@@ -401,7 +401,7 @@ never a miscompile. Unifying the two is tracked future work.
 ### DEFERRED
 
 Aggressive cross-block overlap: the landed pipelining shrinks a terminator only to its issue-side envelope, so
-write-enable words stay in-block and no microcode is replicated. Pushing further -- letting the write-enable words spill
+write-opcode words stay in-block and no microcode is replicated. Pushing further -- letting the write-opcode words spill
 past the terminator -- would shave the remaining per-block tail but needs the commit-side control fields replicated into
 every successor arm, policed by the single-writer microcode validator (already in place). Overlap also stays off across
 any multi-predecessor edge.
@@ -425,40 +425,46 @@ scheduling only adds to the makespan/II; the depth is currently fixed but may be
 The schedule replays step by step: at PC 0 the machine accepts and parallel-loads inputs into the low registers of each
 bank in one cycle (gated by `in_valid`); the PC advances every clock; at the last PC it asserts `out_valid` while
 outputs drive combinationally from their registers by fixed index. Both banks read combinationally, so each operand's
-read-address control rides its issue step (a combinational read mux samples the operand a fetch lag later) and the
-write-enable/address its commit step. The PC holds only at the two I/O boundaries; bubble steps carry an explicit NOP.
-While the PC dwells it re-fetches that word each cycle, but `transacting` (high only while a transaction is in flight)
-gates every operator's `in_valid` and the register write-enables, so the idle re-fetch commits nothing and the entry
-word can carry real work.
+read opcode rides its issue step (a combinational read mux samples the operand a fetch lag later) and each register's
+write opcode its source's executing step. The PC holds only at the two I/O boundaries; bubble steps carry an explicit
+NOP. While the PC dwells it re-fetches that word each cycle, but `transacting` (high only while a transaction is in
+flight) forces every operator's `in_valid` and every register's write opcode to the inert NOP code, so the idle
+re-fetch commits nothing and the entry word can carry real work.
 
-The control word stores selectors and addresses, never data. An inline firing (boolean logic, a cast) is a single
-PC-gated statement rendered by the operator's own expression rather than a microcode lane, because it fires once at a
-statically known step. A control field constant across the whole program (common for sign controls, single-reader read
-addresses, single-writer destinations) is driven by a constant net and lifted out of the ROM, so synthesis prunes what
-it feeds; the Python ROM packer and the module's bit-slice offsets are produced together so they cannot drift. A strobe
-field (operator issue, the write-enables) instead ANDs `transacting` into its decode, so a dwelling re-fetch is inert.
+The control word stores selectors and value routing is uniform across two dual endpoints: a per-operand READ opcode
+selects that port's source, and a per-register WRITE opcode selects that register's next value (code 0 == NOP hold).
+An operator output, an inline expression (boolean logic, a cast, a select), and a phi-arm/constant/state
+move are all just sources one write opcode picks, so PC gates no datapath read or write -- it is left to control flow
+alone. A control field constant across the whole program (sign controls, single-source ports and registers) is driven
+by a constant net and lifted out of the ROM, so synthesis prunes what it feeds; the Python ROM packer and the module's
+bit-slice offsets are produced together so they cannot drift. A gated field (an operator issue strobe or a write
+opcode) ANDs `transacting` into its decode -- a width-generic mask to the NOP code -- so a dwelling re-fetch is inert.
 
-Sparse storage. A multi-reader operand's read mux is a `case` over its dense read-set index selecting a register
-directly. This deliberately avoids an indexed part-select into a packed gather bus, whose variable offset is a multiply
-that, at a non-power-of-two word width, makes Lattice Diamond's LSE infer a DSP per operand on the read path; a `case`
-has no offset arithmetic at all and measures smaller and faster on every flow. Each register's write select is a one-hot
-over only its writers. Both sides carry a set-local index sized to the set, never the file-wide register index, so the
-ROM word stays narrow.
+Sparse storage. Each operand's read mux is a `case` over its read codebook -- the registers it reads plus each distinct
+constant it reads (a constant's magnitude, its sign riding the operand-sign field into the wrapper) -- and each
+register's write is a `case` over its write codebook, both indexed by the endpoint's dense opcode. The `case` form
+deliberately avoids an indexed part-select into a packed gather bus, whose variable offset is a multiply that, at a
+non-power-of-two word width, makes Lattice Diamond's LSE infer a DSP per operand; a `case` has no offset arithmetic and
+measures smaller and faster on every flow. A single-source read port drives its lone source directly and needs no
+opcode field (a single-source register still carries a 1-bit write opcode -- its folded write-enable/NOP); every opcode
+is sized to its own codebook, never the file-wide index, so the ROM word stays narrow.
 
 Errors are non-fatal and informative: each error-bearing operator's flag (`div0`, `domain_error`, etc.) ORs into a
-global `err` gated by that instance's write-enable, and an `err_pc` latch records the executing step of the last error
-(reset at every accept).
+global `err` gated by whether some destination register's write opcode selects that instance's output this step (its
+commit window), and an `err_pc` latch records the executing step of the last error (reset at every accept).
 
 Reset covers the control registers and the persistent state registers: the reset arm loads each state register with its
-snapshot while the non-reset arm applies that register's update chain (its coalesced writebacks and boundary install),
-the two segregated as the arms of one `rst` condition. The fetch registers and the rest of the datapath are
-reset-unconditional (so they pack into the BRAM output register) and settle to the first word under reset. The control
-word and datapath skeleton are the only ZISC-specific part -- LIR itself is controller-agnostic.
+snapshot while the non-reset arm applies that register's opcode-selected update and its boundary install (a
+handshake-gated arm at `out_valid && out_ready`), the two segregated as the arms of one `rst` condition. The fetch
+registers and the rest of the datapath are reset-unconditional (so they pack into the BRAM output register) and settle
+to the first word under reset. The control word and datapath skeleton are the only ZISC-specific part --
+LIR itself is controller-agnostic.
 
 Why read-first plus a +1 dependency cycle, not write-through forwarding? Write-through would erase the +1 but its
 forwarding muxes cost `O(NRD*NWR)`, and we need many ports -- unsustainable. Read-first plus the +1, hidden under
-pipelined overlap, is the better trade. Constant operands are kept as immediates on the input mux; folding them into the
-register file or emitting constant-load micro-instructions are noted alternatives for when this becomes a constraint.
+pipelined overlap, is the better trade. Constant operands are kept as immediate `const_N` nets the read opcode selects,
+never stored in the ROM word; folding them into the register file or emitting constant-load micro-instructions are noted
+alternatives for when this becomes a constraint.
 
 Each operator instance carries its own parameters and float format, fixed at construction from the `OpConfig`. Every
 instantiation lists every hardware parameter explicitly, so it is self-describing and turns a param-name mismatch into a
@@ -516,12 +522,16 @@ so the dead ends are not re-explored.
 
 Adopted (lossless, f_max-neutral):
 
-- Read mux as a `case` over the dense read-set index rather than an indexed part-select into a packed gather bus:
-  smallest and fastest of the encodings tried. Nested-ternary muxes are catastrophic.
+- Read and write muxes as a `case` over the endpoint's dense opcode (the read codebook folds in the constants a port
+  reads; the write codebook, the sources a register takes) rather than an indexed part-select into a packed gather bus,
+  or the nested-ternary const-pool selector it replaced: smallest and fastest of the encodings tried. Nested-ternary
+  muxes are catastrophic.
 - Commutative operand port assignment, solved exactly as a MILP: a few percent LUT on the EKF across all three tools, at
   zero hardware or latency cost. Based on Chen & Cong.
-- Dense write-target index and a grouped input load: read/write symmetry at neutral area. The per-register write select
-  beats a per-instance write demux.
+- A per-register write opcode and a grouped input load: read/write symmetry (read selects a source per port, write
+  selects a source per register) that folds every write-enable, write-address, const-pool selector, and boolean
+  inversion into one tiny opcode, at modest ROM cost. A signed-constant install folds its sign into a compile-time
+  constant; a register-source sign stays a runtime `holoso_fsgnop`.
 
 Explored and rejected for register-pressure-bound kernels:
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -417,10 +417,15 @@ The Verilog backend is mechanical from LIR: an inline flop bank plus the 1-bit b
 operator instance, and one continuous assignment per pooled constant. Either bank is emitted only when used (a
 purely-boolean kernel carries no wide register file). There is no general multiport register-file module; storage is
 the sparse, schedule-specific fabric below. The controller is a microcode ROM -- one pre-decoded VLIW
-control word per step, stored in a BRAM-inferable ROM read through a short multi-stage fetch (a PC latch, the array
-read, and the BRAM output register) so the controller is short register-to-register paths rather than a wide
-combinational `case(cyc)` cone, for a fast clock-to-out. The fetch leads the executing step, which under static
-scheduling only adds to the makespan/II; the depth is currently fixed but may be made disableable for faster chips.
+control word per step, written as a synchronous `case` over the fetch PC. That `case`-over-address is the inferable-ROM
+form every backend recognizes, so each maps it to an appropriate ROM (LUT logic or block RAM), rather than the
+array-plus-`initial` form, which some backends do not recognize as a ROM at all (flattening it to logic) and others
+force into a slow block RAM even when tiny. It is read through a short multi-stage fetch (a PC
+latch, the ROM read register, and a routing register) so the controller is short register-to-register paths rather than
+a wide combinational `case(cyc)` cone, for a fast clock-to-out. The ROM `case` occupies its own clocked block -- the
+sole sanctioned second `always @(posedge clk)` -- since that dedicated form is what triggers the memory inference. The
+fetch leads the executing step, which under static scheduling only adds to the makespan/II; the depth is currently fixed
+but may be made disableable for faster chips.
 
 The schedule replays step by step: at PC 0 the machine accepts and parallel-loads inputs into the low registers of each
 bank in one cycle (gated by `in_valid`); the PC advances every clock; at the last PC it asserts `out_valid` while

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -440,7 +440,7 @@ The control word stores selectors and value routing is uniform across two dual e
 selects that port's source, and a per-register WRITE opcode selects that register's next value (code 0 == NOP hold).
 An operator output, an inline expression (boolean logic, a cast, a select), and a phi-arm/constant/state
 move are all just sources one write opcode picks, so PC gates no datapath read or write -- it is left to control flow
-alone. A control field constant across the whole program (sign controls, single-source ports and registers) is driven
+alone. A control field constant across the whole program -- a sign control the program never varies, say -- is driven
 by a constant net and lifted out of the ROM, so synthesis prunes what it feeds; the Python ROM packer and the module's
 bit-slice offsets are produced together so they cannot drift. A gated field (an operator issue strobe or a write
 opcode) ANDs `transacting` into its decode -- a width-generic mask to the NOP code -- so a dwelling re-fetch is inert.

--- a/holoso/_backend/numerical.py
+++ b/holoso/_backend/numerical.py
@@ -298,9 +298,8 @@ class NumericalSimulator(_Kernel):
 
     def _apply(self, pc: int) -> None:
         # Commit the landings due here BEFORE sampling this PC's reads/installs (read-first within the cycle).
-        # A register takes at most one landing per PC -- the interference graph guarantees it, and the RTL encodes each
-        # register with a single write opcode that could not carry two sources at once.
-        landings = self._pending.pop(pc, [])
+        # At most one landing per register per PC (interference graph + single per-register write opcode).
+        landings = self._pending.pop(pc, ())
         assert len({dst for dst, _ in landings}) == len(landings), f"reg landing conflict @ pc {pc}: {landings}"
         for dst, value in landings:
             self._write(dst, value)

--- a/holoso/_backend/numerical.py
+++ b/holoso/_backend/numerical.py
@@ -298,7 +298,11 @@ class NumericalSimulator(_Kernel):
 
     def _apply(self, pc: int) -> None:
         # Commit the landings due here BEFORE sampling this PC's reads/installs (read-first within the cycle).
-        for dst, value in self._pending.pop(pc, ()):
+        # A register takes at most one landing per PC -- the interference graph guarantees it, and the RTL encodes each
+        # register with a single write opcode that could not carry two sources at once.
+        landings = self._pending.pop(pc, [])
+        assert len({dst for dst, _ in landings}) == len(landings), f"reg landing conflict @ pc {pc}: {landings}"
+        for dst, value in landings:
             self._write(dst, value)
         for event in self._op_events.get(pc, ()):
             results = event.op.operator.evaluate(

--- a/holoso/_backend/verilog/_emit.py
+++ b/holoso/_backend/verilog/_emit.py
@@ -86,23 +86,14 @@ def _source_net(source: RegRef | FloatConstRef) -> str:
     return f"const_{source.index}" if isinstance(source, FloatConstRef) else f"regs[{source.index}]"
 
 
-def _fsgnop(w: _Writer, raw: str, sign: FloatSignControl, dst: str, inst: str) -> None:
-    w(f"holoso_fsgnop #(.WFULL(W)) {inst} (.x({raw}), .op(2'd{sign.encoded}), .y({dst}));")
-
-
-def _state_sign_wire(slot: FloatStateSlot) -> str | None:
-    """
-    The sign-conditioning wire name for a slot's writeback copy, or None when the copied tap needs no sign op. The stem
-    is deliberately not ``state_*``: a public attribute is exposed as a ``state_<attr>`` port, so a ``state_<name>_d``
-    net would collide with the port of an attribute literally named ``<name>_d``.
-    """
-    if slot.needs_copy and slot.tap.sign != FloatSignControl():
-        return f"statesgn_{slot.name}"
-    return None
+def _signed_source_net(source: RegRef | FloatConstRef, sign: FloatSignControl) -> str:
+    """A source net with its folded sign applied inline via ``holoso_fsgnop``, or bare when the sign is identity."""
+    raw = _source_net(source)
+    return raw if sign == FloatSignControl() else f"holoso_fsgnop({raw}, 2'd{sign.encoded})"
 
 
 def _state_copy_rhs(slot: FloatStateSlot) -> str:
-    return _state_sign_wire(slot) or _source_net(slot.tap.source)
+    return _signed_source_net(slot.tap.source, slot.tap.sign)
 
 
 def _inline_fire_pc(lir: Lir, block_index: int, op: InlineScheduledOp) -> int:
@@ -113,23 +104,16 @@ def _inline_fire_pc(lir: Lir, block_index: int, op: InlineScheduledOp) -> int:
     return lir.block_base[block_index] + inline_fire_cycle(op.commit_cycle, lir.fetch_lag)
 
 
-def _inline_sign_wire(block_index: int, op_index: int, pos: int) -> str:
-    return f"inlsgn_{block_index}_{op_index}_{pos}"
-
-
-def _inline_rhs(block_index: int, op_index: int, op: InlineScheduledOp) -> str:
+def _inline_rhs(op: InlineScheduledOp) -> str:
     """
-    The RHS of one inline firing: the operator's own combinational expression over its operand nets (a float operand
-    routes through its sign-conditioning wire when its folded sign is non-identity), with the result conditioner
-    applied -- an inversion folds into the expression; sign-conditioned wide inline results have no producer yet.
+    The RHS of one inline firing: the operator's own combinational expression over its operand nets (a float operand's
+    folded sign applies inline via ``holoso_fsgnop``), with the result conditioner applied -- an inversion folds into
+    the expression; sign-conditioned wide inline results have no producer yet.
     """
     nets: list[str] = []
-    for pos, operand in enumerate(op.operands):
+    for operand in op.operands:
         if isinstance(operand, FloatOperand):
-            if operand.sign != FloatSignControl():
-                nets.append(_inline_sign_wire(block_index, op_index, pos))
-            else:
-                nets.append(_source_net(operand.source))
+            nets.append(_signed_source_net(operand.source, operand.sign))
         else:
             nets.append(_bool_operand_rhs(operand))
     expr = op.operator.verilog_expr(*nets)
@@ -176,9 +160,6 @@ def generate(lir: Lir) -> VerilogOutput:
     _emit_field_wires(w, fields)
     _emit_operators(w, lir, write_lists)
     _emit_datapath_comb(w, lir, port_consts, write_lists)
-    _emit_state_next(w, lir)
-    _emit_copy_sign_wires(w, lir)
-    _emit_inline_sign_wires(w, lir)
     _emit_read_muxes(w, lir, read_port, port_consts, read_sets)
     _emit_clocked(w, lir, write_sets, write_lists)
     _emit_outputs(w, lir)
@@ -529,14 +510,8 @@ def _bool_write_pc(lir: Lir, block: LirBlock, write: BoolWrite) -> int:
     return lir.block_base[block.index] + write.fire_step(lir.fetch_lag)
 
 
-def _copy_sign_wire(block_index: int, copy_index: int) -> str:
-    return f"copysgn_{block_index}_{copy_index}"
-
-
-def _float_copy_rhs(block_index: int, copy_index: int, copy: FloatCopy) -> str:
-    if copy.source.sign == FloatSignControl():
-        return _source_net(copy.source.source)
-    return _copy_sign_wire(block_index, copy_index)
+def _float_copy_rhs(copy: FloatCopy) -> str:
+    return _signed_source_net(copy.source.source, copy.source.sign)
 
 
 def _bool_operand_rhs(operand: BoolOperand) -> str:
@@ -559,12 +534,10 @@ def _copies_grouped(lir: Lir) -> dict[int, list[tuple[int, str]]]:
     """
     grouped: dict[int, list[tuple[int, str]]] = {}
     for block in lir.blocks:
-        for copy_index, copy in enumerate(block.copies):
+        for copy in block.copies:
             if is_ucode_const_copy(copy):
                 continue
-            grouped.setdefault(copy.dst.index, []).append(
-                (_float_copy_pc(lir, block, copy), _float_copy_rhs(block.index, copy_index, copy))
-            )
+            grouped.setdefault(copy.dst.index, []).append((_float_copy_pc(lir, block, copy), _float_copy_rhs(copy)))
     return grouped
 
 
@@ -580,46 +553,6 @@ def _bool_writes_grouped(lir: Lir) -> dict[int, list[tuple[int, str]]]:
                 continue
             grouped.setdefault(write.dst.index, []).append((_bool_write_pc(lir, block, write), _bool_write_rhs(write)))
     return grouped
-
-
-def _emit_copy_sign_wires(w: _Writer, lir: Lir) -> None:
-    emitted = False
-    for block in lir.blocks:
-        for copy_index, copy in enumerate(block.copies):
-            if copy.source.sign != FloatSignControl():
-                wire = _copy_sign_wire(block.index, copy_index)
-                w(f"wire [W-1:0] {wire};")
-                _fsgnop(w, _source_net(copy.source.source), copy.source.sign, wire, f"u_{wire}")
-                emitted = True
-    if emitted:
-        w("")
-
-
-def _emit_inline_sign_wires(w: _Writer, lir: Lir) -> None:
-    emitted = False
-    for block in lir.blocks:
-        for op_index, op in enumerate(block.inline_ops):
-            for pos, operand in enumerate(op.operands):
-                if isinstance(operand, FloatOperand) and operand.sign != FloatSignControl():
-                    wire = _inline_sign_wire(block.index, op_index, pos)
-                    w(f"wire [W-1:0] {wire};")
-                    _fsgnop(w, _source_net(operand.source), operand.sign, wire, f"u_{wire}")
-                    emitted = True
-    if emitted:
-        w("")
-
-
-def _emit_state_next(w: _Writer, lir: Lir) -> None:
-    emitted = False
-    for slot in lir.float_state_slots:
-        wire = _state_sign_wire(slot)
-        if wire is None:
-            continue
-        w(f"wire [W-1:0] {wire};")
-        _fsgnop(w, _source_net(slot.tap.source), slot.tap.sign, wire, f"u_statesgn_{slot.name}")
-        emitted = True
-    if emitted:
-        w("")
 
 
 def _read_mux_stmts(w: _Writer, target: str, port: int, read_set: list[int], port_consts: dict[int, list[int]]) -> None:
@@ -701,12 +634,12 @@ def _wide_writer_entries(
             (f_cwen(RegRef(reg)), _const_pool_mux(f_ccidx(RegRef(reg)), const_books[reg]), "")
         )
     for block in lir.blocks:
-        for op_index, inline_op in enumerate(block.inline_ops):
+        for inline_op in block.inline_ops:
             if isinstance(inline_op.write.dst, RegRef):
                 entries.setdefault(inline_op.write.dst.index, []).append(
                     (
                         f"pc == {_inline_fire_pc(lir, block.index, inline_op)}",
-                        _inline_rhs(block.index, op_index, inline_op),
+                        _inline_rhs(inline_op),
                         "inline fire",
                     )
                 )
@@ -737,12 +670,12 @@ def _bool_writer_entries(
     for reg in const_install_bool_regs(lir):
         entries.setdefault(reg, []).append((f_cwen(BoolRegRef(reg)), f_cval(BoolRegRef(reg)), ""))
     for block in lir.blocks:
-        for op_index, inline_op in enumerate(block.inline_ops):
+        for inline_op in block.inline_ops:
             if isinstance(inline_op.write.dst, BoolRegRef):
                 entries.setdefault(inline_op.write.dst.index, []).append(
                     (
                         f"pc == {_inline_fire_pc(lir, block.index, inline_op)}",
-                        _inline_rhs(block.index, op_index, inline_op),
+                        _inline_rhs(inline_op),
                         "inline fire",
                     )
                 )
@@ -900,16 +833,10 @@ assign in_ready  = (pc == 0);
 assign out_valid = (pc == LASTPC);  // result valid on PRESENT; execution lags the fetch by FETCH_LAG
 assign err_pc    = err_pc_q;
 """)
-    float_index = 0
     for wire in lir.outputs:
         match wire:
             case BoolOutputWire():
                 w(f"assign {wire.name} = {_bool_operand_rhs(wire.tap)};")
             case FloatOutputWire():
-                raw = _source_net(wire.tap.source)
-                if wire.tap.sign == FloatSignControl():
-                    w(f"assign {wire.name} = {raw};")
-                else:
-                    _fsgnop(w, raw, wire.tap.sign, wire.name, f"u_outsgn_{float_index}")
-                float_index += 1
+                w(f"assign {wire.name} = {_signed_source_net(wire.tap.source, wire.tap.sign)};")
     w("")

--- a/holoso/_backend/verilog/_emit.py
+++ b/holoso/_backend/verilog/_emit.py
@@ -97,6 +97,16 @@ def _bool_operand_rhs(operand: BoolOperand) -> str:
     return f"~{net}" if operand.inversion.invert else net
 
 
+def _operand_rhs(operand: FloatOperand | BoolOperand) -> str:
+    match operand:
+        case FloatOperand():
+            return _signed_source_net(operand.source, operand.sign)
+        case BoolOperand():
+            return _bool_operand_rhs(operand)
+        case _:
+            assert_never(operand)
+
+
 def _render_inline(
     operator: InlineHardwareOperator, operands: tuple[FloatOperand | BoolOperand, ...], conditioner: PortConditioner
 ) -> str:
@@ -105,21 +115,12 @@ def _render_inline(
     sign applies inline via ``holoso_fsgnop``), with the result conditioner applied -- an inversion folds into the
     expression; sign-conditioned wide inline results have no producer yet.
     """
-    nets: list[str] = []
-    for operand in operands:
-        if isinstance(operand, FloatOperand):
-            nets.append(_signed_source_net(operand.source, operand.sign))
-        else:
-            nets.append(_bool_operand_rhs(operand))
+    nets = [_operand_rhs(operand) for operand in operands]
     expr = operator.verilog_expr(*nets)
     if isinstance(conditioner, BoolInversion):
         return conditioner.decorate(f"({expr})") if conditioner.invert else expr
     assert conditioner == FloatSignControl(), "no pass produces sign-conditioned wide inline results yet"
     return expr
-
-
-def _state_copy_rhs(slot: FloatStateSlot) -> str:
-    return _signed_source_net(slot.tap.source, slot.tap.sign)
 
 
 def _write_source_rhs(source: WriteSource) -> str:
@@ -130,10 +131,8 @@ def _write_source_rhs(source: WriteSource) -> str:
             return f"~{net}" if invert else net
         case InlineWriteSource(operator=operator, operands=operands, conditioner=conditioner):
             return _render_inline(operator, operands, conditioner)
-        case FloatMoveWriteSource(operand=operand):
-            return _signed_source_net(operand.source, operand.sign)
-        case BoolMoveWriteSource(operand=operand):
-            return _bool_operand_rhs(operand)
+        case MoveWriteSource(operand=operand):
+            return _operand_rhs(operand)
         case _:
             assert_never(source)
 
@@ -147,13 +146,12 @@ def generate(lir: Lir) -> VerilogOutput:
     # The two dual codebooks, built once and threaded to both the microcode packer and the emitters so the
     # code<->source mapping cannot drift: per operand port (read) and per register (write). The write side derives from
     # a single ``write_events`` traversal, shared by the codebook, the packer, and the ROM-comment landings.
-    read_port = read_ports(lir)
-    read_books = read_codebook(lir, read_port)
+    read_books = read_codebook(lir)
     events = write_events(lir)
     write_books = write_codebook(events)
     tapped = tapped_lanes(lir)
 
-    fields = build_microcode(lir, read_port, read_books, write_books, events, tapped)
+    fields = build_microcode(lir, read_books, write_books, events, tapped)
     ucw = finalize_fields(fields)
 
     issues_by_cycle, commits_by_cycle = lir.group_by_cycle
@@ -170,7 +168,7 @@ def generate(lir: Lir) -> VerilogOutput:
     _emit_field_wires(w, fields)
     _emit_operators(w, lir, tapped)
     _emit_datapath_comb(w, lir, write_books)
-    _emit_read_muxes(w, lir, read_port, read_books)
+    _emit_read_muxes(w, lir, read_books)
     _emit_clocked(w, lir, write_books)
     _emit_outputs(w, lir)
     w("\nendmodule\n")
@@ -491,7 +489,7 @@ def _terminator_redirects(lir: Lir) -> list[tuple[int, str]]:
     return redirects
 
 
-def _emit_read_case(w: _Writer, target: str, port: int, book: ReadCodebook) -> None:
+def _emit_read_case(w: _Writer, target: str, field: str, book: ReadCodebook) -> None:
     """
     Emit one operand's combinational read mux: a direct assign for a single source, else a ``case`` over the port's
     read opcode selecting a register or a constant directly. The last entry is the ``default`` arm so the case is full
@@ -503,7 +501,7 @@ def _emit_read_case(w: _Writer, target: str, port: int, book: ReadCodebook) -> N
         w(f"{target} = {_source_net(book.sources[0])};")
         return
     arms = book.arms()
-    w(f"case ({f_rd(port)})")
+    w(f"case ({field})")
     w.push()
     for index, (code, source) in enumerate(arms):
         label = "default" if index == len(arms) - 1 else _lit(book.opcode_width, code)
@@ -515,8 +513,7 @@ def _emit_read_case(w: _Writer, target: str, port: int, book: ReadCodebook) -> N
 def _emit_read_muxes(
     w: _Writer,
     lir: Lir,
-    read_port: dict[tuple[OperatorInstance, int], int],
-    read_books: dict[int, ReadCodebook],
+    read_books: dict[tuple[OperatorInstance, int], ReadCodebook],
 ) -> None:
     """
     Emit the combinational operand read muxes driving each wrapper directly, so regfile-read -> operator is
@@ -530,9 +527,9 @@ def _emit_read_muxes(
     w.push()
     for inst in lir.instances:
         sig = _sig(inst)
+        base = base_name(inst)
         for pos in range(inst.operator.arity):
-            port = read_port[(inst, pos)]
-            _emit_read_case(w, f"{sig}_{PORT_LETTERS[pos]}", port, read_books[port])
+            _emit_read_case(w, f"{sig}_{PORT_LETTERS[pos]}", f_rd(base, PORT_LETTERS[pos]), read_books[(inst, pos)])
     w.pop()
     w("end")
     w("")
@@ -647,13 +644,13 @@ always @(posedge clk) begin
             # write. It never can: a non-coalesced boundary slot holds its live-in until the read-first boundary read,
             # so the allocator lands no intermediate write on it -- pinned here so a future scheduler cannot regress it.
             assert RegRef(reg) not in write_books, "a boundary-install slot must carry no opcode write sources"
-            arms.append(("out_valid && out_ready", _state_copy_rhs(slot)))
+            arms.append(("out_valid && out_ready", _operand_rhs(slot.tap)))
         _emit_reg_write(w, f"regs[{reg}]", RegRef(reg), write_books.get(RegRef(reg)), arms)
     for reg, bslot in sorted(bool_slots.items()):
         arms = load_arm(bool_loads, reg)
         if bslot.needs_copy:
             assert BoolRegRef(reg) not in write_books, "a boundary-install bool slot must carry no opcode write sources"
-            arms.append(("out_valid && out_ready", _bool_operand_rhs(bslot.live_out)))
+            arms.append(("out_valid && out_ready", _operand_rhs(bslot.live_out)))
         _emit_reg_write(w, f"bregs[{reg}]", BoolRegRef(reg), write_books.get(BoolRegRef(reg)), arms)
     w.pop()
     w("end")
@@ -669,9 +666,5 @@ assign out_valid = (pc == LASTPC);  // result valid on PRESENT; execution lags t
 assign err_pc    = err_pc_q;
 """)
     for wire in lir.outputs:
-        match wire:
-            case BoolOutputWire():
-                w(f"assign {wire.name} = {_bool_operand_rhs(wire.tap)};")
-            case FloatOutputWire():
-                w(f"assign {wire.name} = {_signed_source_net(wire.tap.source, wire.tap.sign)};")
+        w(f"assign {wire.name} = {_operand_rhs(wire.tap)};")
     w("")

--- a/holoso/_backend/verilog/_emit.py
+++ b/holoso/_backend/verilog/_emit.py
@@ -7,15 +7,16 @@ The controller is a microcode ROM (see :mod:`._microcode`): one pre-decoded VLIW
 critical control cones are short register-to-register paths. The executing step therefore lags the fetch PC by
 FETCH_LAG, which the sequencer accounts for: the PC counts up to LASTPC and out_valid is asserted there.
 
-Storage is a sparse, schedule-specific register file emitted inline instead of a general-purpose multiport file.
-The register array is a plain ``reg`` bank. Each operator operand has a dedicated read port whose combinational mux
-spans only the registers that operand ever reads across the schedule (a single-register operand needs no mux). Each
-operator result drives a per-register write select directly, spanning only the instances that ever write that register
-(a single-writer register needs no address compare).
+Storage is a sparse, schedule-specific register file emitted inline instead of a general-purpose multiport file. Value
+routing is uniform: each operand port's read mux is a ``case`` over that port's read codebook (its registers and the
+constants it reads), and each register's write is a ``case`` over that register's write codebook selected by a tiny
+per-register opcode (code 0 == NOP hold). PC drives only the sequencer; it never gates a datapath read or write.
 """
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from textwrap import dedent
+from typing import assert_never
 
 from ..._lir import *
 from ..._operators import *
@@ -78,10 +79,6 @@ def _wire(width: int) -> str:
     return f"wire [{width - 1:2}:0] " if width > 1 else "wire        "
 
 
-def _cterm_expr(port: int, consts: list[int]) -> str:
-    return f"const_{consts[0]}" if len(consts) == 1 else f"cterm{port}"
-
-
 def _source_net(source: RegRef | FloatConstRef) -> str:
     return f"const_{source.index}" if isinstance(source, FloatConstRef) else f"regs[{source.index}]"
 
@@ -92,36 +89,53 @@ def _signed_source_net(source: RegRef | FloatConstRef, sign: FloatSignControl) -
     return raw if sign == FloatSignControl() else f"holoso_fsgnop({raw}, 2'd{sign.encoded})"
 
 
-def _state_copy_rhs(slot: FloatStateSlot) -> str:
-    return _signed_source_net(slot.tap.source, slot.tap.sign)
+def _bool_operand_rhs(operand: BoolOperand) -> str:
+    source = operand.source
+    if isinstance(source, BoolConstRef):
+        return "1'b1" if source.value else "1'b0"  # an inverted immediate folded at construction
+    net = f"bregs[{source.index}]"
+    return f"~{net}" if operand.inversion.invert else net
 
 
-def _inline_fire_pc(lir: Lir, block_index: int, op: InlineScheduledOp) -> int:
+def _render_inline(
+    operator: InlineHardwareOperator, operands: tuple[FloatOperand | BoolOperand, ...], conditioner: PortConditioner
+) -> str:
     """
-    The fetch PC at which an inline firing's single PC-gated statement executes: its combinational fire step, one
-    fetch lag after the commit. An inline op drives its destination's write data combinationally on this step.
-    """
-    return lir.block_base[block_index] + inline_fire_cycle(op.commit_cycle, lir.fetch_lag)
-
-
-def _inline_rhs(op: InlineScheduledOp) -> str:
-    """
-    The RHS of one inline firing: the operator's own combinational expression over its operand nets (a float operand's
-    folded sign applies inline via ``holoso_fsgnop``), with the result conditioner applied -- an inversion folds into
-    the expression; sign-conditioned wide inline results have no producer yet.
+    An inline firing's combinational RHS: the operator's own expression over its operand nets (a float operand's folded
+    sign applies inline via ``holoso_fsgnop``), with the result conditioner applied -- an inversion folds into the
+    expression; sign-conditioned wide inline results have no producer yet.
     """
     nets: list[str] = []
-    for operand in op.operands:
+    for operand in operands:
         if isinstance(operand, FloatOperand):
             nets.append(_signed_source_net(operand.source, operand.sign))
         else:
             nets.append(_bool_operand_rhs(operand))
-    expr = op.operator.verilog_expr(*nets)
-    conditioner = op.write.conditioner
+    expr = operator.verilog_expr(*nets)
     if isinstance(conditioner, BoolInversion):
         return conditioner.decorate(f"({expr})") if conditioner.invert else expr
     assert conditioner == FloatSignControl(), "no pass produces sign-conditioned wide inline results yet"
     return expr
+
+
+def _state_copy_rhs(slot: FloatStateSlot) -> str:
+    return _signed_source_net(slot.tap.source, slot.tap.sign)
+
+
+def _write_source_rhs(source: WriteSource) -> str:
+    """Render one write-codebook source to its Verilog RHS -- the dual of the microcode's structured source key."""
+    match source:
+        case OpWriteSource(inst=inst, port=port, invert=invert):
+            net = f"{_sig(inst)}_y{port}"  # wide: sign rode the wrapper; bool: fabric inversion folds here
+            return f"~{net}" if invert else net
+        case InlineWriteSource(operator=operator, operands=operands, conditioner=conditioner):
+            return _render_inline(operator, operands, conditioner)
+        case FloatMoveWriteSource(operand=operand):
+            return _signed_source_net(operand.source, operand.sign)
+        case BoolMoveWriteSource(operand=operand):
+            return _bool_operand_rhs(operand)
+        case _:
+            assert_never(source)
 
 
 def generate(lir: Lir) -> VerilogOutput:
@@ -130,38 +144,34 @@ def generate(lir: Lir) -> VerilogOutput:
     cycw = lir.cyc_width
     pcw = max(1, lir.initiation_interval.bit_length())
 
-    # One dedicated read port per operator operand; the per-port read mux spans only the registers it actually reads.
+    # The two dual codebooks, built once and threaded to both the microcode packer and the emitters so the
+    # code<->source mapping cannot drift: per operand port (read) and per register (write). The write side derives from
+    # a single ``write_events`` traversal, shared by the codebook, the packer, and the ROM-comment landings.
     read_port = read_ports(lir)
-    port_consts = port_const_map(lir, read_port)
-    read_sets = lir.read_set_per_port
-    write_sets = lir.write_set_per_register
-    # Symmetric to the read-set index on the read side: the write-address field and the per-register write comparators
-    # carry the dense write-target index (ceil(log2 M) over each instance's M write targets, not the whole file). The
-    # codebook is shared between the microcode and the comparators so they cannot drift.
-    write_lists = write_target_lists(lir)
+    read_books = read_codebook(lir, read_port)
+    events = write_events(lir)
+    write_books = write_codebook(events)
+    tapped = tapped_lanes(lir)
 
-    fields = build_microcode(lir, read_port, port_consts, write_lists)
+    fields = build_microcode(lir, read_port, read_books, write_books, events, tapped)
     ucw = finalize_fields(fields)
 
     issues_by_cycle, commits_by_cycle = lir.group_by_cycle
-    installs_by_step = const_installs_by_step(lir)
-    # Commit annotations land on each firing's write step -- the commit step itself, the same step the microcode places
-    # its write-enable word (every bank writes combinationally, so a pooled lane's write word sits at the commit step).
-    # A const install rides the same word via its cwen strobe (block_base + issue_cycle), so it shares the annotation.
+    landings = landings_by_step(events)
 
     depth = lir.last_pc + 1  # one microcode word per fetch PC (0..last_pc); inter-block drains and the tail pack to NOP
 
     _emit_header(w, lir)
     _emit_localparams(w, lir, cycw, pcw, ucw)
     _emit_inline_support(w)
-    _emit_declarations(w, lir, write_lists)
+    _emit_declarations(w, lir, tapped)
     _emit_consts(w, lir)
-    _emit_microcode_rom(w, fields, ucw, depth, issues_by_cycle, commits_by_cycle, installs_by_step)
+    _emit_microcode_rom(w, fields, ucw, depth, issues_by_cycle, commits_by_cycle, landings)
     _emit_field_wires(w, fields)
-    _emit_operators(w, lir, write_lists)
-    _emit_datapath_comb(w, lir, port_consts, write_lists)
-    _emit_read_muxes(w, lir, read_port, port_consts, read_sets)
-    _emit_clocked(w, lir, write_sets, write_lists)
+    _emit_operators(w, lir, tapped)
+    _emit_datapath_comb(w, lir, write_books)
+    _emit_read_muxes(w, lir, read_port, read_books)
+    _emit_clocked(w, lir, write_books)
     _emit_outputs(w, lir)
     w("\nendmodule\n")
     return VerilogOutput(verilog=w.render(), support_files=support_files())
@@ -245,7 +255,7 @@ def _emit_inline_support(w: _Writer) -> None:
     w("")
 
 
-def _emit_declarations(w: _Writer, lir: Lir, write_lists: dict[tuple[OperatorInstance, int], list[int]]) -> None:
+def _emit_declarations(w: _Writer, lir: Lir, tapped: set[tuple[OperatorInstance, int]]) -> None:
     assert lir.fetch_lag >= 1, "transacting_q is [FETCH_LAG-1:0]; FETCH_LAG==0 needs an explicit leading NOP"
     w("""
     reg  [PCW-1:0]  pc;            // fetch program counter; the executing step lags it by FETCH_LAG
@@ -273,7 +283,7 @@ def _emit_declarations(w: _Writer, lir: Lir, write_lists: dict[tuple[OperatorIns
         # One net per TAPPED output port -- the raw operator output (wide W-bit or boolean 1-bit). The in_valid and
         # sign-control ports bind directly to the decoded uc_* fields, so no s_* control net is declared for them.
         for q, result_type in enumerate(inst.operator.signature.result_types):
-            if (inst, q) not in write_lists:
+            if (inst, q) not in tapped:
                 continue  # a never-tapped output port: no nets, the module port is left unconnected
             if is_wide_type(result_type):
                 w(f"wire [W-1:0] {sig}_y{q};")
@@ -294,7 +304,7 @@ def _emit_consts(w: _Writer, lir: Lir) -> None:
         w("")
 
 
-def _emit_operators(w: _Writer, lir: Lir, write_lists: dict[tuple[OperatorInstance, int], list[int]]) -> None:
+def _emit_operators(w: _Writer, lir: Lir, tapped: set[tuple[OperatorInstance, int]]) -> None:
     for inst in lir.instances:
         sig, base = _sig(inst), base_name(inst)
         operator = inst.operator
@@ -317,14 +327,14 @@ def _emit_operators(w: _Writer, lir: Lir, write_lists: dict[tuple[OperatorInstan
         # to the identity. Boolean output ports have none -- their inversion conditioner is fabric-side at the write.
         for q, result_type in enumerate(operator.signature.result_types):
             if is_wide_type(result_type):
-                conditioner = f_ysgn(base, q) if (inst, q) in write_lists else "2'd0"
+                conditioner = f_ysgn(base, q) if (inst, q) in tapped else "2'd0"
                 w(f".{operator.output_hdl_ports[q]}_sgnop({conditioner}),")
         for letter in letters:
             w(f".{letter}({sig}_{letter}),")
         # out_valid is left unconnected: the static schedule already knows when each result is ready.
         w(".out_valid(),")
         outputs = [
-            f".{operator.output_hdl_ports[q]}({f'{sig}_y{q}' if (inst, q) in write_lists else ''})"
+            f".{operator.output_hdl_ports[q]}({f'{sig}_y{q}' if (inst, q) in tapped else ''})"
             for q in range(len(operator.signature.result_types))
         ]
         for line_index, line in enumerate(outputs):
@@ -343,7 +353,7 @@ def _emit_microcode_rom(
     depth: int,
     issues_by_cycle: dict[int, list[PooledScheduledOp]],
     commits_by_cycle: dict[int, list[PooledScheduledOp]],
-    installs_by_step: dict[int, list[str]],
+    landings: dict[int, list[str]],
 ) -> None:
     digits = (ucw + 3) // 4
     w("""
@@ -355,10 +365,8 @@ reg [UCW-1:0] ucode [0:LASTPC];
 initial begin
     """)
     w.push()
-    for step in range(depth):  # depth == LASTPC + 1: one word per fetch PC, NOP where no operator issues or commits
-        summary = cycle_summary(
-            issues_by_cycle.get(step, []), commits_by_cycle.get(step, []), installs_by_step.get(step, [])
-        )
+    for step in range(depth):  # depth == LASTPC + 1: one word per fetch PC, NOP where nothing issues, commits, or lands
+        summary = cycle_summary(issues_by_cycle.get(step, []), commits_by_cycle.get(step, []), landings.get(step, []))
         comment = f"  // {summary}" if summary else ""
         w(f"ucode[{step: 5}] = {ucw}'h{pack(fields, step):0{digits}x};{comment}")
     w.pop()
@@ -374,56 +382,37 @@ reg [UCW-1:0] ucode_word;  // 3rd fetch stage: packs into the BRAM output regist
 def _emit_field_wires(w: _Writer, fields: dict[str, Field]) -> None:
     w("""
 // Decoded control fields. A field constant across the whole program is driven by a constant net (so synthesis prunes
-// the logic it feeds); a varying field is a slice of the instruction word. The effect-trigger fields -- the ones
-// flagged ``is_strobe`` (operator issue, pooled write-enable, const-install write-enable) -- are ANDed with
-// `transacting` HERE, so a held ucode[0] dwell, a fill bubble, or a stale pre-reset word triggers no issue, commit,
-// or install; their use sites then read the gated field. The AND wraps the constant branch too, so the gate stays
-// unconditional even if a trigger ever folds to a constant.
+// the logic it feeds); a varying field is a slice of the instruction word. The effect-trigger fields -- the ``gated``
+// ones (operator issue strobes and per-register write opcodes) -- are ANDed with `transacting` HERE, so a held
+// ucode[0] dwell, a fill bubble, or a stale pre-reset word decodes to 0 (NOP): no issue and every register holds.
+// The AND wraps the constant branch too, so the gate stays unconditional even if a trigger ever folds to a constant.
 """)
     for f in fields.values():
-        gate = "transacting & " if f.is_strobe else ""
-        if f.offset < 0:
-            rhs = _lit(f.width, f.const_value)
-        else:
-            rhs = f"ucode_word[{f.offset} +: {f.width}]"
-        w(f"{_wire(f.width)}{f.name} = {gate}{rhs};")
+        rhs = _lit(f.width, f.const_value) if f.offset < 0 else f"ucode_word[{f.offset} +: {f.width}]"
+        if f.gated:
+            mask = "transacting" if f.width == 1 else f"{{{f.width}{{transacting}}}}"
+            rhs = f"{mask} & {rhs}"
+        w(f"{_wire(f.width)}{f.name} = {rhs};")
     w("")
 
 
-def _const_pool_mux(selector: str, consts: list[int]) -> str:
-    """
-    A const-pool read expression: the lone ``const_N`` net, or a ``selector``-indexed ternary mux over ``consts``. Used
-    on the read side (an operand's per-port const select, ``uc_cidx``) and the write side (a register's ucode-driven
-    constant install, ``uc_ccidx``) alike.
-    """
-    expr = f"const_{consts[-1]}"
-    for local in range(len(consts) - 2, -1, -1):
-        expr = f"({selector} == {local}) ? const_{consts[local]} : {expr}"
-    return expr
-
-
-def _emit_datapath_comb(
-    w: _Writer, lir: Lir, port_consts: dict[int, list[int]], write_lists: dict[tuple[OperatorInstance, int], list[int]]
-) -> None:
-    for port in sorted(port_consts):
-        if len(port_consts[port]) > 1:
-            w(f"wire [W-1:0] cterm{port} = {_const_pool_mux(f_cidx(port), port_consts[port])};")
-    w("")
-
-    # An error matters only on the step its operator commits, which is exactly its tapped lanes' write-enable window;
-    # both the write-enables and the operator's combinational error output fire on the commit step, so the error flag is
-    # sampled directly when its result drives the register write.
+def _emit_datapath_comb(w: _Writer, lir: Lir, write_books: dict[RegRef | BoolRegRef, WriteCodebook]) -> None:
+    # An error matters only on the step its operator commits -- the step some destination register's write opcode
+    # selects this operator's output lane. So the error output is gated by the OR, over the op's write-codebook entries,
+    # of (uc_op_<reg> == that entry's code); the opcode is transacting-masked, so the gate is live exactly on that
+    # commit step.
+    op_gates: dict[OperatorInstance, list[str]] = {}
+    for dst, book in write_books.items():
+        for code, source in book.arms():
+            if isinstance(source, OpWriteSource):
+                op_gates.setdefault(source.inst, []).append(f"({f_op(dst)} == {_lit(book.opcode_width, code)})")
     err_terms: list[str] = []
     for inst in lir.instances:
         if not inst.operator.error_ports:
             continue
-        lane_wes = [
-            f_wen(base_name(inst), q)
-            for q in range(len(inst.operator.signature.result_types))
-            if (inst, q) in write_lists
-        ]
-        assert lane_wes, "an error-bearing operator must have a tapped lane to align its sideband with"
-        gate = lane_wes[0] if len(lane_wes) == 1 else "(" + " | ".join(lane_wes) + ")"
+        gates = op_gates.get(inst, [])
+        assert gates, "an error-bearing operator must have a tapped lane to align its sideband with"
+        gate = gates[0] if len(gates) == 1 else "(" + " | ".join(gates) + ")"
         for err_port in inst.operator.error_ports:
             err_terms.append(f"({gate} & {_sig(inst)}_{err_port})")
     err_rhs = " | ".join(err_terms) if err_terms else "1'b0"
@@ -497,270 +486,101 @@ def _terminator_redirects(lir: Lir) -> list[tuple[int, str]]:
     return redirects
 
 
-def _float_copy_pc(lir: Lir, block: LirBlock, copy: FloatCopy) -> int:
+def _emit_read_case(w: _Writer, target: str, port: int, book: ReadCodebook) -> None:
     """
-    The fetch PC at which a pc-gated phi-arm copy installs its value: its block base plus the copy's fire step (a fetch
-    lag after the ``issue_cycle`` that ``install_issue_cycle`` placed at the work makespan, or one past for a last-work
-    source).
+    Emit one operand's combinational read mux: a direct assign for a single source, else a ``case`` over the port's
+    read opcode selecting a register or a constant directly. The last entry is the ``default`` arm so the case is full
+    (no inferred latch on this combinational path); unused high codes fall there too and are don't-cares on idle steps.
+    The mux carries no indexed part-select, so there is no offset multiply for synthesis to (mis)infer as a DSP.
     """
-    return lir.block_base[block.index] + copy.fire_step(lir.fetch_lag)
-
-
-def _bool_write_pc(lir: Lir, block: LirBlock, write: BoolWrite) -> int:
-    return lir.block_base[block.index] + write.fire_step(lir.fetch_lag)
-
-
-def _float_copy_rhs(copy: FloatCopy) -> str:
-    return _signed_source_net(copy.source.source, copy.source.sign)
-
-
-def _bool_operand_rhs(operand: BoolOperand) -> str:
-    source = operand.source
-    if isinstance(source, BoolConstRef):
-        return "1'b1" if source.value else "1'b0"  # an inverted immediate folded at construction
-    net = f"bregs[{source.index}]"
-    return f"~{net}" if operand.inversion.invert else net
-
-
-def _bool_write_rhs(write: BoolWrite) -> str:
-    return _bool_operand_rhs(write.source)
-
-
-def _copies_grouped(lir: Lir) -> dict[int, list[tuple[int, str]]]:
-    """
-    Destination wide register -> [(install PC, source net)], over the phi-arm copies that remain pc-gated: register-
-    source copies and signed-constant installs. Identity-sign constant installs are ucode-driven (see
-    ``_wide_writer_entries``), not pc-gated.
-    """
-    grouped: dict[int, list[tuple[int, str]]] = {}
-    for block in lir.blocks:
-        for copy in block.copies:
-            if is_ucode_const_copy(copy):
-                continue
-            grouped.setdefault(copy.dst.index, []).append((_float_copy_pc(lir, block, copy), _float_copy_rhs(copy)))
-    return grouped
-
-
-def _bool_writes_grouped(lir: Lir) -> dict[int, list[tuple[int, str]]]:
-    """
-    Destination boolean register -> [(install PC, source expression)], over the boolean phi-arm writes that remain
-    pc-gated: register-source writes. Constant boolean installs are ucode-driven (see ``_bool_writer_entries``).
-    """
-    grouped: dict[int, list[tuple[int, str]]] = {}
-    for block in lir.blocks:
-        for write in block.bool_writes:
-            if write.is_const:
-                continue
-            grouped.setdefault(write.dst.index, []).append((_bool_write_pc(lir, block, write), _bool_write_rhs(write)))
-    return grouped
-
-
-def _read_mux_stmts(w: _Writer, target: str, port: int, read_set: list[int], port_consts: dict[int, list[int]]) -> None:
-    """
-    Emit the combinational read-mux for one operand, driven in the read-mux ``always @*`` block.
-
-    The mux spans only ``read_set`` (the registers this port ever reads): just the immediate when the operand is
-    always a constant, a direct register read for a single register, and otherwise a ``case`` over the dense read-set
-    index (the read-address field) selecting ``regs[...]`` directly. A const-select picks the immediate when the
-    operand is sometimes a constant. On idle steps the mux drives a don't-care value the operator ignores (its
-    in_valid is low). The read mux carries no indexed part-select, so there is no offset multiply for synthesis to
-    (mis)infer as a DSP -- which is why the read-set index addresses a case rather than a packed gather bus.
-    """
-    consts = port_consts.get(port)
-    cterm = _cterm_expr(port, consts) if consts else None
-    if not read_set:  # the operand is always a constant immediate
-        w(f"{target} = {cterm};")
+    assert book.sources, "an operand port always reads at least one source"
+    if len(book.sources) == 1:
+        w(f"{target} = {_source_net(book.sources[0])};")
         return
-    if len(read_set) == 1:
-        reg_expr = f"regs[{read_set[0]}]"
-        w(f"{target} = {f_csel(port)} ? {cterm} : {reg_expr};" if cterm else f"{target} = {reg_expr};")
-        return
-    # Multi-register operand: a case over the dense read-set index. The last entry is the default arm so the case is
-    # full (no inferred latch); the unused high codes fall there too and are don't-cares on idle steps.
-    if cterm:
-        w(f"if ({f_csel(port)}) {target} = {cterm};", "else begin")
-        w.push()
-    w(f"case ({f_raddr(port)})")
+    arms = book.arms()
+    w(f"case ({f_rd(port)})")
     w.push()
-    for index, reg in enumerate(read_set):
-        label = "default" if index == len(read_set) - 1 else _lit(code_width(len(read_set)), index)
-        w(f"{label}: {target} = regs[{reg}];")
+    for index, (code, source) in enumerate(arms):
+        label = "default" if index == len(arms) - 1 else _lit(book.opcode_width, code)
+        w(f"{label}: {target} = {_source_net(source)};")
     w.pop()
     w("endcase")
-    if cterm:
-        w.pop()
-        w("end")
-
-
-def _write_cond(
-    inst: OperatorInstance, port: int, reg: int, write_lists: dict[tuple[OperatorInstance, int], list[int]]
-) -> str:
-    """
-    The guard under which lane ``(inst, port)`` writes ``reg``: its write-enable, plus a write-address compare when
-    the lane targets more than one register (the dense write-target index this register occupies in its codebook).
-    """
-    base = base_name(inst)
-    targets = write_lists[(inst, port)]
-    if len(targets) == 1:
-        return f_wen(base, port)
-    return f"{f_wen(base, port)} && ({f_waddr(base, port)} == {_lit(code_width(len(targets)), targets.index(reg))})"
-
-
-def _wide_writer_entries(
-    lir: Lir,
-    write_sets: dict[int, list[tuple[OperatorInstance, int]]],
-    write_lists: dict[tuple[OperatorInstance, int], list[int]],
-) -> dict[int, list[tuple[str, str, str]]]:
-    """
-    Per wide register, the ordered ``(condition, rhs)`` of every driver other than its state-slot install: the
-    accept-step input load (highest priority), each pooled lane's write, each pc-gated wide-result inline firing
-    (the bool->float cast), and each pc-gated phi-arm copy. The conditions are pairwise mutually exclusive (the load
-    step, the per-lane write-enable steps, and the distinct inline/copy PCs never coincide for one register -- the
-    schedule and the allocator's interference guarantee it), so the emitter folds them into one priority chain and a
-    register is driven by exactly one statement, however many sources reuse or coalesce onto it.
-    """
-    entries: dict[int, list[tuple[str, str, str]]] = {}
-    for fload in sorted(lir.float_inputs, key=lambda load: load.dst.index):
-        entries.setdefault(fload.dst.index, []).append(("in_ready && in_valid", f"in_{fload.name}", ""))
-    for reg in sorted(write_sets):
-        for inst, port in write_sets[reg]:
-            entries.setdefault(reg, []).append((_write_cond(inst, port, reg, write_lists), f"{_sig(inst)}_y{port}", ""))
-    # Ucode-driven constant installs: the decode-gated const write-enable arm (like an operator lane), reusing the
-    # const-pool nets. Unlike the pooled lanes above (which commit at issue + latency >= 1), a cycle-0 install can ride
-    # the held ucode[0], so its write-enable is one of the gated strobes.
-    const_books = const_install_codebooks(lir)
-    for reg in sorted(const_books):
-        entries.setdefault(reg, []).append(
-            (f_cwen(RegRef(reg)), _const_pool_mux(f_ccidx(RegRef(reg)), const_books[reg]), "")
-        )
-    for block in lir.blocks:
-        for inline_op in block.inline_ops:
-            if isinstance(inline_op.write.dst, RegRef):
-                entries.setdefault(inline_op.write.dst.index, []).append(
-                    (
-                        f"pc == {_inline_fire_pc(lir, block.index, inline_op)}",
-                        _inline_rhs(inline_op),
-                        "inline fire",
-                    )
-                )
-    for reg, items in _copies_grouped(lir).items():
-        for install_pc, rhs in sorted(items):
-            entries.setdefault(reg, []).append((f"pc == {install_pc}", rhs, "phi-arm install"))
-    return entries
-
-
-def _bool_writer_entries(
-    lir: Lir, write_lists: dict[tuple[OperatorInstance, int], list[int]]
-) -> dict[int, list[tuple[str, str, str]]]:
-    """
-    Per boolean register, the ordered ``(condition, rhs)`` of every driver other than its state-slot install: the
-    input load, each pooled boolean lane (microcode-gated, with its fabric-XOR inversion conditioner),
-    each pc-gated bool-result inline firing, and each pc-gated phi-arm write.
-    """
-    entries: dict[int, list[tuple[str, str, str]]] = {}
-    for bload in sorted(lir.bool_inputs, key=lambda load: load.dst.index):
-        entries.setdefault(bload.dst.index, []).append(("in_ready && in_valid", f"in_{bload.name}", ""))
-    bool_write_sets = lir.bool_write_set_per_register
-    for reg in sorted(bool_write_sets):
-        for inst, port in bool_write_sets[reg]:
-            rhs = f"{_sig(inst)}_y{port} ^ {f_binv(base_name(inst), port)}"
-            entries.setdefault(reg, []).append((_write_cond(inst, port, reg, write_lists), rhs, ""))
-    # Ucode-driven constant installs: the decode-gated const write-enable arm carrying the 1-bit value (no XOR -- the
-    # inversion is folded into the value at construction).
-    for reg in const_install_bool_regs(lir):
-        entries.setdefault(reg, []).append((f_cwen(BoolRegRef(reg)), f_cval(BoolRegRef(reg)), ""))
-    for block in lir.blocks:
-        for inline_op in block.inline_ops:
-            if isinstance(inline_op.write.dst, BoolRegRef):
-                entries.setdefault(inline_op.write.dst.index, []).append(
-                    (
-                        f"pc == {_inline_fire_pc(lir, block.index, inline_op)}",
-                        _inline_rhs(inline_op),
-                        "inline fire",
-                    )
-                )
-    for reg, items in _bool_writes_grouped(lir).items():
-        for install_pc, rhs in sorted(items):
-            entries.setdefault(reg, []).append((f"pc == {install_pc}", rhs, "phi-arm install"))
-    return entries
-
-
-def _wide_state_install_entry(lir: Lir, slot: FloatStateSlot) -> list[tuple[str, str, str]]:
-    """
-    The slot register's live-out install, appended under the reset-else as the lowest-priority arm of its chain. A
-    coalesced slot has no install (its producing operator already writes the slot register); a non-coalesced one is
-    installed read-first on its writeback step (``state_copy_step``, the absolute install PC -- which reduces to
-    ``LASTPC`` for a boundary install), out_ready-gated so a held boundary copies exactly once.
-    """
-    if not slot.needs_copy:
-        return []
-    pcw = max(1, lir.initiation_interval.bit_length())
-    cond = f"pc == {_lit(pcw, lir.state_copy_step(slot))} && (pc != LASTPC || out_ready)"
-    return [(cond, _state_copy_rhs(slot), "state install")]
-
-
-def _emit_chain(w: _Writer, lhs: str, entries: list[tuple[str, str, str]]) -> None:
-    """One priority chain per register, so the register has exactly one driver (the multi-assign rule). The optional
-    third element labels an arm whose kind is not evident from its guard -- the two ``pc == N`` arms (an inline firing
-    and a phi-arm install) read alike otherwise."""
-    clause = "if"
-    for cond, rhs, note in entries:
-        w(f"{clause} ({cond}) {lhs} <= {rhs};" + (f"  // {note}" if note else ""))
-        clause = "else if"
 
 
 def _emit_read_muxes(
     w: _Writer,
     lir: Lir,
     read_port: dict[tuple[OperatorInstance, int], int],
-    port_consts: dict[int, list[int]],
-    read_sets: dict[tuple[OperatorInstance, int], list[int]],
+    read_books: dict[int, ReadCodebook],
 ) -> None:
     """
-    Emit the combinational operand read muxes: a sparse mux over each operand's read-set drives the wrapper directly, so
-    regfile-read -> operator is combinational and the operand is sampled FETCH_LAG after its read-address word. A
-    pure-inline kernel has no pooled instances, so this would be empty -- skip it rather than emit a bare
-    ``always @* begin end``.
+    Emit the combinational operand read muxes driving each wrapper directly, so regfile-read -> operator is
+    combinational and the operand is sampled FETCH_LAG after its read-opcode word. A pure-inline kernel has no pooled
+    instances, so this would be empty -- skip it rather than emit a bare ``always @* begin end``.
     """
-    if lir.instances:
-        w(
-            "// Operand read muxes: a sparse combinational mux over each operand's "
-            "read-set, driving the wrapper directly."
-        )
-        w("always @* begin")
-        w.push()
-        for inst in lir.instances:
-            sig = _sig(inst)
-            for pos in range(inst.operator.arity):
-                port = read_port[(inst, pos)]
-                _read_mux_stmts(w, f"{sig}_{PORT_LETTERS[pos]}", port, read_sets.get((inst, pos), []), port_consts)
-        w.pop()
-        w("end")
-        w("")
+    if not lir.instances:
+        return
+    w("// Operand read muxes: a per-port case over the read codebook (registers and constants), driving the wrapper.")
+    w("always @* begin")
+    w.push()
+    for inst in lir.instances:
+        sig = _sig(inst)
+        for pos in range(inst.operator.arity):
+            port = read_port[(inst, pos)]
+            _emit_read_case(w, f"{sig}_{PORT_LETTERS[pos]}", port, read_books[port])
+    w.pop()
+    w("end")
+    w("")
 
 
-def _emit_clocked(
+def _emit_reg_write(
     w: _Writer,
-    lir: Lir,
-    write_sets: dict[int, list[tuple[OperatorInstance, int]]],
-    write_lists: dict[tuple[OperatorInstance, int], list[int]],
+    lhs: str,
+    dst: RegRef | BoolRegRef,
+    book: WriteCodebook | None,
+    special_arms: list[tuple[str, str]],
 ) -> None:
-    """Emit every sequential element in one always @(posedge clk): fetch, writes, and control state."""
-    # We MUST ensure that we DO NOT MULTI-ASSIGN any register in the same step; this is ensured by always placing each
-    # assignment to the same register into different branches of the same condition.
-    nreg = lir.regfile.nreg  # 0 for an unused bank; range(0) then yields no non-slot writes (the bank is omitted)
-    nbreg = lir.bool_regfile.nreg
+    """
+    One segregated write statement per register (the multi-assign rule): the handshake-gated special arms first (an
+    input load, a boundary state install), then the opcode ``case`` over the register's write codebook as the final
+    ``else``. Code 0 is the NOP hold -- an unlisted code in this clocked ``case`` retains the flop -- so the
+    write-enable is folded into the opcode with no extra logic level. A single-source register degenerates to
+    ``if (opcode)``.
+    """
+    clause = "if"
+    for cond, rhs in special_arms:
+        w(f"{clause} ({cond}) {lhs} <= {rhs};")
+        clause = "else if"
+    if book is None or not book.sources:
+        return
+    prefix = "else " if special_arms else ""
+    opcode = f_op(dst)
+    if len(book.sources) == 1:
+        w(f"{prefix}if ({opcode}) {lhs} <= {_write_source_rhs(book.sources[0])};")
+        return
+    w(f"{prefix}case ({opcode})")
+    w.push()
+    for code, source in book.arms():
+        w(f"{_lit(book.opcode_width, code)}: {lhs} <= {_write_source_rhs(source)};")
+    w.pop()
+    w("endcase")
+
+
+def _emit_clocked(w: _Writer, lir: Lir, write_books: dict[RegRef | BoolRegRef, WriteCodebook]) -> None:
+    """Emit every sequential element in one always @(posedge clk): fetch, register writes, and control state."""
+    nreg, nbreg = lir.regfile.nreg, lir.bool_regfile.nreg
     float_slots = {slot.reg.index: slot for slot in lir.float_state_slots}
     bool_slots = {slot.reg.index: slot for slot in lir.bool_state_slots}
-    # Each register's whole write is one priority chain over all its drivers (input load, operator writes, casts,
-    # phi copies, comparator/logic results, and -- for a slot -- its boundary install), so a register is never assigned
-    # by two separate statements. The conditions within a chain are pairwise mutually exclusive by construction.
-    wide = _wide_writer_entries(lir, write_sets, write_lists)
-    boolw = _bool_writer_entries(lir, write_lists)
+    float_loads = {load.dst.index: load for load in lir.float_inputs}
+    bool_loads = {load.dst.index: load for load in lir.bool_inputs}
+
+    def load_arm(loads: Mapping[int, FloatInputLoad | BoolInputLoad], reg: int) -> list[tuple[str, str]]:
+        load = loads.get(reg)
+        return [("in_ready && in_valid", f"in_{load.name}")] if load else []
 
     w("""
 // All sequential logic in one clocked process. Reset gates only the control state (pc, err_pc_q, transacting_q) and the
-// persistent state registers; every other register is reset-unconditional. Each is driven by exactly one write chain.
+// persistent state registers; every other register is reset-unconditional. Each is driven by exactly one statement.
 always @(posedge clk) begin
 """)
     w.push()
@@ -771,21 +591,27 @@ always @(posedge clk) begin
     w("ucode_word   <= ucode_q;")
     w("")
 
-    # Non-slot registers: one reset-unconditional write chain each driving regs[]/bregs[]. Datapath payload carries no
-    # reset, keeping the high-fanout reset net off the wide cone (only control/valid state is reset); the contents are
-    # don't-care until a valid write lands. A register with no drivers is simply omitted.
-    nonslot_wide = [reg for reg in range(nreg) if reg not in float_slots and wide.get(reg)]
-    nonslot_bool = [reg for reg in range(nbreg) if reg not in bool_slots and boolw.get(reg)]
+    # Non-slot registers: one reset-unconditional statement each. Datapath payload carries no reset, keeping the
+    # high-fanout reset net off the wide cone (only control/valid state is reset); contents are don't-care until a
+    # valid write lands. A register with neither an input load nor any opcode source is simply omitted.
+    nonslot_wide = [
+        reg for reg in range(nreg) if reg not in float_slots and (RegRef(reg) in write_books or reg in float_loads)
+    ]
+    nonslot_bool = [
+        reg for reg in range(nbreg) if reg not in bool_slots and (BoolRegRef(reg) in write_books or reg in bool_loads)
+    ]
     if nonslot_wide or nonslot_bool:
-        w("// Register write chains (reset-unconditional): one priority chain per register over all its drivers.")
+        w("// Register writes (reset-unconditional): one opcode-selected statement per register.")
         for reg in nonslot_wide:
-            _emit_chain(w, f"regs[{reg}]", wide[reg])
+            _emit_reg_write(w, f"regs[{reg}]", RegRef(reg), write_books.get(RegRef(reg)), load_arm(float_loads, reg))
         for reg in nonslot_bool:
-            _emit_chain(w, f"bregs[{reg}]", boolw[reg])
+            _emit_reg_write(
+                w, f"bregs[{reg}]", BoolRegRef(reg), write_books.get(BoolRegRef(reg)), load_arm(bool_loads, reg)
+            )
         w("")
 
     # Control and persistent state are the reset-gated registers: the slot snapshot (under rst) and the slot's update
-    # chain (its coalesced operator writes and/or its boundary install, under the else) are the two arms of one rst
+    # statement (its opcode-selected writes plus a boundary install arm, under the else) are the two arms of one rst
     # condition, segregating those assignments for the synthesizer.
     fmt = lir.float_format
     digits = (fmt.width + 3) // 4
@@ -807,19 +633,24 @@ always @(posedge clk) begin
     w("transacting_q <= (transacting_q << 1) | transacting_in;")
     w("if (err) err_pc_q <= pc - FETCH_LAG;  // err wins; execution lags the fetch PC by FETCH_LAG, so step is pc-lag")
     w("else if (in_ready && in_valid) err_pc_q <= 0;  // clear the diagnostic when a new transaction is accepted")
+    # A non-coalesced slot installs its live-out read-first at the accepted-output boundary (out_valid && out_ready, so
+    # a held boundary copies exactly once), a lower-priority arm of the same statement; an early install is an ordinary
+    # opcode source (see write_events). Boolean state installs are boundary-only.
     for reg, slot in sorted(float_slots.items()):
-        chain = wide.get(reg, []) + _wide_state_install_entry(lir, slot)
-        if chain:
-            _emit_chain(w, f"regs[{reg}]", chain)
+        arms = load_arm(float_loads, reg)
+        if slot.needs_copy and lir.float_state_install_is_boundary(slot):
+            # The boundary install is a higher-priority arm than the opcode case, so it must not shadow any opcode
+            # write. It never can: a non-coalesced boundary slot holds its live-in until the read-first boundary read,
+            # so the allocator lands no intermediate write on it -- pinned here so a future scheduler cannot regress it.
+            assert RegRef(reg) not in write_books, "a boundary-install slot must carry no opcode write sources"
+            arms.append(("out_valid && out_ready", _state_copy_rhs(slot)))
+        _emit_reg_write(w, f"regs[{reg}]", RegRef(reg), write_books.get(RegRef(reg)), arms)
     for reg, bslot in sorted(bool_slots.items()):
-        install = (
-            [("pc == LASTPC && out_ready", _bool_operand_rhs(bslot.live_out), "state install")]
-            if bslot.needs_copy
-            else []
-        )
-        chain = boolw.get(reg, []) + install
-        if chain:
-            _emit_chain(w, f"bregs[{reg}]", chain)
+        arms = load_arm(bool_loads, reg)
+        if bslot.needs_copy:
+            assert BoolRegRef(reg) not in write_books, "a boundary-install bool slot must carry no opcode write sources"
+            arms.append(("out_valid && out_ready", _bool_operand_rhs(bslot.live_out)))
+        _emit_reg_write(w, f"bregs[{reg}]", BoolRegRef(reg), write_books.get(BoolRegRef(reg)), arms)
     w.pop()
     w("end")
 

--- a/holoso/_backend/verilog/_emit.py
+++ b/holoso/_backend/verilog/_emit.py
@@ -2,10 +2,10 @@
 Render a scheduled :class:`Lir` into a synthesizable Verilog ZISC module that instantiates the shared support library
 (assembled by :mod:`._support`).
 
-The controller is a microcode ROM (see :mod:`._microcode`): one pre-decoded VLIW control word per step, stored in a
-(BRAM-inferable) ROM read through a 3-stage fetch (a PC latch, the array read, and the BRAM output register) so the
-critical control cones are short register-to-register paths. The executing step therefore lags the fetch PC by
-FETCH_LAG, which the sequencer accounts for: the PC counts up to LASTPC and out_valid is asserted there.
+The controller is a microcode ROM (see :mod:`._microcode`): one pre-decoded VLIW control word per step, written as a
+synchronous ``case`` over the fetch PC (the inferable-ROM form every backend recognizes) and read through a 3-stage
+fetch (PC latch, ROM read register, routing register). The executing step lags the fetch PC by FETCH_LAG,
+which the sequencer accounts for: the PC counts up to LASTPC and out_valid is asserted there.
 
 Storage is a sparse, schedule-specific register file emitted inline instead of a general-purpose multiport file. Value
 routing is uniform: each operand port's read mux is a ``case`` over that port's read codebook (its registers and the
@@ -260,7 +260,7 @@ def _emit_declarations(w: _Writer, lir: Lir, tapped: set[tuple[OperatorInstance,
     w("""
     reg  [PCW-1:0]  pc;            // fetch program counter; the executing step lags it by FETCH_LAG
     reg  [PCW-1:0]  next_pc;       // combinational next-state presented to the ROM each cycle
-    reg  [PCW-1:0]  ucode_addr_q;  // PC latch: splits pc -> next_pc -> ROM address from the array read
+    reg  [PCW-1:0]  ucode_addr_q;  // PC latch: splits pc -> next_pc -> ROM address for the case read
     reg  [CYCW-1:0] err_pc_q;
     wire            err;           // an operator error is detected on the current step
 
@@ -357,26 +357,31 @@ def _emit_microcode_rom(
 ) -> None:
     digits = (ucw + 3) // 4
     w("""
-// Microcode VLIW ROM: one pre-decoded control word per fetch PC (0..LASTPC), registered on read (clocked block below).
-// Steps with no scheduled event -- inter-block drains and the present/boundary tail -- pack to a NOP word; constant
-// control fields are lifted out (below) and not stored here, enabling synthesis-time folding.
-(* rom_style = "block", ram_style = "block", syn_romstyle = "EBR" *)
-reg [UCW-1:0] ucode [0:LASTPC];
-initial begin
-    """)
+// Microcode VLIW ROM.
+reg [UCW-1:0] ucode_q;     // 2nd fetch stage
+reg [UCW-1:0] ucode_word;  // 3rd fetch stage""")
+    packed = sorted((f for f in fields.values() if f.offset >= 0), key=lambda f: f.offset)
+    if packed:
+        bit_strs = [f"[{f.offset + f.width - 1}:{f.offset}]" if f.width > 1 else f"[{f.offset}]" for f in packed]
+        wbit = max(len(b) for b in bit_strs)
+        w("// Microcode word field map:")
+        for f, bits in zip(packed, bit_strs):
+            w(f"//   {bits:<{wbit}}  {f.name}")
+    w("""
+(* rom_style = "block", syn_romstyle = "EBR" *)
+always @(posedge clk)
+    case (ucode_addr_q)""")
     w.push()
-    for step in range(depth):  # depth == LASTPC + 1: one word per fetch PC, NOP where nothing issues, commits, or lands
+    w.push()
+    for step in range(depth):  # one arm per fetch PC, NOP where nothing issues, commits, or lands
         summary = cycle_summary(issues_by_cycle.get(step, []), commits_by_cycle.get(step, []), landings.get(step, []))
         comment = f"  // {summary}" if summary else ""
-        w(f"ucode[{step: 5}] = {ucw}'h{pack(fields, step):0{digits}x};{comment}")
+        w(f"{step}: ucode_q <= {ucw}'h{pack(fields, step):0{digits}x};{comment}")
+    w(f"default: ucode_q <= {ucw}'h0;  // unreached (PC bounded to LASTPC); NOP fill")
     w.pop()
-    w("""
-end
-
-reg [UCW-1:0] ucode_q;     // 2nd fetch stage: control-store array-read register
-reg [UCW-1:0] ucode_word;  // 3rd fetch stage: packs into the BRAM output register; drives this step
-
-""")
+    w("endcase")
+    w.pop()
+    w("")
 
 
 def _emit_field_wires(w: _Writer, fields: dict[str, Field]) -> None:
@@ -585,9 +590,8 @@ always @(posedge clk) begin
 """)
     w.push()
 
-    w("// Microcode fetch: PC latch -> control-store array read -> BRAM output register.")
+    w("// Microcode fetch: PC latch; ucode_word pipelines ucode_q.")
     w("ucode_addr_q <= next_pc;")
-    w("ucode_q      <= ucode[ucode_addr_q];")
     w("ucode_word   <= ucode_q;")
     w("")
 

--- a/holoso/_backend/verilog/_microcode.py
+++ b/holoso/_backend/verilog/_microcode.py
@@ -1,25 +1,25 @@
 """
 The microcode model for the Verilog ZISC backend.
 
-From a scheduled :class:`Lir` this derives the per-step VLIW control word: the dedicated read/write port assignment,
-every control field and its value on each step (``None`` == don't-care), and the partition into constant fields
-(driven by constant nets) versus varying fields (packed into the ROM word). It also owns the Verilog-safe naming the
-emitter wires up. It emits no Verilog text -- that is the emitter's job; this module is pure data.
+From a scheduled :class:`Lir` this derives the per-step VLIW control word. Datapath value routing is expressed as
+dense per-endpoint opcodes parsed by ``case`` statements -- the two endpoints are duals:
 
-Write control is per OUTPUT-PORT LANE, keyed ``(instance, port)``: a lane's write-enable/address ride the commit step
-itself (both banks write combinationally). A wide lane carries its issue-step sign conditioner ``y_sgnop``; a boolean
-lane carries a 1-bit inversion conditioner on the commit step (the boolean dual, applied as a fabric XOR at the register
-write). A lane exists only if some firing taps it; a never-tapped module output gets no fields and is left unconnected.
+- a READ endpoint is an operator operand port; its opcode selects one source from that port's read codebook;
+- a WRITE endpoint is a register; its opcode selects one source from that register's write codebook,
+  with code 0 reserved for NOP (hold).
+
+Everything a register can take on a cycle is thus one tiny opcode, carrying its write-enable, destination select,
+const-pool select, and boolean inversion together; PC is left to control flow alone. This module is pure data -- the
+emitter owns the Verilog text and renders each source key.
 """
 
 from dataclasses import dataclass
 from string import ascii_letters
 
 from ..._lir import (
-    BoolConstRef,
+    BoolOperand,
     BoolRegRef,
     FloatConstRef,
-    FloatCopy,
     FloatOperand,
     Lir,
     OperatorInstance,
@@ -27,7 +27,7 @@ from ..._lir import (
     RegRef,
     pooled_write_word,
 )
-from ..._operators import FloatSignControl
+from ..._operators import BoolInversion, InlineHardwareOperator, PortConditioner
 from ..._type import is_wide_type
 
 PORT_LETTERS = ascii_letters  # operand position -> wrapper port letter (a, b, ...)
@@ -38,10 +38,11 @@ class Field:
     """
     One scalar control field of the microcode word, with its value on every step (``None`` == don't-care).
 
-    ``is_strobe`` marks an effect trigger (operator issue, or a register write-enable): it is concrete every step
-    (inert 0 when idle) and ``transacting``-gated at the decode, so a held ``ucode[0]`` dwell commits nothing. Every
-    other field is qualifying data, a don't-care while its strobe is inactive, never gated. The gate keys on this
-    explicit flag, not on a resting value of 0, so a future concrete-zero non-strobe field is not silently gated.
+    ``gated`` marks an effect trigger (an operator issue strobe, or a per-register write opcode): it is concrete every
+    step (inert 0 when idle) and ANDed with ``transacting`` at the decode -- ``& {width{transacting}}`` -- so a held
+    ``ucode[0]`` dwell, a fill bubble, or a stale pre-reset word decodes to 0 (NOP) and commits nothing. A write opcode
+    reserves code 0 for NOP, so the mask is exactly a NOP. Every other field is qualifying data, a don't-care while its
+    trigger is inactive, never masked.
 
     After :func:`finalize_fields`, a field is either constant across the program (``offset < 0``; driven by the
     constant net ``const_value``) or varying (stored at bit ``offset`` of the ROM word).
@@ -50,18 +51,14 @@ class Field:
     name: str
     width: int
     values: list[int | None]
-    is_strobe: bool = False
+    gated: bool = False
     offset: int = -1
     const_value: int = 0
 
-    def __post_init__(self) -> None:
-        # A strobe is ANDed with the 1-bit ``transacting`` at the decode, so it must itself be 1-bit.
-        assert not self.is_strobe or self.width == 1, f"strobe field {self.name!r} must be 1-bit"
-
     @property
     def default(self) -> int | None:
-        """Resting value on a don't-care step: a strobe is inert (0); a non-strobe is an unconstrained don't-care."""
-        return 0 if self.is_strobe else None
+        """Resting value on a don't-care step: a gated field is inert (0); a plain field is unconstrained (None)."""
+        return 0 if self.gated else None
 
 
 def base_name(inst: OperatorInstance) -> str:
@@ -73,163 +70,126 @@ def code_width(count: int) -> int:
     return max(1, (count - 1).bit_length()) if count > 1 else 1
 
 
-def write_target_lists(lir: Lir) -> dict[tuple[OperatorInstance, int], list[int]]:
+# Source descriptors: value-equal keys the codebooks dedup on, and which the emitter renders to an RHS net/expression.
+# A read source reuses the LIR refs directly (``regs[i]`` / ``const_i``); the write sources below discriminate the four
+# ways a register takes a value.
+type ReadSource = RegRef | FloatConstRef
+
+
+@dataclass(frozen=True, slots=True)
+class OpWriteSource:
     """
-    Per output-port lane ``(instance, port)``, the sorted distinct registers it ever writes -- the lane's
-    write-address codebook (its bank is implied by the destinations' type). The write-address field carries the
-    position in this list, not the raw register index, so its width is ``code_width(M)`` over the lane's ``M``
-    targets rather than the whole register file. The per-register write selector compares against the same position,
-    so the recode is transparent (no decode logic on the consumer) and mirrors the read side, where the read-address
-    field carries the dense read-set index. Lanes never tapped by any firing are absent.
+    A pooled operator output lane. A boolean lane folds its fabric inversion into ``invert``; a wide lane's sign rides
+    the wrapper (the ``y*sgn`` field), so its ``invert`` is always False and equal signs never split the opcode.
     """
-    targets: dict[tuple[OperatorInstance, int], list[int]] = {}
-    for op in lir.ops:
-        for write in op.writes:
-            regs = targets.setdefault((op.inst, write.port), [])
-            if write.dst.index not in regs:
-                regs.append(write.dst.index)
-    for regs in targets.values():
-        regs.sort()
-    return targets
+
+    inst: OperatorInstance
+    port: int
+    invert: bool
 
 
-# Microcode field names. Signal names (``s_<base>_*``) and field names (``uc_*_<base>``) live in disjoint namespaces.
-def f_raddr(port: int) -> str:
-    return f"uc_raddr{port}"
+@dataclass(frozen=True, slots=True)
+class InlineWriteSource:
+    """An inline-operator combinational result; structurally identical results dedup to one opcode (loop bodies)."""
+
+    operator: InlineHardwareOperator
+    operands: tuple[FloatOperand | BoolOperand, ...]
+    conditioner: PortConditioner
 
 
+@dataclass(frozen=True, slots=True)
+class FloatMoveWriteSource:
+    """A wide phi-arm copy, a constant install (any folded sign), or an early state writeback -- a move of one tap."""
+
+    operand: FloatOperand
+
+
+@dataclass(frozen=True, slots=True)
+class BoolMoveWriteSource:
+    """A boolean phi-arm write or constant install -- a move of one boolean tap (its inversion folded)."""
+
+    operand: BoolOperand
+
+
+type WriteSource = OpWriteSource | InlineWriteSource | FloatMoveWriteSource | BoolMoveWriteSource
+
+
+@dataclass(frozen=True, slots=True)
+class WriteEvent:
+    """One microcode-driven register write: which register takes which ``source`` on which ROM (executing) ``step``."""
+
+    dst: RegRef | BoolRegRef
+    source: WriteSource
+    step: int
+
+
+@dataclass(frozen=True, slots=True)
+class ReadCodebook:
+    """
+    An operand port's ordered read sources and the dense opcode that selects among them: code ``i`` picks
+    ``sources[i]`` over ``opcode_width`` bits. A single-source port drives its source directly and carries no field.
+    """
+
+    sources: tuple[ReadSource, ...]
+
+    @property
+    def opcode_width(self) -> int:
+        return code_width(len(self.sources))
+
+    def code(self, source: ReadSource) -> int:
+        return self.sources.index(source)
+
+    def arms(self) -> list[tuple[int, ReadSource]]:
+        return list(enumerate(self.sources))
+
+
+@dataclass(frozen=True, slots=True)
+class WriteCodebook:
+    """
+    A register's ordered write sources and the dense opcode that selects among them, code 0 reserved for the NOP hold:
+    code ``i+1`` picks ``sources[i]`` over ``opcode_width`` bits. A register with no sources carries no write opcode.
+    """
+
+    sources: tuple[WriteSource, ...]
+
+    @property
+    def opcode_width(self) -> int:
+        return code_width(len(self.sources) + 1)  # +1: code 0 is the NOP hold
+
+    def code(self, source: WriteSource) -> int:
+        return self.sources.index(source) + 1
+
+    def arms(self) -> list[tuple[int, WriteSource]]:
+        return [(index + 1, source) for index, source in enumerate(self.sources)]
+
+
+# Microcode field names. Signal names (``s_<base>_*``) and field names (``uc_*``) live in disjoint namespaces.
 def f_issue(base: str) -> str:
     return f"uc_issue_{base}"
-
-
-def f_osgn(base: str, letter: str) -> str:
-    return f"uc_{base}_{letter}sgn"
 
 
 def f_imm(base: str, name: str) -> str:
     return f"uc_{base}_imm_{name}"
 
 
+def f_osgn(base: str, letter: str) -> str:
+    return f"uc_{base}_{letter}sgn"
+
+
 def f_ysgn(base: str, port: int) -> str:
     return f"uc_{base}_y{port}sgn"
 
 
-def f_csel(port: int) -> str:
-    return f"uc_csel{port}"
+def f_rd(port: int) -> str:
+    return f"uc_rd{port}"
 
 
-def f_cidx(port: int) -> str:
-    return f"uc_cidx{port}"
-
-
-def f_wen(base: str, port: int) -> str:
-    return f"uc_wen_{base}_y{port}"
-
-
-def f_waddr(base: str, port: int) -> str:
-    return f"uc_waddr_{base}_y{port}"
-
-
-def f_binv(base: str, port: int) -> str:
-    return f"uc_binv_{base}_y{port}"
-
-
-# Per-REGISTER constant-install fields: a phi-arm constant install is not an operator, so it has no (instance, port)
-# write lane. Each destination register that receives a ucode-driven constant install carries a 1-bit write-enable; a
-# wide register additionally carries a const-pool index selector when it installs more than one distinct constant, and
-# a boolean register carries the 1-bit value. Names key on ``stable_label`` (``r<k>``/``b<k>``), disjoint from the
-# operator-lane fields (``uc_*_<base>_y<port>``).
-def f_cwen(dst: RegRef | BoolRegRef) -> str:
-    return f"uc_cwen_{dst.stable_label}"
-
-
-def f_ccidx(reg: RegRef) -> str:
-    return f"uc_ccidx_{reg.stable_label}"
-
-
-def f_cval(breg: BoolRegRef) -> str:
-    return f"uc_cval_{breg.stable_label}"
-
-
-def is_ucode_const_copy(copy: FloatCopy) -> bool:
-    """
-    Whether a wide phi-arm copy is a constant install the microcode can drive directly: a constant source with the
-    identity sign, so its write data is a bare ``const_N`` net needing no register read port and no sign conditioning.
-    A register-source copy (needs a read port) or a signed constant install (``-CONST``, whose write data is an inline
-    ``holoso_fsgnop`` expression rather than a bare net) stays pc-gated -- the deferred harder cases.
-    """
-    return copy.is_const and copy.source.sign == FloatSignControl()
-
-
-def const_install_codebooks(lir: Lir) -> dict[int, list[int]]:
-    """
-    Wide register -> the sorted distinct const-pool indices its ucode-driven constant installs use -- the per-register
-    write-data codebook the ``uc_ccidx`` selector indexes (the write-side analogue of ``port_const_map``). A register
-    installing a single constant has a one-entry book (the selector is then a lifted-out constant, no ROM bits).
-    """
-    books: dict[int, list[int]] = {}
-    for block in lir.blocks:
-        for copy in block.copies:
-            if is_ucode_const_copy(copy):
-                assert isinstance(copy.source.source, FloatConstRef)
-                book = books.setdefault(copy.dst.index, [])
-                if copy.source.source.index not in book:
-                    book.append(copy.source.source.index)
-    for book in books.values():
-        book.sort()
-    return books
-
-
-def const_install_bool_regs(lir: Lir) -> list[int]:
-    """
-    The boolean registers that receive a ucode-driven constant install (the bool analogue of
-    :func:`const_install_codebooks`; a boolean constant carries no pool, only its 1-bit value).
-    """
-    return sorted({write.dst.index for block in lir.blocks for write in block.bool_writes if write.is_const})
-
-
-def _op_expr(op: PooledScheduledOp) -> str:
-    dsts = "/".join(write.conditioner.decorate(write.dst.stable_label) for write in op.writes)
-    operands = [operand.stable_label for operand in op.operands]
-    return f"{dsts}={op.inst.operator.render(*operands, immediates=op.immediates)}"
-
-
-def const_installs_by_step(lir: Lir) -> dict[int, list[str]]:
-    """
-    Per ROM step, the constant installs whose write-enable that microcode word carries (the ``uc_cwen_*`` strobes
-    :func:`build_microcode` sets), each rendered ``dst=source`` in the issue/commit summary's vocabulary. Mirrors that
-    function's predicate (``is_ucode_const_copy`` / ``BoolWrite.is_const``) and step (``block_base + issue_cycle``); a
-    register-source or signed-const install stays pc-gated -- not a word bit -- so it is excluded here.
-    """
-    installs: dict[int, list[str]] = {}
-    for block in lir.blocks:
-        base_pc = lir.block_base[block.index]
-        for copy in block.copies:
-            if is_ucode_const_copy(copy):
-                installs.setdefault(base_pc + copy.issue_cycle, []).append(
-                    f"{copy.dst.stable_label}={copy.source.stable_label}"
-                )
-        for bwrite in block.bool_writes:
-            if bwrite.is_const:
-                installs.setdefault(base_pc + bwrite.issue_cycle, []).append(
-                    f"{bwrite.dst.stable_label}={bwrite.source.stable_label}"
-                )
-    return installs
-
-
-def cycle_summary(issues: list[PooledScheduledOp], commits: list[PooledScheduledOp], installs: list[str]) -> str:
-    parts: list[str] = []
-    if issues:
-        parts.append("issue " + ", ".join(_op_expr(op) for op in issues))
-    if commits:
-        parts.append("commit " + ", ".join("/".join(write.dst.stable_label for write in op.writes) for op in commits))
-    if installs:
-        parts.append("install " + ", ".join(installs))
-    return "; ".join(parts)
+def f_op(dst: RegRef | BoolRegRef) -> str:
+    return f"uc_op_{dst.stable_label}"
 
 
 def read_ports(lir: Lir) -> dict[tuple[OperatorInstance, int], int]:
-    """One dedicated read port per operator operand, numbered in instance/operand order (counts to ``nrd``)."""
+    """One dedicated read port per operator operand, numbered in instance/operand order."""
     read_port: dict[tuple[OperatorInstance, int], int] = {}
     for inst in lir.instances:
         for pos in range(inst.operator.arity):
@@ -237,52 +197,113 @@ def read_ports(lir: Lir) -> dict[tuple[OperatorInstance, int], int]:
     return read_port
 
 
-def port_const_map(lir: Lir, read_port: dict[tuple[OperatorInstance, int], int]) -> dict[int, list[int]]:
-    """Read port -> the distinct constant-pool indices it ever sources (drives the per-operand constant select)."""
-    port_consts: dict[int, list[int]] = {}
+def tapped_lanes(lir: Lir) -> set[tuple[OperatorInstance, int]]:
+    """The operator output ports some firing writes -- an untapped port gets no nets and is left unconnected."""
+    return {(op.inst, write.port) for op in lir.ops for write in op.writes}
+
+
+def _read_ref(operand: FloatOperand) -> ReadSource:
+    """
+    The read-codebook key of a float operand: its register, or its constant magnitude (the sign rides ``uc_*sgn``).
+    """
+    return operand.source  # a RegRef, or a nonnegative-pool FloatConstRef (its magnitude); the sign is separate
+
+
+def read_codebook(lir: Lir, read_port: dict[tuple[OperatorInstance, int], int]) -> dict[int, ReadCodebook]:
+    """
+    Per operand port, the ordered distinct read sources: the registers it reads (read-set order) then each distinct
+    constant magnitude it reads (first-appearance over the schedule). The read opcode carries the position, so its
+    width is ``code_width`` over this book; a single-source port keeps its lone source and needs no opcode field.
+    """
+    sources: dict[int, list[ReadSource]] = {port: [] for port in read_port.values()}
+    for key, regs in lir.read_set_per_port.items():
+        sources[read_port[key]] = [RegRef(reg) for reg in regs]
     for op in lir.ops:
         for pos, operand in enumerate(op.operands):
-            if isinstance(operand.source, FloatConstRef):
-                port = read_port[(op.inst, pos)]
-                port_consts.setdefault(port, [])
-                if operand.source.index not in port_consts[port]:
-                    port_consts[port].append(operand.source.index)
-    return port_consts
+            if isinstance(operand, FloatOperand) and isinstance(operand.source, FloatConstRef):
+                book = sources[read_port[(op.inst, pos)]]
+                ref = _read_ref(operand)
+                if ref not in book:
+                    book.append(ref)
+    return {port: ReadCodebook(tuple(srcs)) for port, srcs in sources.items()}
+
+
+def write_events(lir: Lir) -> list[WriteEvent]:
+    """
+    Every microcode-driven register write as ``(dst, source, ROM step)``, in one deterministic traversal shared by the
+    codebook builder and the packer so the code<->source mapping cannot drift. The ROM step is the source's executing
+    step (the fetch PC it fires on, minus the fetch lag): a pooled write rides its commit cycle, an inline/copy/write
+    rides ``block_base + issue/commit``, an early state install rides ``state_copy_step - fetch_lag``. Boundary state
+    installs (and all boolean state installs, which are boundary-only) are handshake-gated special arms, not opcode
+    sources, so they are excluded here.
+    """
+    events: list[WriteEvent] = []
+    for op in lir.ops:
+        for write in op.writes:
+            if isinstance(write.dst, RegRef):
+                invert = False  # a wide lane's sign rides the wrapper, not the opcode
+            else:
+                assert isinstance(write.conditioner, BoolInversion)
+                invert = write.conditioner.invert
+            events.append(
+                WriteEvent(write.dst, OpWriteSource(op.inst, write.port, invert), pooled_write_word(op.commit_cycle))
+            )
+    for block in lir.blocks:
+        base = lir.block_base[block.index]
+        for inline_op in block.inline_ops:
+            source = InlineWriteSource(inline_op.operator, tuple(inline_op.operands), inline_op.write.conditioner)
+            events.append(WriteEvent(inline_op.write.dst, source, base + inline_op.commit_cycle))
+        for copy in block.copies:
+            events.append(WriteEvent(copy.dst, FloatMoveWriteSource(copy.source), base + copy.issue_cycle))
+        for bwrite in block.bool_writes:
+            events.append(WriteEvent(bwrite.dst, BoolMoveWriteSource(bwrite.source), base + bwrite.issue_cycle))
+    for slot in lir.float_state_slots:
+        if slot.needs_copy and not lir.float_state_install_is_boundary(slot):
+            events.append(
+                WriteEvent(slot.reg, FloatMoveWriteSource(slot.tap), lir.state_copy_step(slot) - lir.fetch_lag)
+            )
+    return events
+
+
+def write_codebook(
+    events: list[WriteEvent],
+) -> dict[RegRef | BoolRegRef, WriteCodebook]:
+    """Per register, the ordered distinct write sources (first-appearance dedup over :func:`write_events`)."""
+    sources: dict[RegRef | BoolRegRef, list[WriteSource]] = {}
+    for event in events:
+        book = sources.setdefault(event.dst, [])
+        if event.source not in book:
+            book.append(event.source)
+    return {dst: WriteCodebook(tuple(srcs)) for dst, srcs in sources.items()}
 
 
 def build_microcode(
     lir: Lir,
     read_port: dict[tuple[OperatorInstance, int], int],
-    port_consts: dict[int, list[int]],
-    write_lists: dict[tuple[OperatorInstance, int], list[int]],
+    read_books: dict[int, ReadCodebook],
+    write_books: dict[RegRef | BoolRegRef, WriteCodebook],
+    events: list[WriteEvent],
+    tapped: set[tuple[OperatorInstance, int]],
 ) -> dict[str, Field]:
     """
     Build the per-step value table of every control field from the static schedule.
 
-    ``in_valid`` and the write-enables are concrete every step (they gate operation), so they default to 0; every
-    other field is a don't-care (``None``) except on the step its firing issues or commits, which maximises the
-    constant columns that later get lifted out of the ROM.
-
-    Control is placed on the step each operation requires: the read-address group rides the issue step (the read is
-    latch-free, so the datapath samples the operand a fetch lag later); a lane's write-enable and write-address are
-    presented ON the commit step (both banks write combinationally). A WIDE lane's sign conditioner rides the issue
-    step (consumed inside the wrapper); a BOOLEAN lane's inversion rides the commit step with its write-enable. Placing
-    the write word on the commit step -- not one later -- is exactly what gives a branch condition its one cycle of
-    slack at the block boundary.
+    Control is placed on the step each operation requires: the issue strobe, the operand signs, the read opcodes, and a
+    wide result's sign ride the ISSUE step (the read is latch-free, so the datapath samples an operand a fetch lag
+    later); each register's WRITE opcode rides the source's executing step (see :func:`write_events`). A write opcode
+    carries ``code_width(N+1)`` bits over its ``N`` sources with code 0 reserved for the NOP hold; the read opcode
+    carries ``code_width(K)`` over its ``K`` sources with no NOP (a don't-care idle read is harmless).
     """
     depth = lir.last_pc + 1  # one control word per fetch PC: blocks are laid out across 0..last_pc with NOP gaps
     fields: dict[str, Field] = {}
 
-    def add(name: str, width: int, is_strobe: bool = False) -> None:
-        fields[name] = Field(name, width, [0 if is_strobe else None] * depth, is_strobe=is_strobe)
+    def add(name: str, width: int, gated: bool = False) -> None:
+        fields[name] = Field(name, width, [0 if gated else None] * depth, gated=gated)
 
     def put(name: str, step: int, value: int) -> None:
         # Single-writer rule: a field's step slot may be set once to a non-default value (or repeatedly to the same
-        # value). Every write word stays inside its block (only the result LANDING spills into a successor frame -- see
-        # pooled_write_word), so under per-block draining no two firings share a control word and this never fires.
-        # Under cross-block overlap a successor's base PC drops so its head words can share an absolute fetch step with
-        # the predecessor's tail words; this catches at build time any two firings' control words colliding on one slot
-        # instead of silently clobbering.
+        # value). For a write opcode this is exactly "<=1 landing per register per step" -- distinct sources take
+        # distinct codes, so a genuine double-landing on one register trips this rather than silently clobbering.
         field = fields[name]
         current = field.values[step]
         assert (
@@ -290,105 +311,42 @@ def build_microcode(
         ), f"microcode single-writer violation on field {name!r} step {step}: holds {current!r}, cannot write {value!r}"
         field.values[step] = value
 
-    # The read-address field selects within a port's read-set, not the whole register file: it carries the dense
-    # read-set index (0..K-1), so its width is ceil(log2 K) and the emitter's read-mux case selects by it. A
-    # single-reader or always-constant port keeps the constant value finalize_fields lifts out of the ROM.
-    port_read_set = {read_port[key]: regs for key, regs in lir.read_set_per_port.items()}
-
     for inst in lir.instances:
         base = base_name(inst)
-        add(f_issue(base), 1, is_strobe=True)
+        add(f_issue(base), 1, gated=True)
         for imm in inst.operator.immediate_ports:
             add(f_imm(base, imm.name), imm.width)
         for pos in range(inst.operator.arity):
             add(f_osgn(base, PORT_LETTERS[pos]), 2)
             port = read_port[(inst, pos)]
-            add(f_raddr(port), code_width(len(port_read_set.get(port, []))))
-            if port in port_consts:
-                add(f_csel(port), 1)
-                if len(port_consts[port]) > 1:
-                    add(f_cidx(port), code_width(len(port_consts[port])))
-    for (inst, port_index), targets in sorted(write_lists.items(), key=lambda kv: (base_name(kv[0][0]), kv[0][1])):
-        base = base_name(inst)
-        add(f_wen(base, port_index), 1, is_strobe=True)
-        # The write-address field carries the dense write-target index (0..M-1), symmetric to the read-address field.
-        add(f_waddr(base, port_index), code_width(len(targets)))
-        if is_wide_type(inst.operator.signature.result_types[port_index]):
-            add(f_ysgn(base, port_index), 2)
-        else:
-            add(f_binv(base, port_index), 1)
-
-    # Per-register constant-install fields. A wide register's selector is declared only when it installs more than one
-    # distinct constant; otherwise the single index is a constant column finalize lifts out of the ROM. A boolean
-    # register carries its 1-bit value. The write-enable defaults to 0 (concrete every step, so it always packs).
-    const_books = const_install_codebooks(lir)
-    for reg in sorted(const_books):
-        add(f_cwen(RegRef(reg)), 1, is_strobe=True)
-        if len(const_books[reg]) > 1:
-            add(f_ccidx(RegRef(reg)), code_width(len(const_books[reg])))
-    for reg in const_install_bool_regs(lir):
-        add(f_cwen(BoolRegRef(reg)), 1, is_strobe=True)
-        add(f_cval(BoolRegRef(reg)), 1)
+            if len(read_books[port].sources) > 1:
+                add(f_rd(port), read_books[port].opcode_width)
+        for q, result_type in enumerate(inst.operator.signature.result_types):
+            if is_wide_type(result_type) and (inst, q) in tapped:
+                add(f_ysgn(base, q), 2)
+    for dst, book in write_books.items():
+        add(f_op(dst), book.opcode_width, gated=True)
 
     for op in lir.ops:
         base = base_name(op.inst)
-        # The issue step carries in_valid, the sign controls (consumed inside the wrapper), and -- the read being
-        # latch-free -- the read-address group; the datapath samples the operand a fetch lag later.
         ci = op.issue_cycle
         assert 0 <= ci < depth, f"microcode read/issue step out of range: ci={ci}, depth={depth}"
         put(f_issue(base), ci, 1)
         for value, imm in zip(op.immediates, op.operator.immediate_ports, strict=True):
-            put(f_imm(base, imm.name), ci, value)  # per-firing immediate rides the issue step, like the sign controls
+            put(f_imm(base, imm.name), ci, value)
         for pos, operand in enumerate(op.operands):
-            port = read_port[(op.inst, pos)]
             assert isinstance(operand, FloatOperand), "pooled operators read only wide operands today (no read lane)"
             put(f_osgn(base, PORT_LETTERS[pos]), ci, operand.sign.encoded)
-            if isinstance(operand.source, FloatConstRef):
-                put(f_csel(port), ci, 1)
-                if f_cidx(port) in fields:
-                    put(f_cidx(port), ci, port_consts[port].index(operand.source.index))
-            elif isinstance(operand.source, RegRef):
-                if f_csel(port) in fields:
-                    put(f_csel(port), ci, 0)
-                put(f_raddr(port), ci, port_read_set[port].index(operand.source.index))
+            port = read_port[(op.inst, pos)]
+            if f_rd(port) in fields:
+                put(f_rd(port), ci, read_books[port].code(_read_ref(operand)))
         for write in op.writes:
-            lane = (op.inst, write.port)
-            wide = isinstance(write.dst, RegRef)
-            # Both banks write combinationally, so the write-enable/address ride the commit step (NOT one later -- a +1
-            # would land the result past a branch's boundary read). The same step the overlap layout uses to keep every
-            # write word inside the block (see pooled_write_word).
-            wcc = pooled_write_word(op.commit_cycle)
-            assert wcc < depth, f"microcode step out of range: wcc={wcc}, depth={depth}"
-            if wide:
-                put(f_ysgn(base, write.port), ci, write.conditioner.encoded)  # sign rides the wrapper at issue
-            else:
-                put(f_binv(base, write.port), wcc, write.conditioner.encoded)  # inversion applied at the write
-            put(f_wen(base, write.port), wcc, 1)
-            put(f_waddr(base, write.port), wcc, write_lists[lane].index(write.dst.index))
+            if isinstance(write.dst, RegRef):
+                put(f_ysgn(base, write.port), ci, write.conditioner.encoded)  # wide result sign rides the wrapper
 
-    # Constant installs ride the microcode like operator writes: the write-enable (and the wide selector / boolean
-    # value) are placed at ROM step ``block_base + issue_cycle`` == install_pc - fetch_lag, so the datapath write fires
-    # on the very clock the former pc-gate fired -- schedule-neutral. A register-source or signed-const install is not
-    # selected here and stays pc-gated.
-    for block in lir.blocks:
-        base_pc = lir.block_base[block.index]
-        for copy in block.copies:
-            if not is_ucode_const_copy(copy):
-                continue
-            assert isinstance(copy.source.source, FloatConstRef)
-            step = base_pc + copy.issue_cycle
-            assert 0 <= step < depth, f"const-install ROM step out of range: {step}"
-            put(f_cwen(copy.dst), step, 1)
-            if f_ccidx(copy.dst) in fields:
-                put(f_ccidx(copy.dst), step, const_books[copy.dst.index].index(copy.source.source.index))
-        for bwrite in block.bool_writes:
-            if not bwrite.is_const:
-                continue
-            assert isinstance(bwrite.source.source, BoolConstRef)
-            step = base_pc + bwrite.issue_cycle
-            assert 0 <= step < depth, f"const-install ROM step out of range: {step}"
-            put(f_cwen(bwrite.dst), step, 1)
-            put(f_cval(bwrite.dst), step, int(bwrite.source.source.value))
+    for event in events:
+        assert 0 <= event.step < depth, f"microcode write step out of range: step={event.step}, depth={depth}"
+        put(f_op(event.dst), event.step, write_books[event.dst].code(event.source))
 
     return fields
 
@@ -415,3 +373,47 @@ def pack(fields: dict[str, Field], step: int) -> int:
         v = f.values[step]
         word |= ((0 if v is None else v) & ((1 << f.width) - 1)) << f.offset
     return word
+
+
+# ---- ROM-step annotations (human-readable summary shared with the HTML report's schedule view) ----
+def _op_expr(op: PooledScheduledOp) -> str:
+    dsts = "/".join(write.conditioner.decorate(write.dst.stable_label) for write in op.writes)
+    operands = [operand.stable_label for operand in op.operands]
+    return f"{dsts}={op.inst.operator.render(*operands, immediates=op.immediates)}"
+
+
+def _landing_label(dst: RegRef | BoolRegRef, source: WriteSource) -> str:
+    """A non-pooled write rendered ``dst=source`` for the ROM-step comment -- the dual of ``_write_source_rhs``."""
+    match source:
+        case InlineWriteSource(operator=operator, operands=operands, conditioner=conditioner):
+            rendered = operator.render(*[operand.stable_label for operand in operands])
+            return f"{conditioner.decorate(dst.stable_label)}={rendered}"
+        case FloatMoveWriteSource(operand=operand) | BoolMoveWriteSource(operand=operand):
+            return f"{dst.stable_label}={operand.stable_label}"
+        case OpWriteSource():
+            assert False, "pooled commits are named by cycle_summary's commit list, not as landings"
+
+
+def landings_by_step(events: list[WriteEvent]) -> dict[int, list[str]]:
+    """
+    Per ROM step, the non-pooled writes that land there rendered ``dst=source`` -- inline firings, phi-arm copies,
+    boolean writes, and early state installs. Derived from :func:`write_events` (pooled commits are excluded, being
+    named by ``cycle_summary``'s commit list), so the ROM word comment names every value the opcode installs and the
+    emitted RTL stays mappable onto the HTML schedule report.
+    """
+    landings: dict[int, list[str]] = {}
+    for event in events:
+        if not isinstance(event.source, OpWriteSource):
+            landings.setdefault(event.step, []).append(_landing_label(event.dst, event.source))
+    return landings
+
+
+def cycle_summary(issues: list[PooledScheduledOp], commits: list[PooledScheduledOp], landings: list[str]) -> str:
+    parts: list[str] = []
+    if issues:
+        parts.append("issue " + ", ".join(_op_expr(op) for op in issues))
+    if commits:
+        parts.append("commit " + ", ".join("/".join(write.dst.stable_label for write in op.writes) for op in commits))
+    if landings:
+        parts.append("land " + ", ".join(landings))
+    return "; ".join(parts)

--- a/holoso/_backend/verilog/_microcode.py
+++ b/holoso/_backend/verilog/_microcode.py
@@ -154,9 +154,9 @@ def f_cval(breg: BoolRegRef) -> str:
 def is_ucode_const_copy(copy: FloatCopy) -> bool:
     """
     Whether a wide phi-arm copy is a constant install the microcode can drive directly: a constant source with the
-    identity sign, so its write data is a bare ``const_N`` net needing no register read port and no sign-conditioning
-    wire. A register-source copy (needs a read port) or a signed constant install (``-CONST``, needs a sign wire in the
-    write-data mux) stays pc-gated -- the deferred harder cases.
+    identity sign, so its write data is a bare ``const_N`` net needing no register read port and no sign conditioning.
+    A register-source copy (needs a read port) or a signed constant install (``-CONST``, whose write data is an inline
+    ``holoso_fsgnop`` expression rather than a bare net) stays pc-gated -- the deferred harder cases.
     """
     return copy.is_const and copy.source.sign == FloatSignControl()
 

--- a/holoso/_backend/verilog/_microcode.py
+++ b/holoso/_backend/verilog/_microcode.py
@@ -71,9 +71,9 @@ def code_width(count: int) -> int:
 
 
 # Source descriptors: value-equal keys the codebooks dedup on, and which the emitter renders to an RHS net/expression.
-# A read source reuses the LIR refs directly (``regs[i]`` / ``const_i``); the write sources below discriminate the four
-# ways a register takes a value.
-type ReadSource = RegRef | FloatConstRef
+# A read source reuses the LIR refs directly (``regs[i]`` / ``const_i``); the write sources below discriminate
+# the three ways a register takes a value.
+type ReadSource = RegRef | FloatConstRef  # a constant key is its nonnegative-pool magnitude; the sign rides uc_*sgn
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,20 +98,13 @@ class InlineWriteSource:
 
 
 @dataclass(frozen=True, slots=True)
-class FloatMoveWriteSource:
-    """A wide phi-arm copy, a constant install (any folded sign), or an early state writeback -- a move of one tap."""
+class MoveWriteSource:
+    """A move of one operand into a register: a phi-arm copy/write, a constant install, or an early state writeback."""
 
-    operand: FloatOperand
-
-
-@dataclass(frozen=True, slots=True)
-class BoolMoveWriteSource:
-    """A boolean phi-arm write or constant install -- a move of one boolean tap (its inversion folded)."""
-
-    operand: BoolOperand
+    operand: FloatOperand | BoolOperand
 
 
-type WriteSource = OpWriteSource | InlineWriteSource | FloatMoveWriteSource | BoolMoveWriteSource
+type WriteSource = OpWriteSource | InlineWriteSource | MoveWriteSource
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,6 +114,11 @@ class WriteEvent:
     dst: RegRef | BoolRegRef
     source: WriteSource
     step: int
+
+    def __post_init__(self) -> None:
+        # A wide lane's sign rides the ysgn wrapper; only a boolean lane folds an inversion into OpWriteSource.invert.
+        if isinstance(self.source, OpWriteSource) and self.source.invert:
+            assert isinstance(self.dst, BoolRegRef)
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,21 +178,12 @@ def f_ysgn(base: str, port: int) -> str:
     return f"uc_{base}_y{port}sgn"
 
 
-def f_rd(port: int) -> str:
-    return f"uc_rd{port}"
+def f_rd(base: str, letter: str) -> str:
+    return f"uc_{base}_{letter}rd"
 
 
 def f_op(dst: RegRef | BoolRegRef) -> str:
     return f"uc_op_{dst.stable_label}"
-
-
-def read_ports(lir: Lir) -> dict[tuple[OperatorInstance, int], int]:
-    """One dedicated read port per operator operand, numbered in instance/operand order."""
-    read_port: dict[tuple[OperatorInstance, int], int] = {}
-    for inst in lir.instances:
-        for pos in range(inst.operator.arity):
-            read_port[(inst, pos)] = len(read_port)
-    return read_port
 
 
 def tapped_lanes(lir: Lir) -> set[tuple[OperatorInstance, int]]:
@@ -202,30 +191,24 @@ def tapped_lanes(lir: Lir) -> set[tuple[OperatorInstance, int]]:
     return {(op.inst, write.port) for op in lir.ops for write in op.writes}
 
 
-def _read_ref(operand: FloatOperand) -> ReadSource:
+def read_codebook(lir: Lir) -> dict[tuple[OperatorInstance, int], ReadCodebook]:
     """
-    The read-codebook key of a float operand: its register, or its constant magnitude (the sign rides ``uc_*sgn``).
+    Per operand port ``(instance, position)``, the ordered distinct read sources: the registers it reads (read-set
+    order) then each distinct constant magnitude it reads (first-appearance over the schedule). The read opcode carries
+    the position over ``code_width`` bits; a single-source port keeps its lone source and needs no opcode field.
     """
-    return operand.source  # a RegRef, or a nonnegative-pool FloatConstRef (its magnitude); the sign is separate
-
-
-def read_codebook(lir: Lir, read_port: dict[tuple[OperatorInstance, int], int]) -> dict[int, ReadCodebook]:
-    """
-    Per operand port, the ordered distinct read sources: the registers it reads (read-set order) then each distinct
-    constant magnitude it reads (first-appearance over the schedule). The read opcode carries the position, so its
-    width is ``code_width`` over this book; a single-source port keeps its lone source and needs no opcode field.
-    """
-    sources: dict[int, list[ReadSource]] = {port: [] for port in read_port.values()}
+    sources: dict[tuple[OperatorInstance, int], list[ReadSource]] = {
+        (inst, pos): [] for inst in lir.instances for pos in range(inst.operator.arity)
+    }
     for key, regs in lir.read_set_per_port.items():
-        sources[read_port[key]] = [RegRef(reg) for reg in regs]
+        sources[key] = [RegRef(reg) for reg in regs]
     for op in lir.ops:
         for pos, operand in enumerate(op.operands):
             if isinstance(operand, FloatOperand) and isinstance(operand.source, FloatConstRef):
-                book = sources[read_port[(op.inst, pos)]]
-                ref = _read_ref(operand)
-                if ref not in book:
-                    book.append(ref)
-    return {port: ReadCodebook(tuple(srcs)) for port, srcs in sources.items()}
+                book = sources[(op.inst, pos)]
+                if operand.source not in book:
+                    book.append(operand.source)
+    return {key: ReadCodebook(tuple(srcs)) for key, srcs in sources.items()}
 
 
 def write_events(lir: Lir) -> list[WriteEvent]:
@@ -254,14 +237,12 @@ def write_events(lir: Lir) -> list[WriteEvent]:
             source = InlineWriteSource(inline_op.operator, tuple(inline_op.operands), inline_op.write.conditioner)
             events.append(WriteEvent(inline_op.write.dst, source, base + inline_op.commit_cycle))
         for copy in block.copies:
-            events.append(WriteEvent(copy.dst, FloatMoveWriteSource(copy.source), base + copy.issue_cycle))
+            events.append(WriteEvent(copy.dst, MoveWriteSource(copy.source), base + copy.issue_cycle))
         for bwrite in block.bool_writes:
-            events.append(WriteEvent(bwrite.dst, BoolMoveWriteSource(bwrite.source), base + bwrite.issue_cycle))
+            events.append(WriteEvent(bwrite.dst, MoveWriteSource(bwrite.source), base + bwrite.issue_cycle))
     for slot in lir.float_state_slots:
         if slot.needs_copy and not lir.float_state_install_is_boundary(slot):
-            events.append(
-                WriteEvent(slot.reg, FloatMoveWriteSource(slot.tap), lir.state_copy_step(slot) - lir.fetch_lag)
-            )
+            events.append(WriteEvent(slot.reg, MoveWriteSource(slot.tap), lir.state_copy_step(slot) - lir.fetch_lag))
     return events
 
 
@@ -279,8 +260,7 @@ def write_codebook(
 
 def build_microcode(
     lir: Lir,
-    read_port: dict[tuple[OperatorInstance, int], int],
-    read_books: dict[int, ReadCodebook],
+    read_books: dict[tuple[OperatorInstance, int], ReadCodebook],
     write_books: dict[RegRef | BoolRegRef, WriteCodebook],
     events: list[WriteEvent],
     tapped: set[tuple[OperatorInstance, int]],
@@ -318,9 +298,9 @@ def build_microcode(
             add(f_imm(base, imm.name), imm.width)
         for pos in range(inst.operator.arity):
             add(f_osgn(base, PORT_LETTERS[pos]), 2)
-            port = read_port[(inst, pos)]
-            if len(read_books[port].sources) > 1:
-                add(f_rd(port), read_books[port].opcode_width)
+            read_book = read_books[(inst, pos)]
+            if len(read_book.sources) > 1:
+                add(f_rd(base, PORT_LETTERS[pos]), read_book.opcode_width)
         for q, result_type in enumerate(inst.operator.signature.result_types):
             if is_wide_type(result_type) and (inst, q) in tapped:
                 add(f_ysgn(base, q), 2)
@@ -337,15 +317,17 @@ def build_microcode(
         for pos, operand in enumerate(op.operands):
             assert isinstance(operand, FloatOperand), "pooled operators read only wide operands today (no read lane)"
             put(f_osgn(base, PORT_LETTERS[pos]), ci, operand.sign.encoded)
-            port = read_port[(op.inst, pos)]
-            if f_rd(port) in fields:
-                put(f_rd(port), ci, read_books[port].code(_read_ref(operand)))
+            field = f_rd(base, PORT_LETTERS[pos])
+            if field in fields:
+                put(field, ci, read_books[(op.inst, pos)].code(operand.source))
         for write in op.writes:
             if isinstance(write.dst, RegRef):
                 put(f_ysgn(base, write.port), ci, write.conditioner.encoded)  # wide result sign rides the wrapper
 
     for event in events:
-        assert 0 <= event.step < depth, f"microcode write step out of range: step={event.step}, depth={depth}"
+        assert (
+            0 <= event.step < lir.present_step
+        ), f"microcode write step past present: step={event.step}, present={lir.present_step}"
         put(f_op(event.dst), event.step, write_books[event.dst].code(event.source))
 
     return fields
@@ -388,7 +370,7 @@ def _landing_label(dst: RegRef | BoolRegRef, source: WriteSource) -> str:
         case InlineWriteSource(operator=operator, operands=operands, conditioner=conditioner):
             rendered = operator.render(*[operand.stable_label for operand in operands])
             return f"{conditioner.decorate(dst.stable_label)}={rendered}"
-        case FloatMoveWriteSource(operand=operand) | BoolMoveWriteSource(operand=operand):
+        case MoveWriteSource(operand=operand):
             return f"{dst.stable_label}={operand.stable_label}"
         case OpWriteSource():
             assert False, "pooled commits are named by cycle_summary's commit list, not as landings"

--- a/holoso/_backend/verilog/rtl/holoso_support_inline.vh
+++ b/holoso/_backend/verilog/rtl/holoso_support_inline.vh
@@ -25,4 +25,12 @@ function [W-1:0] holoso_fsaturate;
     holoso_fsaturate = (&x[W-2:WMAN-1]) ? {x[W-1], {(WEXP - 1) {1'b1}}, 1'b0, {(WMAN - 1) {1'b1}}} : x;
 endfunction
 
+// Combinational floating-point sign conditioner (absolute first, then optional negate): op[0]=negate, op[1]=absolute.
+//      op=0: +x        op=1: -x        op=2: +|x|      op=3: -|x|
+function [W-1:0] holoso_fsgnop;
+    input [W-1:0] x;
+    input [1:0]   op;
+    holoso_fsgnop = {(x[W-1] & ~op[1]) ^ op[0], x[W-2:0]};
+endfunction
+
 // END of holoso_support_inline.vh

--- a/holoso/_lir/_bankalloc.py
+++ b/holoso/_lir/_bankalloc.py
@@ -364,7 +364,7 @@ class _BoolBank(_Bank[MirBoolStateSlot]):
         return boundary
 
     def objective_terms(self, ctx: _ObjectiveContext) -> _ObjectiveTerms:
-        # The boolean bank has no read multiplexer and a one-hot pc-gated write chain, so it carries no read ports and a
+        # The boolean bank has no read multiplexer and a per-register write opcode, so it carries no read ports and a
         # single uniform producer -- the objective degenerates to register count.
         return _ObjectiveTerms(
             {vid: set() for vid in ctx.values},

--- a/holoso/_lir/_ir.py
+++ b/holoso/_lir/_ir.py
@@ -235,7 +235,7 @@ class OperatorInstance:
 
 
 # An operator READ port: the ``(instance, operand-position)`` pair keying ``read_set_per_port``. Distinct from the
-# WRITE-side ``(instance, output-port)`` lanes of ``write_set_per_register``/``_write_sets``, which are not read ports.
+# WRITE-side ``(instance, output-port)`` lanes of ``_write_sets``, which are not read ports.
 type ReadPort = tuple[OperatorInstance, int]
 
 
@@ -852,23 +852,8 @@ class Lir:
                     sets.setdefault((op.inst, pos), set()).add(operand.source.index)
         return {port: sorted(regs) for port, regs in sets.items()}
 
-    @property
-    def write_set_per_register(self) -> dict[int, list[tuple[OperatorInstance, int]]]:
-        """
-        For each WIDE register index, the ``(instance, output port)`` lanes that ever write it, in a canonical order.
-
-        A cost proxy for the register allocator (via ``write_select_fanin``); the emitter itself routes writes through
-        the per-register write codebook, not this set. The input-load writers of registers ``0..nload-1`` are tracked
-        separately via ``lir.float_inputs`` (a distinct write source, folded into the same per-register opcode).
-        """
-        return self._write_sets(RegRef)
-
-    @property
-    def bool_write_set_per_register(self) -> dict[int, list[tuple[OperatorInstance, int]]]:
-        """The boolean-bank counterpart of :attr:`write_set_per_register`, in the same canonical lane order."""
-        return self._write_sets(BoolRegRef)
-
     def _write_sets(self, bank: type[RegRef] | type[BoolRegRef]) -> dict[int, list[tuple[OperatorInstance, int]]]:
+        # Cost proxy for write_select_fanin only (writers in canonical order); the emitter routes writes via the opcode.
         sets: dict[int, list[tuple[OperatorInstance, int]]] = {}
         for op in self.ops:
             for write in op.writes:
@@ -888,7 +873,7 @@ class Lir:
         writing it beyond the first (``max(0, drivers - 1)``) -- the input load, every pooled writeback lane, every
         inline (cast) write, every phi-arm copy/write, and a non-coalesced slot's install. The register allocator
         minimizes this steering proxy; a register's live-in carry is the write opcode's implicit NOP hold, not a driver,
-        so it is not counted. It counts the phi-arm copies that ``write_set_per_register`` (pooled lanes only) omits, so
+        so it is not counted. It counts the phi-arm copies that ``_write_sets`` (pooled lanes only) omits, so
         it stays meaningful as coalescing trades copies for shared writeback lanes. The emitted per-register opcode
         ``case`` may fold value-equal drivers below this count, so this is an upper bound on the realized mux fan-in.
         """
@@ -898,9 +883,9 @@ class Lir:
             wide[fload.dst.index] = wide.get(fload.dst.index, 0) + 1
         for bload in self.bool_inputs:
             boolc[bload.dst.index] = boolc.get(bload.dst.index, 0) + 1
-        for reg, lanes in self.write_set_per_register.items():
+        for reg, lanes in self._write_sets(RegRef).items():
             wide[reg] = wide.get(reg, 0) + len(lanes)
-        for reg, lanes in self.bool_write_set_per_register.items():
+        for reg, lanes in self._write_sets(BoolRegRef).items():
             boolc[reg] = boolc.get(reg, 0) + len(lanes)
         for block in self.blocks:
             for inline_op in block.inline_ops:

--- a/holoso/_lir/_ir.py
+++ b/holoso/_lir/_ir.py
@@ -70,9 +70,9 @@ def inline_fire_cycle(commit_cycle: int, fetch_lag: int) -> int:
 
 def pooled_write_word(commit_cycle: int) -> int:
     """
-    The fetch-PC-frame step on which a pooled lane drives its write-enable/address microcode word: the commit step
-    itself. This is the lone helper in the fetch-PC frame (no ``fetch_lag``) -- it places the microcode word the
-    sequencer fetches, not the step the datapath acts on it. Shared by the emitter's microcode (where the word is
+    The fetch-PC-frame step on which a pooled lane's write commits -- its destination register's write opcode: the
+    commit step itself. This is the lone helper in the fetch-PC frame (no ``fetch_lag``) -- it places the microcode word
+    the sequencer fetches, not the step the datapath acts on it. Shared by the emitter's microcode (where the word is
     placed) and the overlap layout (which keeps every write word inside the block), so the two cannot drift -- the same
     single-source-of-truth contract as the landing/read helpers above.
     """
@@ -220,7 +220,7 @@ class OperatorInstance:
     index: int  # 0-based within this concrete operator value
 
     def __post_init__(self) -> None:
-        # A pooled result commits at issue + latency, so latency >= 1 keeps its write-enable off the held ``ucode[0]``
+        # A pooled result commits at issue + latency, so latency >= 1 keeps its write opcode off the held ``ucode[0]``
         # (the accept-dwell word) -- a latency-0 pooled operator would re-commit every idle cycle (see ``transacting``).
         assert self.operator.latency >= 1, f"{self.operator.mnemonic}: pooled operator latency must be >= 1"
         # Every pooled operator passes through here, so its three hand-synchronized per-port declarations are
@@ -857,9 +857,9 @@ class Lir:
         """
         For each WIDE register index, the ``(instance, output port)`` lanes that ever write it, in a canonical order.
 
-        This drives the sparse per-register write select: a register written by a single lane needs no write-port
-        mux. The input-load writers of registers ``0..nload-1`` are tracked separately via ``lir.float_inputs``
-        (they are a distinct, address-free write source folded into the same select).
+        A cost proxy for the register allocator (via ``write_select_fanin``); the emitter itself routes writes through
+        the per-register write codebook, not this set. The input-load writers of registers ``0..nload-1`` are tracked
+        separately via ``lir.float_inputs`` (a distinct write source, folded into the same per-register opcode).
         """
         return self._write_sets(RegRef)
 
@@ -884,14 +884,13 @@ class Lir:
     @property
     def write_select_fanin(self) -> int:
         """
-        The ground-truth per-register write-select fan-in summed over both banks: for every register, the number of
-        distinct drivers in its write chain beyond the first (``max(0, drivers - 1)``). The backend drives each register
-        with one priority chain over exactly these drivers -- the input load, every pooled writeback lane, every inline
-        (cast) write, every phi-arm copy/write, and a non-coalesced slot's install. A register's live-in carry is the
-        chain's implicit hold (the unmatched-condition fall-through), not a mux input, so it is not counted. This is the
-        true steering cost the sparse register file synthesizes, counting the phi-arm copies that
-        ``write_set_per_register`` (pooled lanes only) omits, so it stays meaningful as coalescing trades copies for
-        shared writeback lanes.
+        The per-register writer fan-in summed over both banks: for every register, the number of distinct drivers
+        writing it beyond the first (``max(0, drivers - 1)``) -- the input load, every pooled writeback lane, every
+        inline (cast) write, every phi-arm copy/write, and a non-coalesced slot's install. The register allocator
+        minimizes this steering proxy; a register's live-in carry is the write opcode's implicit NOP hold, not a driver,
+        so it is not counted. It counts the phi-arm copies that ``write_set_per_register`` (pooled lanes only) omits, so
+        it stays meaningful as coalescing trades copies for shared writeback lanes. The emitted per-register opcode
+        ``case`` may fold value-equal drivers below this count, so this is an upper bound on the realized mux fan-in.
         """
         wide: dict[int, int] = {}
         boolc: dict[int, int] = {}

--- a/holoso/_lir/_layout.py
+++ b/holoso/_lir/_layout.py
@@ -15,14 +15,14 @@ from ._mir_facts import mir_operation, mir_rpo, succ_map
 def _value_word_and_landing(mir: Mir, vid: ValueId, issue: int, fetch_lag: int) -> tuple[int, int, HardwareOperator]:
     """
     For a scheduled value, the (last in-block control WORD, result LANDING) in its block-local frame. The word is the
-    latest fetch step the op still drives -- a pooled lane's write-enable on its commit step or an inline op's
+    latest fetch step the op still drives -- a pooled lane's write opcode on its commit step or an inline op's
     combinational fire step; the result lands later, after the fetch pipeline. Cross-block overlap may place
     ``term_offset`` between the two: the word stays in the block, the landing spills into the (single-predecessor)
     successor frame.
     """
     operator = mir_operation(mir, vid).operator
     commit = issue + operator.latency
-    # The control WORD placement still distinguishes the op class: a pooled lane drives its write-enable word on the
+    # The control WORD placement still distinguishes the op class: a pooled lane drives its write-opcode word on the
     # commit step, an inline op fires its combinational statement one fetch_lag later. The result LANDING is uniform.
     word = (
         pooled_write_word(commit)

--- a/holoso/_lir/_regalloc.py
+++ b/holoso/_lir/_regalloc.py
@@ -76,8 +76,9 @@ class ColoringProblem:
     ``movable`` are the values to place (in a stable order); ``pinned`` fixes inputs and state live-ins to their
     registers; ``interferes`` is the symmetric adjacency; ``consumer_ports`` and ``producer_key`` drive the mux-fan-in
     objective; ``fresh_start`` is the first register index above the pinned block. There is no write-path restriction:
-    the emitter drives every register with a single priority chain over all its writers, so any two non-interfering
-    values may share a register regardless of whether they are produced by an operator, a phi-arm copy, or a cast.
+    the emitter drives every register with a single write opcode selecting among all its writers, so any two
+    non-interfering values may share a register regardless of whether they are produced by an operator, a phi-arm copy,
+    or a cast.
 
     ``producer_key`` is a SET of producers per value, not a single one: a coalesced phi class is one ``movable`` entry
     backed by every arm operator that writes its register, so the write-select fan-in counts the union of those

--- a/holoso/_operators.py
+++ b/holoso/_operators.py
@@ -177,7 +177,7 @@ class PooledHardwareOperator(HardwareOperator, ABC):
     """
     An operator backed by a physical streaming module instance (in_valid/out_valid, per-float-port sign conditioners).
     The scheduler pools and contends equal operators over shared instances; every port is microcode-driven in the
-    generated RTL (read-address lanes for operands, write-enable lanes per output port).
+    generated RTL (a per-operand read opcode selects each operand, a per-register write opcode installs each result).
     """
 
     error_ports: ClassVar[list[str]] = []

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,13 +68,11 @@ def synth_examples(session: nox.Session) -> None:
     Out-of-context FPGA synthesis (f_max/fabric) of the bundled example matrix across the available tools.
     This one takes a long time.
 
-    Targets are independent and embarrassingly parallel, but the wide e8m36 datapaths are RAM-bound under
-    place-and-route, so the worker count is half the host core count (at least 2) rather than the full count --
-    leaving memory headroom while still scaling with the machine. pytest-enabler, which would otherwise force
-    ``-n auto`` (the full core count), is disabled here so this holds.
+    Each run is itself multithreaded, so the worker count (two-thirds of the cores) balances core utilization against
+    peak P&R memory on the wide e8m36 rows. pytest-enabler is disabled so it cannot force ``-n auto`` (the full count).
     """
     session.install("-e", ".[test]")
-    workers = max(2, (os.cpu_count() or 4) // 2)
+    workers = max(2, int((os.cpu_count() or 4) * 2 / 3))
     session.run("python", "-m", "pytest", "-p", "no:enabler", "-s", "-m", "synth", "-n", str(workers), "tests")
 
 

--- a/synth/flows/_flow.py
+++ b/synth/flows/_flow.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
+
 from holoso import SynthesisResult
+
 from .._synth import SynthArtifact
 
 

--- a/synth/flows/diamond.py
+++ b/synth/flows/diamond.py
@@ -1,5 +1,4 @@
 import html
-import os
 import re
 import shlex
 from dataclasses import dataclass, field
@@ -82,27 +81,14 @@ def _strategy(freq_MHz: float) -> str:
         "PROP_LST_UseLPF": "True",
         "PROP_MAP_RegRetiming": "True",
         "PROP_MAP_TimingDriven": "True",
-        "PROP_PAR_EffortParDes": "5",
-        "PROP_PAR_LowSkewClokNet": "True",  # Diamond property name spelling is intentional.
-        "PROP_PAR_RoutePassParDes": "6",
+        "PROP_PAR_EffortParDes": "2",
+        "PROP_PAR_LowSkewClokNet": "False",  # Diamond property name spelling is intentional.
+        "PROP_PAR_RoutePassParDes": "2",
         "PROP_PAR_RunParWithTrce": "True",
         "PROP_SYN_EdfFrequency": f"{freq_MHz:.0f}",
         "PROP_SYN_EdfInsertIO": "False",
         "PROP_SYN_UseLPF": "True",
     }
-    # Some wide-argument kernels need an extra push to close timings.
-    if int(os.getenv("HOLOSO_DIAMOND_HARD", "0").strip()) != 0:
-        properties.update(
-            {
-                "PROP_PAR_PlcIterParDes": "6",
-                "PROP_PAR_SaveBestRsltParDes": "1",
-                "PROP_PAR_MultiSeedSortMode": "Worst Slack",
-                "PROP_MAP_TimingDrivenPack": "True",
-                "PROP_MAP_TimingDrivenNodeRep": "True",
-                "PROP_PAR_RouteDlyRedParDes": "1",
-                "PROP_PAR_RouteResOptParDes": "1",
-            }
-        )
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
         "<!DOCTYPE strategy>",

--- a/synth/flows/vivado.py
+++ b/synth/flows/vivado.py
@@ -64,10 +64,9 @@ def _tcl(top: str, part: str, verilog_paths: list[Path]) -> str:
             f"read_xdc {_XDC}",
             f"synth_design -top {top} -part {part} -mode out_of_context "
             "-directive PerformanceOptimized -global_retiming on -resource_sharing off",
-            "opt_design -directive Explore",
-            "place_design -directive ExtraTimingOpt",
-            "phys_opt_design -directive AddRetime",
-            "route_design -directive AggressiveExplore -tns_cleanup",
+            "opt_design -directive Default",
+            "place_design -directive Default",
+            "route_design -directive Default -tns_cleanup",
             f"report_utilization -file {_UTIL}",
             f"report_timing -delay_type max -max_paths 1 -nworst 1 -file {_TIMING}",
             "",

--- a/synth/flows/yosys.py
+++ b/synth/flows/yosys.py
@@ -1,5 +1,4 @@
 import json
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -60,10 +59,6 @@ class YosysEcp5Flow(Flow):
             _REPORT,
             *(str(a) for a in self.options.get("nextpnr_extra", ())),
         ]
-        # A few wide kernels sit at the very edge on nextpnr; HOLOSO_YOSYS_HARD raises the heap placer's timing weight
-        # (default 10) so placement chases the critical routes harder -- the yosys analogue of HOLOSO_DIAMOND_HARD.
-        if int(os.getenv("HOLOSO_YOSYS_HARD", "0").strip() or "0") != 0:
-            nextpnr_args += ["--placer-heap-timingweight", "25"]
         commands = [
             CommandSpec(["yosys", "-s", _SCRIPT]),
             CommandSpec(["nextpnr-ecp5", *nextpnr_args]),

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -147,7 +147,9 @@ TARGETS: list[SynthTarget] = [
             fdiv=FDivOperator(F_e6m18, stage_output=1),
         ),
     ),
-    for_example("pid", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_output=1))),
+    for_example(
+        "pid", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_input=1, stage_output=1))
+    ),
     for_example("pid", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("schmitt_trigger", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("schmitt_trigger", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
@@ -193,6 +195,7 @@ TARGETS: list[SynthTarget] = [
         op_config(
             F_e6m18,
             fadd=FAddOperator(F_e6m18, stage_input=1),
+            fmul=FMulOperator(F_e6m18, stage_output=1),
             fdiv=FDivOperator(F_e6m18, stage_input=1, stage_output=1),
         ),
         env={"HOLOSO_DIAMOND_HARD": "1"},
@@ -201,7 +204,7 @@ TARGETS: list[SynthTarget] = [
         "ekf1_stateless",
         FlowId.VIVADO_ARTIX7,
         150,
-        op_config(F_e6m18, fmul=FMulOperator(F_e6m18, stage_product=1)),
+        op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_input=1), fmul=FMulOperator(F_e6m18, stage_product=1)),
     ),
     for_example(
         "ekf1_stateful",
@@ -251,7 +254,17 @@ TARGETS: list[SynthTarget] = [
     ),
     for_example("cordic_sincos", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("octave_index", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
-    for_example("octave_index", FlowId.DIAMOND_ECP5, 100, op_config_staged_output(F_e6m18)),
+    for_example(
+        "octave_index",
+        FlowId.DIAMOND_ECP5,
+        100,
+        op_config(
+            F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_input=1, stage_output=1),
+            fmul=FMulOperator(F_e6m18, stage_output=1),
+            fdiv=FDivOperator(F_e6m18, stage_output=1),
+        ),
+    ),
     for_example("octave_index", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("remainder", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example(

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -5,15 +5,15 @@ operator configuration). This is the single source of truth for what the example
 
 Deliberately a dumb-simple data table -- literal frequencies, one explicit row per (example, flow), and a full typed
 OpConfig per row; duplication is preferred over indirection here. Catalogued example targets reuse the shared example
-registry (_examples.SPECS) so each kernel is constructed once; test_synth_targets checks that every catalogued example
-appears. Off-catalogue regression cores may be added as SynthTarget records with example=None.
+registry (_examples.SPECS) so each kernel is constructed once. Off-catalogue regression cores may be added as
+SynthTarget records with example=None.
 
 The bar (all at minimum speed grade): yosys-ecp5 and diamond-ecp5 at 100 MHz, vivado-artix7 at 150 MHz. Almost every
 kernel closes lean; stage knobs are row-local and appear only where measured closure needs them.
 """
 
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
+from collections.abc import Callable
+from dataclasses import dataclass
 
 from holoso import (
     FAddOperator,
@@ -73,8 +73,7 @@ class SynthTarget:
     flow: FlowId
     target_frequency_MHz: float
     ops: OpConfig
-    name: str  # descriptive module/report label; unique per flow (guarded by test_synth_targets)
-    env: Mapping[str, str] = field(default_factory=dict)
+    name: str  # descriptive module/report label; unique per flow
     example: str | None = None  # the SPECS name this exercises; None for an off-catalogue regression core
 
     @property
@@ -93,7 +92,6 @@ def for_example(
     *,
     kernel: Callable[[], Callable[..., object]] | None = None,
     name: str | None = None,
-    env: Mapping[str, str] | None = None,
 ) -> SynthTarget:
     """
     A target whose kernel is the catalogued example `example`. The kernel defaults to the SPEC factory, but a kernel
@@ -109,7 +107,6 @@ def for_example(
         target_frequency_MHz=target_frequency_MHz,
         ops=ops,
         name=name or f"{example}_e{fmt.wexp}m{fmt.wman}",
-        env=env or {},
         example=example,
     )
 
@@ -129,7 +126,7 @@ TARGETS: list[SynthTarget] = [
     for_example("madd", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("poly3", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("poly3", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
-    for_example("poly3", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
+    for_example("poly3", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))),
     for_example("signal_window", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("signal_window", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
     for_example("signal_window", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
@@ -171,7 +168,9 @@ TARGETS: list[SynthTarget] = [
     for_example("recip_newton", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("integrator", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("integrator", FlowId.DIAMOND_ECP5, 100, op_config_staged_output(F_e6m18)),
-    for_example("integrator", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
+    for_example(
+        "integrator", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))
+    ),
     for_example("uart_tx", FlowId.YOSYS_ECP5, 100, op_config(F_e4m8)),
     for_example("uart_tx", FlowId.DIAMOND_ECP5, 100, op_config(F_e4m8)),
     for_example("uart_tx", FlowId.VIVADO_ARTIX7, 150, op_config(F_e4m8)),
@@ -194,17 +193,20 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1),
-            fmul=FMulOperator(F_e6m18, stage_output=1),
+            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOperator(F_e6m18, stage_input=1, stage_output=1),
             fdiv=FDivOperator(F_e6m18, stage_input=1, stage_output=1),
         ),
-        env={"HOLOSO_DIAMOND_HARD": "1"},
     ),
     for_example(
         "ekf1_stateless",
         FlowId.VIVADO_ARTIX7,
         150,
-        op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_input=1), fmul=FMulOperator(F_e6m18, stage_product=1)),
+        op_config(
+            F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOperator(F_e6m18, stage_product=1),
+        ),
     ),
     for_example(
         "ekf1_stateful",
@@ -224,16 +226,20 @@ TARGETS: list[SynthTarget] = [
         op_config(
             F_e6m18,
             fadd=FAddOperator(F_e6m18, stage_input=1, stage_decode=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOperator(F_e6m18, stage_pack=1),
             fdiv=FDivOperator(F_e6m18, stage_input=1, stage_output=1),
         ),
-        env={"HOLOSO_DIAMOND_HARD": "1"},
         kernel=_ekf1_stateful_kernel,
     ),
     for_example(
         "ekf1_stateful",
         FlowId.VIVADO_ARTIX7,
         150,
-        op_config(F_e6m18, fmul=FMulOperator(F_e6m18, stage_product=1)),
+        op_config(
+            F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1),
+            fmul=FMulOperator(F_e6m18, stage_product=1),
+        ),
         kernel=_ekf1_stateful_kernel,
     ),
     for_example(
@@ -252,7 +258,9 @@ TARGETS: list[SynthTarget] = [
             fmul_ilog2=FMulILog2OperatorFamily(F_e6m18, stage_decode=1),
         ),
     ),
-    for_example("cordic_sincos", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
+    for_example(
+        "cordic_sincos", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))
+    ),
     for_example("octave_index", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example(
         "octave_index",
@@ -260,7 +268,7 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_output=1),
+            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1),
             fmul=FMulOperator(F_e6m18, stage_output=1),
             fdiv=FDivOperator(F_e6m18, stage_output=1),
         ),
@@ -273,14 +281,16 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(F_e6m18, fdiv=FDivOperator(F_e6m18, stage_input=1, stage_output=1)),
     ),
-    for_example("remainder", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
+    for_example(
+        "remainder", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))
+    ),
     for_example(
         "ekf1_stateless",
         FlowId.YOSYS_ECP5,
         100,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(F_e8m36, stage_input=1, stage_decode=1, stage_normalize=1, stage_pack=1, stage_output=1),
+            fadd=FAddOperator(F_e8m36, stage_input=1, stage_decode=1, stage_normalize=2, stage_pack=1, stage_output=1),
             fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=2, stage_pack=1, stage_output=1),
             fdiv=FDivOperator(F_e8m36, stage_input=1, stage_output=1),
             fmul_ilog2=FMulILog2OperatorFamily(F_e8m36, stage_input=1, stage_decode=1),
@@ -299,7 +309,6 @@ TARGETS: list[SynthTarget] = [
             fdiv=FDivOperator(F_e8m36, stage_input=1, stage_pack=1, stage_output=1),
             fmul_ilog2=FMulILog2OperatorFamily(F_e8m36, stage_decode=1),
         ),
-        env={"HOLOSO_DIAMOND_HARD": "1"},
     ),
     for_example(
         "ekf1_stateless",
@@ -318,11 +327,10 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(F_e8m36, stage_input=1, stage_decode=1, stage_normalize=1, stage_pack=1),
+            fadd=FAddOperator(F_e8m36, stage_input=1, stage_decode=1, stage_normalize=2, stage_pack=1),
             fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=2, stage_output=1),
             fmul_ilog2=FMulILog2OperatorFamily(F_e8m36, stage_input=1, stage_decode=1),
         ),
-        env={"HOLOSO_YOSYS_HARD": "1"},
         kernel=_ekf1_stateful_kernel,
     ),
     for_example(
@@ -335,7 +343,6 @@ TARGETS: list[SynthTarget] = [
             fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=1, stage_pack=1),
             fdiv=FDivOperator(F_e8m36, stage_input=3, stage_pack=1, stage_output=1),
         ),
-        env={"HOLOSO_DIAMOND_HARD": "1"},
         kernel=_ekf1_stateful_kernel,
     ),
     for_example(
@@ -352,8 +359,4 @@ TARGETS: list[SynthTarget] = [
     ),
 ]
 
-
-# Every environment-variable key any target sets. The harness clears these before applying a target's own env, so an
-# ambient value (e.g. a shell HOLOSO_DIAMOND_HARD=1) cannot leak into a lean row and mask a closure regression by
-# silently running the hard strategy.
-TARGET_ENV_KEYS: frozenset[str] = frozenset(key for target in TARGETS for key in target.env)
+assert len({t.label for t in TARGETS}) == len(TARGETS)  # labels key build dirs and pytest ids

--- a/tests/hdl/holoso_support_fn_tb.v
+++ b/tests/hdl/holoso_support_fn_tb.v
@@ -22,4 +22,14 @@ module holoso_fsaturate_tb #(parameter WEXP = 6, parameter WMAN = 18) (
     assign y = holoso_fsaturate(x);
 endmodule
 
+module holoso_fsgnop_tb #(parameter WEXP = 6, parameter WMAN = 18) (
+    input  wire [WEXP+WMAN-1:0] x,
+    input  wire           [1:0] op,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam W = WEXP + WMAN;
+    `include "holoso_support_inline.vh"
+    assign y = holoso_fsgnop(x, op);
+endmodule
+
 `default_nettype wire

--- a/tests/hdl/test_fsgnop_fn.py
+++ b/tests/hdl/test_fsgnop_fn.py
@@ -1,0 +1,73 @@
+"""
+Tests the holoso_fsgnop inline function. The same-named module is co-compiled from the megafile, so this also serves
+as a function/module name-coexistence canary across simulators.
+"""
+
+from pathlib import Path
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import Timer
+from cocotb_tools.runner import get_runner
+
+from .hdl_float_oracle import (
+    DIRECTED_F32,
+    HDL_DIR,
+    REPO_ROOT,
+    SGNOP_OPS,
+    SIMULATORS,
+    apply_sgnop,
+    build_args,
+    get_random_count,
+    get_seed,
+    random_zkf_f32,
+    sources,
+)
+
+_WEXP = 8
+_WMAN = 24
+_WFULL = _WEXP + _WMAN
+
+
+@cocotb.test()
+async def holoso_fsgnop_fn_cocotb(dut) -> None:
+    async def check(x_bits: int, op: int) -> None:
+        dut.x.value = x_bits
+        dut.op.value = op
+        await Timer(1, unit="ns")
+        actual = int(dut.y.value)
+        expected = apply_sgnop(x_bits, op, _WFULL)
+        assert actual == expected, f"x=0x{x_bits:08x} op={op}: got 0x{actual:08x}, want 0x{expected:08x}"
+
+    for x in DIRECTED_F32:
+        for op in SGNOP_OPS:
+            await check(x, op)
+
+    rng = np.random.default_rng(get_seed())
+    for _ in range(get_random_count()):
+        x = random_zkf_f32(rng)
+        for op in SGNOP_OPS:
+            await check(x, op)
+
+
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_holoso_fsgnop_fn(sim: str) -> None:
+    runner = get_runner(sim)
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / "fsgnop_fn"
+    runner.build(
+        sources=[*sources(), Path(__file__).resolve().parent / "holoso_support_fn_tb.v"],
+        includes=[HDL_DIR],
+        hdl_toplevel="holoso_fsgnop_tb",
+        parameters={"WEXP": _WEXP, "WMAN": _WMAN},
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="holoso_fsgnop_tb",
+        test_module="tests.hdl.test_fsgnop_fn",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -243,10 +243,9 @@ def test_kernel_without_outputs_is_rejected() -> None:
 
 
 @requires_iverilog
-def test_state_port_name_does_not_collide_with_internal_sign_wire(tmp_path: Path) -> None:
+def test_state_slot_folded_sign_coexists_with_sibling_port(tmp_path: Path) -> None:
     # A public attribute `y_d` becomes the port state_y_d; a sibling slot `y` whose boundary copy carries a folded sign
-    # used to emit an internal wire also named state_y_d, producing a duplicate (multiply-driven) identifier. The
-    # internal sign wire must live outside the state_<attr> port namespace, so the module elaborates cleanly.
+    # is emitted as an inline holoso_fsgnop() call in the state install. Both must elaborate cleanly together.
     class Collide:
         def __init__(self) -> None:
             self.y = 0.0
@@ -255,7 +254,7 @@ def test_state_port_name_does_not_collide_with_internal_sign_wire(tmp_path: Path
 
         def __call__(self, x):  # type: ignore[no-untyped-def]
             self.y_d = self._p
-            self.y = -self._p  # sign-flipped boundary copy -> internal sign-conditioning wire for slot y
+            self.y = -self._p  # sign-flipped state boundary copy -> inline holoso_fsgnop() in the state install
             self._p = x
             return self.y
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -286,40 +286,56 @@ def test_ekf1_stateful_elaborates(tmp_path: Path) -> None:
     _elaborate("ekf1_stateful", generate(lir).verilog, tmp_path)
 
 
-def test_both_bank_lane_write_enables_ride_the_commit_step() -> None:
-    # A pooled lane's write-enable -- boolean OR wide -- sits at ROM step
-    # ``pooled_write_word(commit)``, which is the commit step itself (the flag is valid on that executing step;
-    # one later would land a wide result past the branch's boundary read, which has exactly one cycle of slack).
-    # Checked white-box against the microcode tables of a kernel with both lane kinds.
+def test_both_bank_lane_write_commit_rides_the_commit_step() -> None:
+    # A pooled lane commits on its commit step: the destination register's write opcode holds that lane's source code
+    # at ROM step ``pooled_write_word(commit)`` == the commit step itself (valid on that executing step; one later would
+    # land a wide result past the branch's boundary read, which has exactly one cycle of slack). Checked white-box
+    # against the microcode tables of a kernel with both lane kinds.
     from holoso._backend.verilog._microcode import (
-        base_name,
+        OpWriteSource,
         build_microcode,
-        f_wen,
-        port_const_map,
+        f_op,
+        read_codebook,
         read_ports,
-        write_target_lists,
+        tapped_lanes,
+        write_codebook,
+        write_events,
     )
-    from holoso._lir import BoolRegRef as LirBoolRegRef
     from ._modelref import branch_boundary_kernel, fcmp_staged_ops
 
     fmt = FloatFormat(6, 18)
     lir = build(_run(branch_boundary_kernel, fcmp_staged_ops(fmt, 1)), "lane_steps", fetch_stages=3)
     read_port = read_ports(lir)
-    write_lists = write_target_lists(lir)
-    fields = build_microcode(lir, read_port, port_const_map(lir, read_port), write_lists)
+    events = write_events(lir)
+    write_books = write_codebook(events)
+    fields = build_microcode(lir, read_port, read_codebook(lir, read_port), write_books, events, tapped_lanes(lir))
     checked_bool = checked_wide = 0
     for op in lir.ops:
         for write in op.writes:
-            field = fields[f_wen(base_name(op.inst), write.port)]
-            is_wide = not isinstance(write.dst, LirBoolRegRef)
+            is_wide = not isinstance(write.dst, BoolRegRef)
+            source = OpWriteSource(op.inst, write.port, False if is_wide else write.conditioner.invert)
+            code = write_books[write.dst].code(source)
             assert (
-                field.values[pooled_write_word(op.commit_cycle)] == 1
-            ), "a pooled lane's write-enable must ride the commit step on both banks"
+                fields[f_op(write.dst)].values[pooled_write_word(op.commit_cycle)] == code
+            ), "a pooled lane's write opcode must ride the commit step on both banks"
             if is_wide:
                 checked_wide += 1
             else:
                 checked_bool += 1
     assert checked_bool >= 1 and checked_wide >= 2  # the kernel has a comparison and several float results
+
+
+def _two_division_kernel(a: float, b: float, c: float, d: float) -> float:
+    return a / b + c / d  # two divisions share one fdiv instance and land in two distinct registers
+
+
+def test_error_gate_ors_over_multiple_landing_registers() -> None:
+    # An error-bearing operator (fdiv) whose result lands in >=2 distinct registers reconstructs its commit window as
+    # the OR, over those registers, of ``uc_op_<reg> == <its source code>``. No bundled example produces a multi-term
+    # err gate, and the numerical model does not simulate ``err``, so cosim cannot reach it -- pin the reconstruction.
+    verilog = generate(build(_run(_two_division_kernel, _ops(FloatFormat(6, 18))), "two_div", fetch_stages=3)).verilog
+    err = next(line.strip() for line in verilog.splitlines() if line.strip().startswith("assign err ="))
+    assert err.count("uc_op_") >= 2 and " | " in err and "div0" in err, err
 
 
 def test_wide_multi_output_operator_elaborates_with_per_port_lanes(tmp_path: Path) -> None:
@@ -416,7 +432,6 @@ def test_wide_multi_output_operator_elaborates_with_per_port_lanes(tmp_path: Pat
         assert re.search(
             rf"regs\[\d+\] <= s_fsortlike_\w+_0_y{q}\b", verilog
         ), "the wide write must read the combinational output wire directly"
-        assert re.search(rf"uc_wen_fsortlike_\w+_0_y{q}\b", verilog)
         assert re.search(rf"uc_fsortlike_\w+_0_y{q}sgn\b", verilog)
     assert ".min(" in verilog and ".max(" in verilog and ".min_sgnop(" in verilog and ".max_sgnop(" in verilog
     if shutil.which("iverilog") is None:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -296,7 +296,6 @@ def test_both_bank_lane_write_commit_rides_the_commit_step() -> None:
         build_microcode,
         f_op,
         read_codebook,
-        read_ports,
         tapped_lanes,
         write_codebook,
         write_events,
@@ -305,10 +304,9 @@ def test_both_bank_lane_write_commit_rides_the_commit_step() -> None:
 
     fmt = FloatFormat(6, 18)
     lir = build(_run(branch_boundary_kernel, fcmp_staged_ops(fmt, 1)), "lane_steps", fetch_stages=3)
-    read_port = read_ports(lir)
     events = write_events(lir)
     write_books = write_codebook(events)
-    fields = build_microcode(lir, read_port, read_codebook(lir, read_port), write_books, events, tapped_lanes(lir))
+    fields = build_microcode(lir, read_codebook(lir), write_books, events, tapped_lanes(lir))
     checked_bool = checked_wide = 0
     for op in lir.ops:
         for write in op.writes:
@@ -340,8 +338,8 @@ def test_error_gate_ors_over_multiple_landing_registers() -> None:
 
 def test_wide_multi_output_operator_elaborates_with_per_port_lanes(tmp_path: Path) -> None:
     # No shipped operator has several WIDE outputs yet (fsort will), so the per-port wide lane machinery -- per-output
-    # write-enable/address and sign-conditioner fields, each result driven combinationally from the operator into its
-    # register write -- is exercised with a synthetic two-output operator on a hand-built
+    # sign-conditioner fields plus the per-register write opcodes, each result driven combinationally from the operator
+    # into its register write -- is exercised with a synthetic two-output operator on a hand-built
     # Lir, down to Icarus elaboration against a matching stub module.
     from dataclasses import dataclass
     from typing import ClassVar

--- a/tests/test_const_install.py
+++ b/tests/test_const_install.py
@@ -46,5 +46,5 @@ def test_multi_distinct_const_install_selects_among_constants() -> None:
 @pytest.mark.cosim
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_multi_distinct_const_install_cosim(sim: str) -> None:
-    """RTL == model for a register installing two distinct constants: the ``uc_ccidx`` selector picks the right one."""
+    """RTL == model for a register installing two distinct constants: one write-opcode case arm per const."""
     run_cosim(sim, _multi_const_install, _FMT, "multi_const")

--- a/tests/test_const_install.py
+++ b/tests/test_const_install.py
@@ -1,10 +1,12 @@
 """
 Coverage for the multi-distinct-constant install path. A register that receives two or more DISTINCT constant phi-arm
-installs is driven by a microcode const-pool selector (``uc_ccidx``) muxing among its constants, rather than the bare
-``const_N`` net a single-constant register uses. No bundled example exercises this -- each installs at most one distinct
-constant per register -- so this kernel pins it: a comparison-gated branch (a division per arm blocks if-conversion, so
-the merge stays a real phi) assigns two distinct constants to one merged variable.
+installs selects among them through its per-register write opcode, one ``case`` arm per constant ``const_N`` net. No
+bundled example exercises this -- each installs at most one distinct constant per register -- so this kernel pins it: a
+comparison-gated branch (a division per arm blocks if-conversion, so the merge stays a real phi) assigns two distinct
+constants to one merged variable.
 """
+
+import re
 
 import pytest
 
@@ -32,10 +34,13 @@ def _multi_const_install(x: float) -> float:
     return a + w
 
 
-def test_multi_distinct_const_install_emits_selector() -> None:
-    """The kernel must emit a const-pool selector field; otherwise the cosim below would not exercise the mux at all."""
+def test_multi_distinct_const_install_selects_among_constants() -> None:
+    """A register must select among >=2 distinct constants; otherwise the cosim below would not exercise that mux."""
     lir = build(lower_to_mir(optimize(lower(_multi_const_install)), default_ops(_FMT)), "multi_const", fetch_stages=3)
-    assert "uc_ccidx_" in generate_verilog(lir).verilog
+    per_reg: dict[str, set[str]] = {}
+    for reg, const in re.findall(r"regs\[(\d+)\] <= const_(\d+);", generate_verilog(lir).verilog):
+        per_reg.setdefault(reg, set()).add(const)
+    assert any(len(consts) >= 2 for consts in per_reg.values()), "no register selects among >=2 distinct constants"
 
 
 @pytest.mark.cosim

--- a/tests/test_cosim_sign.py
+++ b/tests/test_cosim_sign.py
@@ -1,0 +1,29 @@
+"""
+Cosim of the two inlined-``holoso_fsgnop`` sites the bundled examples miss: a folded sign on a state writeback and on
+output taps. The ``remainder``/``pid`` specs already cover the inline-firing and phi-arm-install sites.
+"""
+
+import pytest
+
+from holoso import FloatFormat
+from ._cosim import run_cosim
+from .hdl.hdl_float_oracle import SIMULATORS
+
+
+class SignHold:
+    """Negated-input hold: writes ``-a`` to persistent state and outputs the negated previous state."""
+
+    def __init__(self) -> None:
+        self.acc = 0.0
+
+    def __call__(self, a):
+        prev = self.acc
+        self.acc = -a
+        return -prev
+
+
+@pytest.mark.cosim
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_sign_conditioning_cosim(sim: str) -> None:
+    fmt = FloatFormat(wexp=6, wman=18)
+    run_cosim(sim, SignHold().__call__, fmt, "sign_hold")

--- a/tests/test_gate_edge.py
+++ b/tests/test_gate_edge.py
@@ -63,7 +63,8 @@ def _assert_effect_trigger_gated(fn: Callable[..., object], name: str, prefix: s
     ]
     assert arms, f"kernel produced no {prefix} wires to check"
     for line in arms:
-        assert "transacting &" in line, f"{prefix} decode is not gated by transacting: {line}"
+        # A 1-bit trigger masks as ``transacting & ...``; a wider write opcode as ``{W{transacting}} & ...``.
+        assert "transacting" in line and " & " in line, f"{prefix} decode is not gated by transacting: {line}"
 
 
 def test_every_operator_iv_is_gated_by_transacting() -> None:
@@ -73,16 +74,16 @@ def test_every_operator_iv_is_gated_by_transacting() -> None:
 
 
 def test_const_install_is_gated_by_transacting() -> None:
-    # A cycle-0 const-install sits on ucode[0]; the decoded const-install write-enable must AND transacting. The bool
-    # install arm decodes identically, so this float-slot kernel covers the mechanism.
-    _assert_effect_trigger_gated(_ConstInstallState().__call__, "gate_cwe", "uc_cwen")
+    # A cycle-0 const-install sits on ucode[0]; its per-register write opcode must AND transacting so the held dwell
+    # decodes to the NOP code (0) and installs nothing. This float-slot kernel covers the mechanism.
+    _assert_effect_trigger_gated(_ConstInstallState().__call__, "gate_cwe", "uc_op_")
 
 
 def test_pooled_write_enable_is_gated_by_transacting() -> None:
-    # A pooled commit write-enable rides the executing word, so a held ucode[0] (accept dwell) or a stale pre-reset
-    # commit word must commit nothing. Every uc_wen wire ANDs transacting; the single decode-point gate covers both the
-    # register write chains and the err path that consume uc_wen.
-    _assert_effect_trigger_gated(_cycle0_kernel, "gate_we", "uc_wen_")
+    # A pooled commit rides the executing word, so a held ucode[0] (accept dwell) or a stale pre-reset commit word must
+    # commit nothing. Every write opcode ANDs transacting; the single decode-point gate covers both the register write
+    # cases and the err path that reads those opcodes.
+    _assert_effect_trigger_gated(_cycle0_kernel, "gate_we", "uc_op_")
 
 
 def _run_bench(name: str, lir: Lir, testcase: str, env: dict[str, int], monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -83,7 +83,7 @@ class Metrics:
     """
     The non-regression figures sampled off a built :class:`Lir`.
 
-    ``steering`` is the total sparse-regfile mux fan-in -- read-mux fan-in plus the GROUND-TRUTH write-select fan-in
+    ``steering`` is the total sparse-regfile mux fan-in -- read-mux fan-in plus the upper-bound write-select fan-in
     (:attr:`Lir.write_select_fanin`, which counts every write-chain driver the backend synthesizes: pooled lanes,
     inline casts, phi-arm copies, and slot installs). Counting the copies matters here: phi-arm coalescing trades
     pc-gated copies for shared pooled writeback lanes, so a copy-blind proxy would mis-report a coalescing win as a
@@ -151,7 +151,7 @@ def _measure(name: str) -> Metrics:
 # - Registers and steering reflect the unified cross-block allocator: liveness-bounded reuse with coalesced state
 #   slots, per-(instance, port) lane accounting of both banks' write selects, the comparator's read ports steered like
 #   any other operand muxes, and commutative orientation (the comparator swaps with its gt/lt tap exchange). steering
-#   counts the GROUND-TRUTH write-select fan-in (the emitter's full per-register write chain incl. phi-arm copies), not
+#   counts the upper-bound write-select fan-in (the emitter's full per-register write chain incl. phi-arm copies), not
 #   a pooled-lane-only proxy. Cordic's read-mux steering sits a couple of arms above the best coloring in its
 #   near-equal-cost band -- the disclosed price of deterministic value numbering; deeper annealing is optional.
 # - copies and the phi-dense figures reflect phi-arm coalescing: a phi whose register-backed, identity-conditioner arms

--- a/tests/test_synth_examples.py
+++ b/tests/test_synth_examples.py
@@ -18,21 +18,9 @@ import holoso
 from synth._synth import BUILD_ROOT
 from synth.flows import make_flow
 
-from ._synth_targets import TARGET_ENV_KEYS, TARGETS, SynthTarget
+from ._synth_targets import TARGETS, SynthTarget
 
 pytestmark = pytest.mark.synth
-
-
-def _apply_env(monkeypatch: pytest.MonkeyPatch, target: SynthTarget) -> None:
-    """
-    Set exactly this target's env, normalized: every key any target uses is cleared first so an ambient value (e.g. a
-    shell ``HOLOSO_DIAMOND_HARD=1``) cannot leak into a lean row and run the hard strategy, masking a closure
-    regression. The values are read inside ``flow.prepare()`` (``HOLOSO_DIAMOND_HARD`` in diamond ``_strategy``).
-    """
-    for key in TARGET_ENV_KEYS:
-        monkeypatch.delenv(key, raising=False)
-    for key, value in target.env.items():
-        monkeypatch.setenv(key, value)
 
 
 def test_some_target_flow_is_available() -> None:
@@ -45,12 +33,15 @@ def test_some_target_flow_is_available() -> None:
     ), "no synthesis tool available; the matrix would pass while verifying nothing"
 
 
-@pytest.mark.parametrize("target", TARGETS, ids=lambda t: t.label)
-def test_target_closes_timing(target: SynthTarget, monkeypatch: pytest.MonkeyPatch) -> None:
+# Heaviest-first so xdist starts the long wide-datapath rows immediately instead of scheduling them last and tailing.
+_BY_COST = sorted(TARGETS, key=lambda t: t.ops.float_format.wman, reverse=True)
+
+
+@pytest.mark.parametrize("target", _BY_COST, ids=lambda t: t.label)
+def test_target_closes_timing(target: SynthTarget) -> None:
     flow = make_flow(target.flow, target.target_frequency_MHz)
     if not flow.available():
         pytest.skip(f"{target.flow.value} tool not available")
-    _apply_env(monkeypatch, target)
 
     result = holoso.synthesize(target.kernel(), target.ops, name=target.name)
     directory = BUILD_ROOT / "examples" / target.label

--- a/tools/synth_compare.py
+++ b/tools/synth_compare.py
@@ -67,7 +67,7 @@ def capture(out_path: str) -> None:
             "env": dict(target.env),
         }
         try:
-            lir = build(lower_to_mir(optimize(lower(target.kernel())), target.ops), target.name)
+            lir = build(lower_to_mir(optimize(lower(target.kernel())), target.ops), target.name, fetch_stages=3)
             row["min_ii"] = lir.min_initiation_interval
             row["last_pc"] = lir.last_pc
             flow = make_flow(target.flow, target.target_frequency_MHz)

--- a/tools/synth_compare.py
+++ b/tools/synth_compare.py
@@ -2,11 +2,13 @@
 """
 Before/after synthesis comparison for the bundled example matrix.
 
-``capture`` synthesizes every TARGET on the current checkout and writes a JSON of per-target cycle latency (min II and
-last PC), f_max, slack, fabric area, and pass/fail. ``render`` reads a BEFORE and an AFTER JSON and emits a side-by-side
-HTML report with deltas, pass/fail badges, headline totals, and a flag on every target whose operator stage knobs were
-retuned (its f_max delta then reflects change+retune, not an isolated knob-fixed comparison; retuning is detected by a
-changed ops repr). Report-only tooling -- not part of the compiler, no tests, no design-doc coupling.
+``capture`` synthesizes every TARGET on the current checkout and writes a JSON of per-target cycle latency, f_max,
+slack, fabric area, and pass/fail.
+
+``render`` reads a BEFORE and an AFTER JSON and emits a side-by-side HTML report with deltas and a flag on every
+target whose operator stage knobs were retuned.
+
+Report-only tooling -- not part of the compiler, no tests, no design-doc coupling.
 
 Usage:
     python tools/synth_compare.py capture --out before.json
@@ -253,7 +255,7 @@ def render(before_path: str, after_path: str, out_path: str) -> None:
     print(f"Wrote {out_path}")
 
 
-_PAGE = """<!doctype html><html><head><meta charset="utf-8"><title>Holoso synthesis: before vs after</title>
+_PAGE = """<!doctype html><html><head><meta charset="utf-8"><title>Holoso synthesis delta report</title>
 <style>
  body{{font:14px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;margin:2rem;color:#1a1a2e;background:#fafaff}}
  h1{{font-size:1.4rem;margin:0 0 .3rem}}
@@ -277,7 +279,7 @@ _PAGE = """<!doctype html><html><head><meta charset="utf-8"><title>Holoso synthe
  .cphdr{{font-size:.76rem;color:#667;font-weight:600;text-transform:uppercase;letter-spacing:.04em;margin-bottom:.25rem}}
  .cp pre{{background:#0d1117;color:#c9d1d9;padding:.6rem .8rem;border-radius:6px;font-size:.73rem;overflow-x:auto;white-space:pre;line-height:1.35}}
 </style></head><body>
-<h1>Holoso synthesis — before vs after the <code>ucode[0]</code> NOP reclaim</h1>
+<h1>Holoso synthesis deltas</h1>
 <div class="sub">before <code>{before_commit}</code> ({before_ts}) &nbsp;→&nbsp; after <code>{after_commit}</code> ({after_ts})</div>
 <div class="headline">{headline}</div>
 <table><thead><tr>

--- a/tools/synth_compare.py
+++ b/tools/synth_compare.py
@@ -18,7 +18,6 @@ Usage:
 import argparse
 import html
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -34,7 +33,7 @@ from holoso._hir import optimize  # noqa: E402
 from holoso._lir import build  # noqa: E402
 from holoso._mir import lower as lower_to_mir  # noqa: E402
 from synth.flows import make_flow  # noqa: E402
-from tests._synth_targets import TARGETS, TARGET_ENV_KEYS  # noqa: E402
+from tests._synth_targets import TARGETS  # noqa: E402
 
 # Per-flow resource-primitive names for the LUT/FF/DSP/BRAM report columns; each tool names them differently.
 _RES_KEYS = {
@@ -44,13 +43,6 @@ _RES_KEYS = {
 }
 
 
-def _apply_env(env: dict) -> None:
-    for key in TARGET_ENV_KEYS:
-        os.environ.pop(key, None)
-    for key, value in env.items():
-        os.environ[key] = value
-
-
 def capture(out_path: str) -> None:
     commit = subprocess.run(
         ["git", "rev-parse", "--short", "HEAD"], cwd=REPO, capture_output=True, text=True
@@ -58,7 +50,6 @@ def capture(out_path: str) -> None:
     dirty = bool(subprocess.run(["git", "status", "--porcelain"], cwd=REPO, capture_output=True, text=True).stdout)
     rows = []
     for target in TARGETS:
-        _apply_env(target.env)
         row = {
             "label": target.label,
             "name": target.name,
@@ -66,7 +57,6 @@ def capture(out_path: str) -> None:
             "flow": target.flow.value,
             "target_MHz": target.target_frequency_MHz,
             "ops": repr(target.ops),
-            "env": dict(target.env),
         }
         try:
             lir = build(lower_to_mir(optimize(lower(target.kernel())), target.ops), target.name, fetch_stages=3)
@@ -174,9 +164,7 @@ def render(before_path: str, after_path: str, out_path: str) -> None:
     for label in labels:
         a = after[label]
         b = before.get(label, {})
-        retuned = (b.get("ops") is not None and b.get("ops") != a.get("ops")) or (
-            b.get("env") is not None and b.get("env") != a.get("env")
-        )
+        retuned = b.get("ops") is not None and b.get("ops") != a.get("ops")
         ii_b, ii_a = b.get("min_ii"), a.get("min_ii")
         if ii_b is not None and ii_a is not None:
             cycles_saved += ii_b - ii_a


### PR DESCRIPTION
Refactors Verilog microcode emission around explicit read/write codebooks, emits ROMs as inferable case logic, and adds inline float sign-conditioning coverage.