### PR TITLE
ci: run full synth matrix on EDA runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - &checkout_step
         uses: actions/checkout@v7
+      - &python_cache_step
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: pip-${{ runner.os }}-
       - run: nox -s tests typecheck black
 
   cosim_examples:
@@ -25,6 +31,7 @@ jobs:
     container: *fpga_toolchain_container
     steps:
       - *checkout_step
+      - *python_cache_step
       - run: nox -s cosim_examples
 
   fuzz:
@@ -33,14 +40,18 @@ jobs:
     container: *fpga_toolchain_container
     steps:
       - *checkout_step
+      - *python_cache_step
       - run: nox -s fuzz
 
   synth:
     name: synth
-    runs-on: ubuntu-latest
-    container: *fpga_toolchain_container
+    runs-on: [self-hosted, ci-runner]
+    container: &mega_toolchain_container
+      image: containers.zubax.com/zubax-fpga-toolchain-mega:latest
+      options: --user root --cap-add NET_ADMIN --shm-size 8g --volume /run/udev:/run/udev:ro
     steps:
       - *checkout_step
+      - *python_cache_step
       - run: nox -s synth
       - if: always()
         uses: actions/upload-artifact@v7
@@ -48,10 +59,11 @@ jobs:
 
   synth_examples:
     name: synth_examples
-    runs-on: ubuntu-latest
-    container: *fpga_toolchain_container
+    runs-on: [self-hosted, ci-runner]
+    container: *mega_toolchain_container
     steps:
       - *checkout_step
+      - *python_cache_step
       - run: nox -s synth_examples
       - if: always()
         uses: actions/upload-artifact@v7

--- a/noxfile.py
+++ b/noxfile.py
@@ -88,7 +88,8 @@ def run_examples(session: nox.Session) -> None:
 def synth(session: nox.Session) -> None:
     """Run external FPGA synthesis/place-and-route checks."""
     session.install("-e", ".[test]")
-    session.run("python", "-m", "pytest", "-s", "synth")
+    workers = max(2, int((os.cpu_count() or 4) * 2 / 3))
+    session.run("python", "-m", "pytest", "-p", "no:enabler", "-s", "-n", str(workers), "synth")
 
 
 @nox.session

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -246,7 +246,11 @@ TARGETS: list[SynthTarget] = [
         "cordic_sincos",
         FlowId.YOSYS_ECP5,
         100,
-        op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_decode=1)),
+        op_config(
+            F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_decode=1),
+            fmul_ilog2=FMulILog2OperatorFamily(F_e6m18, stage_decode=1),
+        ),
     ),
     for_example(
         "cordic_sincos",


### PR DESCRIPTION
## Summary
- run synth and synth_examples on the self-hosted mega EDA runner
- configure the mega container with Docker MAC/license env, privileged networking, and Vivado libudev hardening
- run Diamond through the command-line runner under Xvfb with the licensed MAC initialized
- add a targeted Yosys pipeline stage for the cordic_sincos ECP5 timing row

## Verification
- CI green: https://github.com/Zubax/holoso/actions/runs/28710155905
- synth: passed
- synth_examples: passed
- core, cosim_examples, fuzz: passed