### PR TITLE
Frontend: mandatory and validated type annotations

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -229,6 +229,10 @@ test selects one arm with no branch). A walrus `(name := expr)` is supported onl
 rejected where the binding could be short-circuited (inside `and`/`or`, a chained comparison, a conditional-expression
 arm, or a `while` condition).
 
+An `assert` statement is accepted and ignored wholesale: its test is never lowered, mirroring Python under `-O`, so an
+assertion has no hardware effect (each reached assert is logged). Any effect the test would have had when executed is
+dropped along with it; as under `-O`, an assert must be side-effect-free.
+
 A nested `if` with no `else` on either level folds to a single combined-`and` branch (`if A: if B: S` becomes
 `if A and B: S`), emitting one branch instead of two. This is exact because a boolean test here is a pure combinational
 value; the fold is disabled the moment the outer `if` carries an `else` (then the `and` would mis-route the `else`).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -172,9 +172,10 @@ inlined with the instance context kept, so the callee's own `self.<attr>` reads 
 class MRO; `@staticmethod` and `@property` getters are supported). A called method may read `self` but not write it --
 only the entry method owns the state-slot analysis. Name resolution follows Python.
 
-Parameters. Positional and keyword-only parameters become input ports: `bool`-annotated ones are 1-bit boolean ports,
-unannotated and float-annotated scalars are floating-point ports. An aggregate attribute's shape is read from its reset
-value, optionally validated against an explicit jaxtyping annotation; interior shapes are inferred.
+Parameters. Positional and keyword-only parameters become input ports and require an explicit scalar annotation:
+`float`-annotated scalars are floating-point ports, `bool`-annotated ones are 1-bit boolean ports; an unannotated
+scalar is rejected. An aggregate attribute's shape is read from its reset value, optionally validated against an
+explicit jaxtyping annotation; interior shapes are inferred.
 
 ## HIR
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -177,6 +177,10 @@ Parameters. Positional and keyword-only parameters become input ports and requir
 scalar is rejected. An aggregate attribute's shape is read from its reset value, optionally validated against an
 explicit jaxtyping annotation; interior shapes are inferred.
 
+Return type. The return annotation is likewise mandatory and validated against the inferred output leaves: `float`,
+`bool`, an arbitrarily nested `tuple[...]`/`tuple[X, ...]`/`list[X]` of them, or `None` for a method that returns
+nothing. A missing annotation or any shape, arity, or scalar-type divergence rejects the kernel.
+
 ## HIR
 
 HIR is a real CFG of basic blocks -- entry first, a single `Ret` exit -- carrying an SSA value DAG. Values are input

--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ For a detailed technical review of the design and trade-offs, please refer to `D
 
 Holoso follows Python with minimal deviations where it makes sense for hardware synthesis.
 
-- Static typing only.
+- Static typing only. Parameters must be annotated `float` or `bool`; the return type must be annotated too — a
+  scalar, a `tuple`/`list` of scalars (arbitrarily nested), or `None` for a method that returns nothing — and is
+  validated against the kernel's actual outputs.
 - No implicit type conversions.
 - Boolean short-circuiting is not supported, all operands evaluated eagerly.
 - Floating-point precision depends on the selected floating-point format. See below for more info about floats.

--- a/examples/ekf1_stateless.py
+++ b/examples/ekf1_stateless.py
@@ -9,7 +9,25 @@ from pathlib import Path
 import holoso
 
 
-def update_x_P(P00, P01, P02, P11, P12, P22, Q_R, Q_g, Q_i, R_ct, R_shunt, dt, x_R, x_g, x_i, z_ct, z_shunt):
+def update_x_P(
+    P00: float,
+    P01: float,
+    P02: float,
+    P11: float,
+    P12: float,
+    P22: float,
+    Q_R: float,
+    Q_g: float,
+    Q_i: float,
+    R_ct: float,
+    R_shunt: float,
+    dt: float,
+    x_R: float,
+    x_g: float,
+    x_i: float,
+    z_ct: float,
+    z_shunt: float,
+) -> list[list[float]]:
     """
     All inputs are floating point scalars. The float format to use in the generated RTL code is specified at synthesis.
     The return values are flattened in the row-major order, and each element thereof becomes a separate RTL output port.

--- a/examples/finite_set_current_controller.py
+++ b/examples/finite_set_current_controller.py
@@ -5,6 +5,7 @@ TODO FIXME: Currently unsupported.
 """
 
 from dataclasses import dataclass
+from typing import cast
 import numpy as np
 
 
@@ -100,7 +101,11 @@ class FiniteSetCurrentController:
         norm_squares = np.array([float(vector @ vector) for vector in vectors])
         if not np.allclose(norm_squares, norm_squares[0], rtol=0.0, atol=1e-12):
             raise ValueError(f"Active vectors must have equal norms: {norm_squares}")
-        return tuple(candidates), tuple(vectors), 4.0 * self._BALANCE_WEIGHT * float(norm_squares[0])
+        return (
+            cast(tuple[tuple[bool, bool, bool], ...], tuple(candidates)),
+            tuple(vectors),
+            4.0 * self._BALANCE_WEIGHT * float(norm_squares[0]),
+        )
 
     def _balance_step(self, switch_ac: tuple[bool, bool, bool], /) -> np.ndarray:
         return 2.0 * self._zero_mean(np.array(switch_ac, dtype=float))

--- a/examples/madd.py
+++ b/examples/madd.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import holoso
 
 
-def madd(a, b, c):
+def madd(a: float, b: float, c: float) -> float:
     """``c`` is an unused argument, kept as given to exercise dead-input handling."""
     return (a - b) * 0.25 + a * b * 8
 

--- a/examples/poly3.py
+++ b/examples/poly3.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import holoso
 
 
-def poly3(x, c0, c1, c2, c3):
+def poly3(x: float, c0: float, c1: float, c2: float, c3: float) -> float:
     """
     Degree-3 polynomial evaluated in Horner form: ((c3 * x + c2) * x + c1) * x + c0.
     """

--- a/examples/uart.py
+++ b/examples/uart.py
@@ -67,7 +67,7 @@ class UartTx(_UartFrame):
         self._busy = False
         self._phase = 0  # sub-bit countdown LAST_PHASE..0 within the current frame bit
         self._index = 0  # which frame bit is on the wire: 0 start, 1..8 data, then parity/stop
-        self._shift = 0  # the byte being shifted out, current bit in the MSB
+        self._shift = 0.0  # the byte being shifted out, current bit in the MSB
         self._parity = False  # the polarized parity bit, computed once at latch
 
     @staticmethod
@@ -78,7 +78,7 @@ class UartTx(_UartFrame):
         the original byte LSB first (standard UART order). TODO(integers): a one-instruction bit-reversal with integers.
         """
         rest = char
-        rev = 0
+        rev = 0.0
         for _ in range(8):
             bit = rest >= MSB
             rest = (rest - MSB if bit else rest) * 2
@@ -131,7 +131,7 @@ class UartRx(_UartFrame):
         self._busy = False
         self._count = 0  # ticks remaining until the next mid-bit sample
         self._index = 0  # which bit is being sampled: 0 start, 1..8 data, then parity/stop
-        self._char = 0  # the byte, accumulated bit by bit; only meaningful on the tick ``valid`` is high
+        self._char = 0.0  # the byte, accumulated bit by bit; only meaningful on the tick ``valid`` is high
         self._parity_rx = False  # the parity bit as sampled off the wire (E/O only)
 
     def __call__(self, rx: bool, /) -> tuple[bool, float, bool, bool]:

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -47,5 +47,5 @@ from ._operators import (
     OpConfig as OpConfig,
 )
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __url__ = "https://holoso.digital"

--- a/holoso/_frontend/_lower.py
+++ b/holoso/_frontend/_lower.py
@@ -3,6 +3,7 @@
 import ast
 import builtins
 import inspect
+import logging
 import math
 import types
 from collections.abc import Callable, Iterator
@@ -28,6 +29,8 @@ from ._ast_support import (
 )
 from ._aggregate import Aggregate, Scalar, StateAttr, Value
 from ._scope import ArmResult, Scope, parse_fndef
+
+_logger = logging.getLogger(__name__)
 
 _ABSENT = object()  # sentinel distinguishing a missing global from one explicitly bound to None during name resolution
 _NO_PARAMETER_ANNOTATION = object()
@@ -197,6 +200,14 @@ class _Lowerer:
             case ast.Expr(value=ast.Constant(value=str())):
                 return False  # docstring
             case ast.Pass():
+                return False
+            case ast.Assert():
+                # An assert is ignored wholesale: its test is never lowered. Any side effect it would have had is
+                # dropped, as under -O; that is the author's responsibility.
+                loc = self._loc(stmt)
+                _logger.info(
+                    "Assert statement at %s:%d has no effect in Holoso and is ignored", loc.filename, loc.lineno
+                )
                 return False
             case ast.Assign(targets=targets, value=value):
                 # Lower the right-hand side once and bind it to every target; this covers single, chained, and
@@ -1728,27 +1739,32 @@ class _Lowerer:
         loc = where if isinstance(where, SourceLocation) else self._loc(where)
         raise UnsupportedConstruct(f"expected a scalar value here, got a {len(value.leaves())}-element aggregate", loc)
 
-    def _reject_shortcircuit_walrus(self, fndef: ast.FunctionDef) -> None:
+    def _reject_shortcircuit_walrus(self, node: ast.AST) -> None:
         """
         Reject a walrus inside an ``and``/``or`` operand or a chained comparison. Such an operand may be short-circuited
         -- statically dropped by the connective fold, or unevaluated in Python -- so whether its binding happens cannot
         be reconciled between the reachability scans (which see the syntactic walrus) and lowering (which may never
         evaluate it). A walrus is supported only where it is evaluated unconditionally: a single comparison or bare
-        test, an assignment/return value, an ``and``/``or``-free ``if``/``while`` test.
+        test, an assignment/return value, an ``and``/``or``-free ``if``/``while`` test. An ``assert`` is skipped -- it
+        is ignored (its test never lowered), so a short-circuited walrus within it is irrelevant here; its target still
+        counts as a function local (see ``scope_local_walrus_targets``), so a later use is a clean unbound-local error.
         """
-        for node in ast.walk(fndef):
-            operands: list[ast.expr] = []
-            if isinstance(node, ast.BoolOp):
-                operands = node.values
-            elif isinstance(node, ast.Compare) and len(node.ops) > 1:
-                operands = [node.left, *node.comparators]
-            for operand in operands:
-                if contains_walrus(operand):
-                    raise UnsupportedConstruct(
-                        "a walrus ':=' inside an 'and'/'or' or a chained comparison is not supported "
-                        "(its operand may be short-circuited)",
-                        self._loc(operand),
-                    )
+        if isinstance(node, ast.Assert):
+            return
+        operands: list[ast.expr] = []
+        if isinstance(node, ast.BoolOp):
+            operands = node.values
+        elif isinstance(node, ast.Compare) and len(node.ops) > 1:
+            operands = [node.left, *node.comparators]
+        for operand in operands:
+            if contains_walrus(operand):
+                raise UnsupportedConstruct(
+                    "a walrus ':=' inside an 'and'/'or' or a chained comparison is not supported "
+                    "(its operand may be short-circuited)",
+                    self._loc(operand),
+                )
+        for child in ast.iter_child_nodes(node):
+            self._reject_shortcircuit_walrus(child)
 
     def _collect_local_names(self, fndef: ast.FunctionDef) -> set[str]:
         """

--- a/holoso/_frontend/_lower.py
+++ b/holoso/_frontend/_lower.py
@@ -173,7 +173,11 @@ class _Lowerer:
 
     def _input(self, arg: ast.arg) -> ValueId:
         annotation = self._fn.__annotations__.get(arg.arg, _NO_PARAMETER_ANNOTATION)
-        if annotation is _NO_PARAMETER_ANNOTATION or annotation is float:
+        if annotation is _NO_PARAMETER_ANNOTATION:
+            raise UnsupportedConstruct(
+                f"parameter {arg.arg!r} requires an explicit type annotation (float or bool)", self._loc(arg)
+            )
+        if annotation is float:
             return self._builder.float_input(arg.arg)
         if annotation is bool:
             return self._builder.bool_input(arg.arg)

--- a/holoso/_frontend/_lower.py
+++ b/holoso/_frontend/_lower.py
@@ -7,7 +7,7 @@ import logging
 import math
 import types
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import Any, get_args, get_origin
 
 import numpy as np
 
@@ -33,7 +33,35 @@ from ._scope import ArmResult, Scope, parse_fndef
 _logger = logging.getLogger(__name__)
 
 _ABSENT = object()  # sentinel distinguishing a missing global from one explicitly bound to None during name resolution
-_NO_PARAMETER_ANNOTATION = object()
+
+
+def _scalar_annotation_type(annotation: object) -> Type | None:
+    if annotation is float:
+        return FloatType()
+    if annotation is bool:
+        return BoolType()
+    return None
+
+
+def _aggregate_element_annotations(annotation: object, count: int) -> list[object] | None:
+    """The per-leaf annotations of a tuple/list return annotation, or None if it is not an aggregate annotation."""
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is list:
+        return [args[0]] * count if len(args) == 1 else None
+    if origin is tuple:
+        if len(args) == 2 and args[1] is Ellipsis:
+            return [args[0]] * count
+        return list(args)
+    return None
+
+
+def _annotation_name(annotation: object) -> str:
+    return annotation.__name__ if isinstance(annotation, type) else str(annotation)
+
+
+def _hir_type_name(scalar_type: Type) -> str:
+    return "bool" if isinstance(scalar_type, BoolType) else "float"
 
 
 # numpy array constructors that take one array-like and preserve its elements: in this compile-time model the operand is
@@ -146,6 +174,7 @@ class _Lowerer:
         self._builder.block()  # the entry block (id 0); subsequent blocks are created by branch lowering
         self._bind_parameters(self._entry_fndef)
         self._lower_body(self._entry_fndef)
+        self._check_return_annotation(self._entry_fndef)
         self._register_state_slots()
         self._emit_outputs()
         self._builder.ret()  # seal the current (function-exit) block; the frontend emits a single Ret
@@ -172,24 +201,74 @@ class _Lowerer:
             self._env[arg.arg] = Scalar(self._input(arg))
 
     def _input(self, arg: ast.arg) -> ValueId:
-        annotation = self._fn.__annotations__.get(arg.arg, _NO_PARAMETER_ANNOTATION)
-        if annotation is _NO_PARAMETER_ANNOTATION:
+        annotations = self._fn.__annotations__
+        if arg.arg not in annotations:
             raise UnsupportedConstruct(
                 f"parameter {arg.arg!r} requires an explicit type annotation (float or bool)", self._loc(arg)
             )
-        if annotation is float:
-            return self._builder.float_input(arg.arg)
-        if annotation is bool:
-            return self._builder.bool_input(arg.arg)
-        raise UnsupportedConstruct(
-            f"unsupported parameter annotation for {arg.arg!r}: expected float or bool", self._loc(arg)
-        )
+        scalar_type = _scalar_annotation_type(annotations[arg.arg])
+        if scalar_type is None:
+            raise UnsupportedConstruct(
+                f"unsupported parameter annotation for {arg.arg!r}: expected float or bool", self._loc(arg)
+            )
+        return self._builder.input(arg.arg, scalar_type)
 
     def _lower_body(self, fndef: ast.FunctionDef) -> None:
         returned = self._lower_stmts(fndef.body)
         # A stateful method need not return: its public state attributes are observable through their own ports.
         if not returned and self._instance is None:
             raise UnsupportedConstruct("function must end in a 'return'", self._loc(fndef))
+
+    def _check_return_annotation(self, fndef: ast.FunctionDef) -> None:
+        annotations = self._fn.__annotations__
+        loc = self._loc(fndef.returns if fndef.returns is not None else fndef)
+        if "return" not in annotations:
+            raise UnsupportedConstruct("the return type must be explicitly annotated", loc)
+        declared = annotations["return"]
+        if self._return is None:
+            if declared is not None:
+                raise UnsupportedConstruct(
+                    f"declared return type {_annotation_name(declared)} but the function returns no value", loc
+                )
+            return
+        if declared is None:
+            raise UnsupportedConstruct("declared return type None but a value is returned", loc)
+        self._check_return_shape(self._return, declared, loc)
+
+    def _check_return_shape(self, value: Value, declared: object, loc: SourceLocation) -> None:
+        match value:
+            case Scalar(id=vid):
+                expected = _scalar_annotation_type(declared)
+                if expected is None:
+                    if get_origin(declared) in (tuple, list):
+                        raise UnsupportedConstruct(
+                            f"declared return type {_annotation_name(declared)} but a single value is returned", loc
+                        )
+                    raise UnsupportedConstruct(
+                        f"unsupported return annotation {_annotation_name(declared)}: "
+                        "expected float, bool, a tuple or list of them, or None",
+                        loc,
+                    )
+                actual = self._builder.type_of(vid)
+                if actual != expected:
+                    raise UnsupportedConstruct(
+                        f"return type mismatch: declared {_annotation_name(declared)}, "
+                        f"inferred {_hir_type_name(actual)}",
+                        loc,
+                    )
+            case Aggregate(items=items):
+                elements = _aggregate_element_annotations(declared, len(items))
+                if elements is None:
+                    quantity = "value is" if len(items) == 1 else "values are"
+                    raise UnsupportedConstruct(
+                        f"declared return type {_annotation_name(declared)} but {len(items)} {quantity} returned", loc
+                    )
+                if len(elements) != len(items):
+                    raise UnsupportedConstruct(
+                        f"return arity mismatch: declared {len(elements)}, inferred {len(items)}", loc
+                    )
+                for item, element in zip(items, elements):
+                    self._check_return_shape(item, element, loc)
 
     def _lower_stmts(self, stmts: list[ast.stmt]) -> bool:
         """Lower a straight-line statement list, returning True when a ``return`` was reached."""
@@ -249,7 +328,7 @@ class _Lowerer:
                 return self._lower_while(test, body, self._loc(stmt))
             case ast.While():
                 raise UnsupportedConstruct("a 'while' loop with an else clause is not supported", self._loc(stmt))
-            case ast.Return(value=None):
+            case ast.Return(value=None | ast.Constant(value=None)):
                 self._reject_nested_return(stmt)
                 return True
             case ast.Return(value=ast.expr() as value):

--- a/holoso/_hir/_ir.py
+++ b/holoso/_hir/_ir.py
@@ -302,12 +302,6 @@ class HirBuilder:
         self._input_ids.append(vid)
         return vid
 
-    def float_input(self, name: str) -> ValueId:
-        return self.input(name, FloatType())
-
-    def bool_input(self, name: str) -> ValueId:
-        return self.input(name, BoolType())
-
     def state_read(self, slot: str, type: Type) -> ValueId:
         # Interned globally: repeated live-in reads of a slot share one value, resident from the initiation start.
         return self._global(StateRead(slot, type))

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,7 +93,7 @@ def synth(session: nox.Session) -> None:
 
 @nox.session
 def typecheck(session: nox.Session) -> None:
-    session.install("-e", ".", "mypy~=2.1")
+    session.install("-e", ".[test]", "mypy~=2.1")
     session.run("mypy", *session.posargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,8 @@ target-version = ["py312"]
 [tool.mypy]
 python_version = "3.14"
 strict = true
-files = ["holoso"]
+files = ["holoso", "tests", "examples", "synth", "tools"]
 
 [[tool.mypy.overrides]]
-module = ["scipy.*"]
+module = ["scipy.*", "cocotb.*", "cocotb_tools.*"]
 ignore_missing_imports = true

--- a/tests/_examples.py
+++ b/tests/_examples.py
@@ -24,21 +24,21 @@ from ._modelref import (
 )
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
-import ekf1_stateful  # noqa: E402
-import ekf1_stateless  # noqa: E402
+import ekf1_stateful as ekf1_stateful  # noqa: E402
+import ekf1_stateless as ekf1_stateless  # noqa: E402
 import madd  # noqa: E402
 import poly3  # noqa: E402
-from cordic_sincos import CordicSinCos  # noqa: E402
-from iir1_lpf import IIR1LPF  # noqa: E402
+from cordic_sincos import CordicSinCos as CordicSinCos  # noqa: E402
+from iir1_lpf import IIR1LPF as IIR1LPF  # noqa: E402
 from latching_fault_register import LatchingFaultRegister  # noqa: E402
 from majority_voter import MajorityVoter  # noqa: E402
 from octave_index import octave_index  # noqa: E402
-from pid import PID  # noqa: E402
-from phase_frequency_detector import PhaseFrequencyDetector  # noqa: E402
+from pid import PID as PID  # noqa: E402
+from phase_frequency_detector import PhaseFrequencyDetector as PhaseFrequencyDetector  # noqa: E402
 from quadrature_encoder import QuadratureEncoder  # noqa: E402
 from recip_newton import NewtonReciprocal  # noqa: E402
-from remainder import remainder  # noqa: E402
-from schmitt_trigger import SchmittTrigger  # noqa: E402
+from remainder import remainder as remainder  # noqa: E402
+from schmitt_trigger import SchmittTrigger as SchmittTrigger  # noqa: E402
 from signal_window import signal_window  # noqa: E402
 from trapezoidal_leaky_streaming_integrator import TrapezoidalLeakyStreamingIntegrator  # noqa: E402
 from uart import OVERSAMPLE, UartRx, UartTx  # noqa: E402

--- a/tests/_fuzz.py
+++ b/tests/_fuzz.py
@@ -212,6 +212,7 @@ class _Emitter:
         self._counter = 0
         self._lines: list[tuple[int, str]] = []
         self.return_line = ""  # set by the assembly step before rendering
+        self.return_annotation = "float"  # a multi-lane return overrides this to a tuple[...]
 
     def then_value(self) -> _Fragment:
         if self.chance(0.4):
@@ -758,7 +759,7 @@ def _finish_function_kernel(
     mode: Mode,
     dead_arm_chain_depth: int | None = None,
 ) -> GeneratedKernel:
-    source = _assemble_function(name, params, bool_set, em.render_body(), em.return_line)
+    source = _assemble_function(name, params, bool_set, em.render_body(), em.return_line, em.return_annotation)
     module = _render_module(name, source)
     return GeneratedKernel(
         name=name,
@@ -870,18 +871,21 @@ def _emit_return(em: _Emitter, produced: list[_Fragment]) -> Mode:
         em.return_line = f"return {live[0]}"
         return Mode.EXACT
     elif em.chance(0.5):
-        lanes = ", ".join(live[:3])
-        em.return_line = f"return ({lanes},)"
+        lanes = live[:3]
+        em.return_line = f"return ({', '.join(lanes)},)"
+        em.return_annotation = f"tuple[{', '.join('float' for _ in lanes)}]"
         return Mode.EXACT
     else:
         em.return_line = f"return {' + '.join(live)}"
         return Mode.CONTINUOUS
 
 
-def _assemble_function(name: str, params: list[str], bool_set: set[str], body: str, return_line: str) -> str:
+def _assemble_function(
+    name: str, params: list[str], bool_set: set[str], body: str, return_line: str, return_annotation: str
+) -> str:
     sig = ", ".join(f"{p}: bool" if p in bool_set else f"{p}: float" for p in params)
     docstring = '    """A generated fuzz kernel."""'
-    return f"def {name}({sig}):\n{docstring}\n{body}\n    {return_line}\n"
+    return f"def {name}({sig}) -> {return_annotation}:\n{docstring}\n{body}\n    {return_line}\n"
 
 
 def generate_stateful_kernel(
@@ -960,7 +964,7 @@ def _assemble_class(
         f'    """A generated stateful fuzz kernel with private chained slots."""\n\n'
         f"    def __init__(self):\n"
         f"{init_lines}\n\n"
-        f"    def __call__(self, {sig}):\n"
+        f"    def __call__(self, {sig}) -> float:\n"
         f"{body}\n"
         f"        {return_line}\n"
     )

--- a/tests/_fuzz.py
+++ b/tests/_fuzz.py
@@ -879,7 +879,7 @@ def _emit_return(em: _Emitter, produced: list[_Fragment]) -> Mode:
 
 
 def _assemble_function(name: str, params: list[str], bool_set: set[str], body: str, return_line: str) -> str:
-    sig = ", ".join(f"{p}: bool" if p in bool_set else p for p in params)
+    sig = ", ".join(f"{p}: bool" if p in bool_set else f"{p}: float" for p in params)
     docstring = '    """A generated fuzz kernel."""'
     return f"def {name}({sig}):\n{docstring}\n{body}\n    {return_line}\n"
 
@@ -954,7 +954,7 @@ def _assemble_class(
     name: str, inputs: list[str], slots: list[str], resets: list[float], body: str, return_line: str
 ) -> str:
     init_lines = "\n".join(f"        self.{slot} = {reset!r}" for slot, reset in zip(slots, resets))
-    sig = ", ".join(inputs)
+    sig = ", ".join(f"{p}: float" for p in inputs)
     return (
         f"class {name}:\n"
         f'    """A generated stateful fuzz kernel with private chained slots."""\n\n'

--- a/tests/_fuzz.py
+++ b/tests/_fuzz.py
@@ -35,7 +35,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -792,7 +792,7 @@ def generate_stateless_kernel(
     produced: list[_Fragment] = []
     n_fragments = int(rng.integers(1, 4))
     for _ in range(n_fragments):
-        template = rng.choice(_STATELESS_TEMPLATES)  # type: ignore[arg-type]
+        template = cast(Callable[[_Emitter], _Fragment], rng.choice(_STATELESS_TEMPLATES))  # type: ignore[arg-type]
         produced.append(template(em))
 
     # Combining the produced fragments keeps every one LIVE so DCE cannot drop the diamonds/divisions feeding output.

--- a/tests/_modelref.py
+++ b/tests/_modelref.py
@@ -185,7 +185,7 @@ def fcmp_s1_ops(fmt: FloatFormat) -> OpConfig:
     return fcmp_staged_ops(fmt, 1)
 
 
-def branch_boundary_kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+def branch_boundary_kernel(a: float, b: float, c: float) -> float:
     """
     The boundary-slack corner kernel shared by the cosim test and its white-box schedule twin: the comparison is the
     LAST commit in its block and feeds the branch, so its result lands in the condition register exactly one step
@@ -201,7 +201,7 @@ def branch_boundary_kernel(a: float, b: float, c: float):  # type: ignore[no-unt
     return y
 
 
-def overlap_spill_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
+def overlap_spill_kernel(x: float, y: float, z: float) -> float:
     """
     Cross-block software-pipelining corner shared by the cosim test and its white-box twin. The branch CONDITION
     (``x < y``) depends only on inputs, so it commits early; a wide chain (``w``) computed in the same block commits
@@ -218,7 +218,7 @@ def overlap_spill_kernel(x: float, y: float, z: float):  # type: ignore[no-untyp
     return r
 
 
-def overlap_dead_arm_spill_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
+def overlap_dead_arm_spill_kernel(x: float, y: float, z: float) -> float:
     """
     Cross-block overlap SOUNDNESS corner: a value live ONLY in one arm shares no register hazard with a value the
     sibling arm spills onto it. ``v`` is computed in the entry block and used only in the else arm; the wide chain
@@ -238,7 +238,7 @@ def overlap_dead_arm_spill_kernel(x: float, y: float, z: float):  # type: ignore
     return r
 
 
-def const_branch_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
+def const_branch_kernel(x: float, y: float) -> float:
     """
     Empty const-branch block corner shared by the cosim test and its white-box twin. The inner condition ``1.0 / 5.0 >
     0.0`` is constant-true but formed by DIVISION, which escapes the frontend's AST-level reachability fold (it
@@ -256,7 +256,7 @@ def const_branch_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
     return r
 
 
-def diamond_then_loop_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
+def diamond_then_loop_kernel(x: float, y: float) -> float:
     """
     Empty merge-block elimination (B4) corner shared by the cosim test and its white-box twin. The variable-divisor
     division keeps the diamond a REAL branch (unspeculatable), so its merge stays a separate block; that merge holds
@@ -274,7 +274,7 @@ def diamond_then_loop_kernel(x: float, y: float):  # type: ignore[no-untyped-def
     return r
 
 
-def overlap_div_err_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
+def overlap_div_err_kernel(x: float, y: float, z: float) -> float:
     """
     Cross-block overlap err_pc corner (shared by the white-box twin and the directed err_pc cosim). A division -- the
     one error-bearing op -- commits late, so its result spills past the shrunk terminator. The data write lands in the
@@ -331,7 +331,7 @@ class ChainedSlots:
         self._a = 0.0
         self._b = 0.0
 
-    def __call__(self, x: float):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float) -> float:
         self._a = self._b
         self._b = x + 1.0
         return self._a * 2.0 + (x * 1.5) / (x - 0.5)
@@ -346,14 +346,14 @@ class SelectHold:
     def __init__(self) -> None:
         self._h = 1.0
 
-    def step(self, x: float, c: float):  # type: ignore[no-untyped-def]
+    def step(self, x: float, c: float) -> float:
         old = self._h
         self._h = x + 1.0
         y = old if c > 0.0 else x
         return y * 2.0 + (x * 1.5) / (x * x + 0.5)  # structurally nonzero divisor (the bench asserts err_pc == 0)
 
 
-def phi_swap_loop(x: float, n: float):  # type: ignore[no-untyped-def]
+def phi_swap_loop(x: float, n: float) -> float:
     """
     A while loop whose two carried values genuinely SWAP across the back edge (``a, b = b, a``), producing two
     loop-header phis whose back-edge arms cross-reference each other (phi_a's arm is phi_b and vice versa). The header
@@ -374,7 +374,7 @@ def phi_swap_loop(x: float, n: float):  # type: ignore[no-untyped-def]
     return a * 2.0 + b
 
 
-def overlap_drained_passthrough_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
+def overlap_drained_passthrough_kernel(x: float, y: float, z: float) -> float:
     """
     A wide chain ``w`` computed in the overlapping entry block spills past the shrunk terminator into a then arm that
     does NO work and merely passes ``w`` through as the merged value, so ``w`` is the live-out of a fully-DRAINED,
@@ -393,7 +393,7 @@ def overlap_drained_passthrough_kernel(x: float, y: float, z: float):  # type: i
     return r * 2.0
 
 
-def overlap_livein_branch_arm_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
+def overlap_livein_branch_arm_kernel(x: float, y: float, z: float) -> float:
     """
     The wide chain ``w`` spills from the overlapping entry into an arm that ITSELF branches on a LIVE-IN condition ``c``
     (computed in the entry block, not the arm) -- exercising the overlap interaction the plain dead-arm shape never
@@ -425,7 +425,7 @@ class SlotSwap:
         self._a = 1.0
         self._b = -2.0
 
-    def step(self, x: float):  # type: ignore[no-untyped-def]
+    def step(self, x: float) -> float:
         old_a = self._a
         old_b = self._b
         self._a = old_b  # swap: a <- old b

--- a/tests/_modelref.py
+++ b/tests/_modelref.py
@@ -185,7 +185,7 @@ def fcmp_s1_ops(fmt: FloatFormat) -> OpConfig:
     return fcmp_staged_ops(fmt, 1)
 
 
-def branch_boundary_kernel(a, b, c):  # type: ignore[no-untyped-def]
+def branch_boundary_kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
     """
     The boundary-slack corner kernel shared by the cosim test and its white-box schedule twin: the comparison is the
     LAST commit in its block and feeds the branch, so its result lands in the condition register exactly one step
@@ -201,7 +201,7 @@ def branch_boundary_kernel(a, b, c):  # type: ignore[no-untyped-def]
     return y
 
 
-def overlap_spill_kernel(x, y, z):  # type: ignore[no-untyped-def]
+def overlap_spill_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
     """
     Cross-block software-pipelining corner shared by the cosim test and its white-box twin. The branch CONDITION
     (``x < y``) depends only on inputs, so it commits early; a wide chain (``w``) computed in the same block commits
@@ -218,7 +218,7 @@ def overlap_spill_kernel(x, y, z):  # type: ignore[no-untyped-def]
     return r
 
 
-def overlap_dead_arm_spill_kernel(x, y, z):  # type: ignore[no-untyped-def]
+def overlap_dead_arm_spill_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
     """
     Cross-block overlap SOUNDNESS corner: a value live ONLY in one arm shares no register hazard with a value the
     sibling arm spills onto it. ``v`` is computed in the entry block and used only in the else arm; the wide chain
@@ -238,7 +238,7 @@ def overlap_dead_arm_spill_kernel(x, y, z):  # type: ignore[no-untyped-def]
     return r
 
 
-def const_branch_kernel(x, y):  # type: ignore[no-untyped-def]
+def const_branch_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
     """
     Empty const-branch block corner shared by the cosim test and its white-box twin. The inner condition ``1.0 / 5.0 >
     0.0`` is constant-true but formed by DIVISION, which escapes the frontend's AST-level reachability fold (it
@@ -256,7 +256,7 @@ def const_branch_kernel(x, y):  # type: ignore[no-untyped-def]
     return r
 
 
-def diamond_then_loop_kernel(x, y):  # type: ignore[no-untyped-def]
+def diamond_then_loop_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
     """
     Empty merge-block elimination (B4) corner shared by the cosim test and its white-box twin. The variable-divisor
     division keeps the diamond a REAL branch (unspeculatable), so its merge stays a separate block; that merge holds
@@ -274,7 +274,7 @@ def diamond_then_loop_kernel(x, y):  # type: ignore[no-untyped-def]
     return r
 
 
-def overlap_div_err_kernel(x, y, z):  # type: ignore[no-untyped-def]
+def overlap_div_err_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
     """
     Cross-block overlap err_pc corner (shared by the white-box twin and the directed err_pc cosim). A division -- the
     one error-bearing op -- commits late, so its result spills past the shrunk terminator. The data write lands in the
@@ -331,7 +331,7 @@ class ChainedSlots:
         self._a = 0.0
         self._b = 0.0
 
-    def __call__(self, x):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float):  # type: ignore[no-untyped-def]
         self._a = self._b
         self._b = x + 1.0
         return self._a * 2.0 + (x * 1.5) / (x - 0.5)
@@ -346,14 +346,14 @@ class SelectHold:
     def __init__(self) -> None:
         self._h = 1.0
 
-    def step(self, x, c):  # type: ignore[no-untyped-def]
+    def step(self, x: float, c: float):  # type: ignore[no-untyped-def]
         old = self._h
         self._h = x + 1.0
         y = old if c > 0.0 else x
         return y * 2.0 + (x * 1.5) / (x * x + 0.5)  # structurally nonzero divisor (the bench asserts err_pc == 0)
 
 
-def phi_swap_loop(x, n):  # type: ignore[no-untyped-def]
+def phi_swap_loop(x: float, n: float):  # type: ignore[no-untyped-def]
     """
     A while loop whose two carried values genuinely SWAP across the back edge (``a, b = b, a``), producing two
     loop-header phis whose back-edge arms cross-reference each other (phi_a's arm is phi_b and vice versa). The header
@@ -374,7 +374,7 @@ def phi_swap_loop(x, n):  # type: ignore[no-untyped-def]
     return a * 2.0 + b
 
 
-def overlap_drained_passthrough_kernel(x, y, z):  # type: ignore[no-untyped-def]
+def overlap_drained_passthrough_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
     """
     A wide chain ``w`` computed in the overlapping entry block spills past the shrunk terminator into a then arm that
     does NO work and merely passes ``w`` through as the merged value, so ``w`` is the live-out of a fully-DRAINED,
@@ -393,7 +393,7 @@ def overlap_drained_passthrough_kernel(x, y, z):  # type: ignore[no-untyped-def]
     return r * 2.0
 
 
-def overlap_livein_branch_arm_kernel(x, y, z):  # type: ignore[no-untyped-def]
+def overlap_livein_branch_arm_kernel(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
     """
     The wide chain ``w`` spills from the overlapping entry into an arm that ITSELF branches on a LIVE-IN condition ``c``
     (computed in the entry block, not the arm) -- exercising the overlap interaction the plain dead-arm shape never
@@ -425,7 +425,7 @@ class SlotSwap:
         self._a = 1.0
         self._b = -2.0
 
-    def step(self, x):  # type: ignore[no-untyped-def]
+    def step(self, x: float):  # type: ignore[no-untyped-def]
         old_a = self._a
         old_b = self._b
         self._a = old_b  # swap: a <- old b

--- a/tests/hdl/gate_edge_bench.py
+++ b/tests/hdl/gate_edge_bench.py
@@ -17,7 +17,7 @@ from cocotb.triggers import FallingEdge, RisingEdge
 
 
 @cocotb.test()
-async def transacting_edge(dut) -> None:  # type: ignore[no-untyped-def]
+async def transacting_edge(dut: object) -> None:
     fetch_lag = int(os.environ["HOLOSO_FETCH_LAG"])
     k = int(os.environ["HOLOSO_DWELL_K"])
 
@@ -55,7 +55,7 @@ async def transacting_edge(dut) -> None:  # type: ignore[no-untyped-def]
 
 
 @cocotb.test()
-async def state_inert_during_dwell(dut) -> None:  # type: ignore[no-untyped-def]
+async def state_inert_during_dwell(dut: object) -> None:
     # A cycle-0 constant install to a persistent-state slot sits on ``ucode[0]``. While the PC dwells idle at pc 0 the
     # held word re-fetches every cycle, so without the ``transacting`` gate on the install write-enable it would commit
     # to the state register before any transaction. Assert the slot keeps its reset value across the whole idle dwell.

--- a/tests/hdl/gate_edge_bench.py
+++ b/tests/hdl/gate_edge_bench.py
@@ -10,6 +10,7 @@ from the environment so the test can sweep k and stay valid as fetch_lag is conf
 """
 
 import os
+from typing import Any
 
 import cocotb
 from cocotb.clock import Clock
@@ -17,7 +18,7 @@ from cocotb.triggers import FallingEdge, RisingEdge
 
 
 @cocotb.test()
-async def transacting_edge(dut: object) -> None:
+async def transacting_edge(dut: Any) -> None:
     fetch_lag = int(os.environ["HOLOSO_FETCH_LAG"])
     k = int(os.environ["HOLOSO_DWELL_K"])
 
@@ -55,7 +56,7 @@ async def transacting_edge(dut: object) -> None:
 
 
 @cocotb.test()
-async def state_inert_during_dwell(dut: object) -> None:
+async def state_inert_during_dwell(dut: Any) -> None:
     # A cycle-0 constant install to a persistent-state slot sits on ``ucode[0]``. While the PC dwells idle at pc 0 the
     # held word re-fetches every cycle, so without the ``transacting`` gate on the install write-enable it would commit
     # to the state register before any transaction. Assert the slot keeps its reset value across the whole idle dwell.

--- a/tests/hdl/hdl_float_oracle.py
+++ b/tests/hdl/hdl_float_oracle.py
@@ -120,7 +120,7 @@ def bits_to_f32(bits: int) -> np.float32:
     return np.uint32(bits & 0xFFFFFFFF).view(np.float32)
 
 
-def f32_to_bits(x) -> int:
+def f32_to_bits(x: float) -> int:
     return int(np.float32(x).view(np.uint32))
 
 

--- a/tests/hdl/hdl_float_oracle.py
+++ b/tests/hdl/hdl_float_oracle.py
@@ -15,7 +15,7 @@ import os
 import tempfile
 from collections import deque
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 import cocotb
 import holoso
@@ -120,7 +120,7 @@ def bits_to_f32(bits: int) -> np.float32:
     return np.uint32(bits & 0xFFFFFFFF).view(np.float32)
 
 
-def f32_to_bits(x: float) -> int:
+def f32_to_bits(x: float | np.floating[Any]) -> int:
     return int(np.float32(x).view(np.uint32))
 
 
@@ -320,12 +320,12 @@ def get_random_count(default: int = 256) -> int:
     return int(os.environ.get("HOLOSO_TEST_RANDOM_COUNT", str(default)))
 
 
-async def start_clock(dut, period_ns: int = 10) -> None:
+async def start_clock(dut: Any, period_ns: int = 10) -> None:
     cocotb.start_soon(Clock(dut.clk, period_ns, unit="ns").start())
     await FallingEdge(dut.clk)
 
 
-async def drive_reset(dut, cycles: int = 4) -> None:
+async def drive_reset(dut: Any, cycles: int = 4) -> None:
     dut.rst.value = 1
     if hasattr(dut, "in_valid"):
         dut.in_valid.value = 0
@@ -346,14 +346,14 @@ class PipelineScoreboard:
     exactly that many sampled rising edges after the corresponding push.
     """
 
-    def __init__(self, dut, payload_fields: Iterable[tuple[str, str]], latency: int | None = None):
+    def __init__(self, dut: Any, payload_fields: Iterable[tuple[str, str]], latency: int | None = None):
         self.dut = dut
         self.payload_fields = tuple(payload_fields)
-        self.queue: deque = deque()
+        self.queue: deque[dict[str, Any]] = deque()
         self.latency = latency
         self.cycle = 0
 
-    def push(self, expected: dict) -> None:
+    def push(self, expected: dict[str, Any]) -> None:
         if self.latency is not None:
             expected["_due_cycle"] = self.cycle + self.latency
         self.queue.append(expected)

--- a/tests/hdl/test_err_pc.py
+++ b/tests/hdl/test_err_pc.py
@@ -46,17 +46,17 @@ def _ops(stage_output: int) -> OpConfig:
     )
 
 
-def _divide(a: float, b: float):  # type: ignore[no-untyped-def]
+def _divide(a: float, b: float) -> float:
     return a / b
 
 
-async def _settle(dut) -> None:  # type: ignore[no-untyped-def]
+async def _settle(dut: object) -> None:
     await RisingEdge(dut.clk)
     await Timer(1, unit="ns")
 
 
 @cocotb.test()
-async def err_pc_latches_div0(dut) -> None:
+async def err_pc_latches_div0(dut: object) -> None:
     err_step = int(json.loads(os.environ["HOLOSO_ERRCYC"])["err_step"])
     a_bits = FMT.encode(1.0)
 

--- a/tests/hdl/test_err_pc.py
+++ b/tests/hdl/test_err_pc.py
@@ -10,6 +10,7 @@ to latch/land together whether or not an output register stage delays the commit
 
 import json
 import os
+from typing import Any
 
 import cocotb
 import pytest
@@ -50,13 +51,13 @@ def _divide(a: float, b: float) -> float:
     return a / b
 
 
-async def _settle(dut: object) -> None:
+async def _settle(dut: Any) -> None:
     await RisingEdge(dut.clk)
     await Timer(1, unit="ns")
 
 
 @cocotb.test()
-async def err_pc_latches_div0(dut: object) -> None:
+async def err_pc_latches_div0(dut: Any) -> None:
     err_step = int(json.loads(os.environ["HOLOSO_ERRCYC"])["err_step"])
     a_bits = FMT.encode(1.0)
 

--- a/tests/hdl/test_err_pc.py
+++ b/tests/hdl/test_err_pc.py
@@ -46,7 +46,7 @@ def _ops(stage_output: int) -> OpConfig:
     )
 
 
-def _divide(a, b):  # type: ignore[no-untyped-def]
+def _divide(a: float, b: float):  # type: ignore[no-untyped-def]
     return a / b
 
 

--- a/tests/hdl/test_fadd.py
+++ b/tests/hdl/test_fadd.py
@@ -6,6 +6,7 @@ every input cycle.
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -35,7 +36,7 @@ from .hdl_float_oracle import (
 
 
 @cocotb.test()
-async def holoso_fadd_cocotb(dut) -> None:
+async def holoso_fadd_cocotb(dut: Any) -> None:
     await start_clock(dut)
     await drive_reset(dut)
 

--- a/tests/hdl/test_fcmp.py
+++ b/tests/hdl/test_fcmp.py
@@ -6,6 +6,7 @@ sgnop change is needed; a_sgnop and b_sgnop can vary every cycle.
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -33,7 +34,7 @@ from .hdl_float_oracle import (
 
 
 @cocotb.test()
-async def holoso_fcmp_cocotb(dut) -> None:
+async def holoso_fcmp_cocotb(dut: Any) -> None:
     await start_clock(dut)
     await drive_reset(dut)
 

--- a/tests/hdl/test_fdiv.py
+++ b/tests/hdl/test_fdiv.py
@@ -7,6 +7,7 @@ checks that div0 itself is correct. The wrapper delays y_sgnop through the same 
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -44,7 +45,7 @@ def _exp_is_zero(bits: int) -> bool:
 
 
 @cocotb.test()
-async def holoso_fdiv_cocotb(dut) -> None:
+async def holoso_fdiv_cocotb(dut: Any) -> None:
     await start_clock(dut)
     await drive_reset(dut)
 
@@ -62,7 +63,7 @@ async def holoso_fdiv_cocotb(dut) -> None:
         b_eff = apply_sgnop(b, b_op)
         b_eff_is_zero = _exp_is_zero(b_eff)
 
-        expected: dict = {"_desc": f"a=0x{a:08x} b=0x{b:08x} ops={a_op}{b_op}{y_op}"}
+        expected: dict[str, Any] = {"_desc": f"a=0x{a:08x} b=0x{b:08x} ops={a_op}{b_op}{y_op}"}
         if b_eff_is_zero:
             # div0 asserts; y is unspecified -- only check div0.
             expected["div0"] = 1

--- a/tests/hdl/test_ffma.py
+++ b/tests/hdl/test_ffma.py
@@ -8,6 +8,7 @@ multiply-then-add would double-round differently).
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -56,7 +57,7 @@ _CANCELLATION = (
 
 
 @cocotb.test()
-async def holoso_ffma_cocotb(dut) -> None:
+async def holoso_ffma_cocotb(dut: Any) -> None:
     await start_clock(dut)
     await drive_reset(dut)
 

--- a/tests/hdl/test_fisfinite.py
+++ b/tests/hdl/test_fisfinite.py
@@ -1,6 +1,8 @@
 """Tests for holoso_fisfinite (combinational; y=1 iff exponent != all-ones)."""
 
 from pathlib import Path
+from typing import Any
+
 import cocotb
 import numpy as np
 import pytest
@@ -22,7 +24,7 @@ from .hdl_float_oracle import (
 
 
 @cocotb.test()
-async def holoso_fisfinite_cocotb(dut) -> None:
+async def holoso_fisfinite_cocotb(dut: Any) -> None:
     async def check(x_bits: int) -> None:
         dut.x.value = x_bits
         await Timer(1, unit="ns")

--- a/tests/hdl/test_fmul.py
+++ b/tests/hdl/test_fmul.py
@@ -6,6 +6,7 @@ every input cycle.
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -38,7 +39,7 @@ STAGE_COMBOS = ((0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 1))
 
 
 @cocotb.test()
-async def holoso_fmul_cocotb(dut) -> None:
+async def holoso_fmul_cocotb(dut: Any) -> None:
     await start_clock(dut)
     await drive_reset(dut)
 

--- a/tests/hdl/test_fmul_ilog2_const.py
+++ b/tests/hdl/test_fmul_ilog2_const.py
@@ -6,6 +6,7 @@ zkf_mul_ilog2_const.
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -38,7 +39,7 @@ K_VALUES = (-5, -1, 0, 1, 5)
 
 
 @cocotb.test()
-async def holoso_fmul_ilog2_const_cocotb(dut) -> None:
+async def holoso_fmul_ilog2_const_cocotb(dut: Any) -> None:
     k_param = int(os.environ["HOLOSO_TEST_K"])
 
     await start_clock(dut)

--- a/tests/hdl/test_fround.py
+++ b/tests/hdl/test_fround.py
@@ -7,6 +7,7 @@ the wrapper delays y_sgnop through the same number of stages as zkf_round.
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -49,7 +50,7 @@ DIRECTED_ROUND: tuple[int, ...] = DIRECTED_F32 + tuple(
 
 
 @cocotb.test()
-async def holoso_fround_cocotb(dut) -> None:
+async def holoso_fround_cocotb(dut: Any) -> None:
     await start_clock(dut)
     await drive_reset(dut)
 

--- a/tests/hdl/test_fsaturate.py
+++ b/tests/hdl/test_fsaturate.py
@@ -1,6 +1,8 @@
 """Tests for holoso_fsaturate (combinational; +inf -> +max, -inf -> -max, finite passes through)."""
 
 from pathlib import Path
+from typing import Any
+
 import cocotb
 import numpy as np
 import pytest
@@ -24,7 +26,7 @@ from .hdl_float_oracle import (
 
 
 @cocotb.test()
-async def holoso_fsaturate_cocotb(dut) -> None:
+async def holoso_fsaturate_cocotb(dut: Any) -> None:
     async def check(x_bits: int) -> None:
         dut.x.value = x_bits
         await Timer(1, unit="ns")

--- a/tests/hdl/test_fsgnop.py
+++ b/tests/hdl/test_fsgnop.py
@@ -1,6 +1,7 @@
 """Tests for holoso_fsgnop (combinational, format-independent)."""
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -25,7 +26,7 @@ WFULL_VALUES = (6, 12, 24, 32)
 
 
 @cocotb.test()
-async def holoso_fsgnop_cocotb(dut) -> None:
+async def holoso_fsgnop_cocotb(dut: Any) -> None:
     wfull = int(os.environ["HOLOSO_TEST_WFULL"])
 
     async def check(x: int, op: int) -> None:

--- a/tests/hdl/test_fsgnop_fn.py
+++ b/tests/hdl/test_fsgnop_fn.py
@@ -4,6 +4,8 @@ as a function/module name-coexistence canary across simulators.
 """
 
 from pathlib import Path
+from typing import Any
+
 import cocotb
 import numpy as np
 import pytest
@@ -30,7 +32,7 @@ _WFULL = _WEXP + _WMAN
 
 
 @cocotb.test()
-async def holoso_fsgnop_fn_cocotb(dut) -> None:
+async def holoso_fsgnop_fn_cocotb(dut: Any) -> None:
     async def check(x_bits: int, op: int) -> None:
         dut.x.value = x_bits
         dut.op.value = op

--- a/tests/hdl/test_fsort.py
+++ b/tests/hdl/test_fsort.py
@@ -8,6 +8,7 @@ contract.
 """
 
 import os
+from typing import Any
 
 import cocotb
 import numpy as np
@@ -38,7 +39,7 @@ from .hdl_float_oracle import (
 
 
 @cocotb.test()
-async def holoso_fsort_cocotb(dut) -> None:
+async def holoso_fsort_cocotb(dut: Any) -> None:
     await start_clock(dut)
     await drive_reset(dut)
 

--- a/tests/test_arithmetic_behavior.py
+++ b/tests/test_arithmetic_behavior.py
@@ -82,15 +82,15 @@ def _round(value: float) -> float:
 _EDGES = format_edge_bits(FMT)  # zero, ±0.5, ±1, ±smallest-normal, ±largest-finite (9 patterns)
 
 
-def _add(a, b):  # type: ignore[no-untyped-def]
+def _add(a: float, b: float):  # type: ignore[no-untyped-def]
     return a + b
 
 
-def _mul(a, b):  # type: ignore[no-untyped-def]
+def _mul(a: float, b: float):  # type: ignore[no-untyped-def]
     return a * b
 
 
-def _neg_self(x):  # type: ignore[no-untyped-def]
+def _neg_self(x: float):  # type: ignore[no-untyped-def]
     return x + (-x)
 
 
@@ -119,7 +119,7 @@ def test_mul_by_zero_is_positive_zero_over_edges() -> None:
         assert out.bits == 0 and out.sign == 0, f"x*0.0 not +0: bits=0x{out.bits:x} sign={out.sign}"
 
 
-def _abs_via_select(x):  # type: ignore[no-untyped-def]
+def _abs_via_select(x: float):  # type: ignore[no-untyped-def]
     # abs via a sign-select: -x if x < 0 else x. The magnitude must equal |x| exactly (a pure sign-bit clear in ZKF).
     return -x if x < 0.0 else x
 
@@ -133,7 +133,7 @@ def test_abs_via_select_clears_sign_over_edges() -> None:
         assert out.bits == want.bits, f"abs(0x{bits:x}) bits=0x{out.bits:x} vs 0x{want.bits:x}"
 
 
-def _double_neg(x):  # type: ignore[no-untyped-def]
+def _double_neg(x: float):  # type: ignore[no-untyped-def]
     return -(-x)
 
 
@@ -173,7 +173,7 @@ def _largest_finite() -> FloatValue:
     return _val((max_exp << frac_bits) | ((1 << frac_bits) - 1))
 
 
-def _overflow_then_mul(x, y):  # type: ignore[no-untyped-def]
+def _overflow_then_mul(x: float, y: float):  # type: ignore[no-untyped-def]
     # (x + x) overflows to +inf at the extreme; multiplying by y must keep it inf (inf * finite-positive == inf).
     return (x + x) * y
 
@@ -189,7 +189,7 @@ def test_overflow_to_inf_and_stays_inf() -> None:
     assert math.isinf(float(out)) and float(out) > 0.0, f"overflow chain not +inf: {float(out)} (bits 0x{out.bits:x})"
 
 
-def _div(a, b):  # type: ignore[no-untyped-def]
+def _div(a: float, b: float):  # type: ignore[no-untyped-def]
     return a / b
 
 
@@ -200,27 +200,27 @@ def test_divide_by_zero_emits_inf_error_path() -> None:
     assert math.isinf(float(out)) and float(out) > 0.0, f"1.0/0.0 not +inf: {float(out)} (bits 0x{out.bits:x})"
 
 
-def _k_lt(x, y):  # type: ignore[no-untyped-def]
+def _k_lt(x: float, y: float):  # type: ignore[no-untyped-def]
     return x < y
 
 
-def _k_le(x, y):  # type: ignore[no-untyped-def]
+def _k_le(x: float, y: float):  # type: ignore[no-untyped-def]
     return x <= y
 
 
-def _k_gt(x, y):  # type: ignore[no-untyped-def]
+def _k_gt(x: float, y: float):  # type: ignore[no-untyped-def]
     return x > y
 
 
-def _k_ge(x, y):  # type: ignore[no-untyped-def]
+def _k_ge(x: float, y: float):  # type: ignore[no-untyped-def]
     return x >= y
 
 
-def _k_eq(x, y):  # type: ignore[no-untyped-def]
+def _k_eq(x: float, y: float):  # type: ignore[no-untyped-def]
     return x == y
 
 
-def _k_ne(x, y):  # type: ignore[no-untyped-def]
+def _k_ne(x: float, y: float):  # type: ignore[no-untyped-def]
     return x != y
 
 
@@ -246,7 +246,7 @@ def test_all_six_relational_operators_exact_at_boundary() -> None:
             assert got is want, f"{name}({x}, {y}) = {got}, want {want}"
 
 
-def _chained(lo, x, hi):  # type: ignore[no-untyped-def]
+def _chained(lo: float, x: float, hi: float):  # type: ignore[no-untyped-def]
     # lo < x < hi lowers to two comparators AND-fused; must match Python's chained-comparison semantics exactly.
     return lo < x < hi
 
@@ -273,23 +273,23 @@ def test_equality_bit_equal_vs_bit_different() -> None:
     assert sim_ne.run(same, other)[0] is True
 
 
-def _x_times_2(x):  # type: ignore[no-untyped-def]
+def _x_times_2(x: float):  # type: ignore[no-untyped-def]
     return x * 2.0
 
 
-def _x_times_half(x):  # type: ignore[no-untyped-def]
+def _x_times_half(x: float):  # type: ignore[no-untyped-def]
     return x * 0.5
 
 
-def _x_times_8(x):  # type: ignore[no-untyped-def]
+def _x_times_8(x: float):  # type: ignore[no-untyped-def]
     return x * 8.0
 
 
-def _x_times_eighth(x):  # type: ignore[no-untyped-def]
+def _x_times_eighth(x: float):  # type: ignore[no-untyped-def]
     return x * 0.125
 
 
-def _x_times_2_pow_neg5(x):  # type: ignore[no-untyped-def]
+def _x_times_2_pow_neg5(x: float):  # type: ignore[no-untyped-def]
     return x * 2.0**-5
 
 
@@ -310,7 +310,7 @@ def test_power_of_two_strength_reduction_is_exact() -> None:
             assert got.bits == want.bits, f"{name}: {x}*{factor} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _x_times_3(x):  # type: ignore[no-untyped-def]
+def _x_times_3(x: float):  # type: ignore[no-untyped-def]
     # 3.0 is NOT a power of two, so this stays an ordinary fmul; still must round-correctly.
     return x * 3.0
 
@@ -385,7 +385,7 @@ def test_de_morgan_equivalence_full_truth_table() -> None:
             assert lhs is want and rhs is want, f"de morgan ({a},{b}): lhs={lhs} rhs={rhs} want={want}"
 
 
-def _float_of_cond(x, y):  # type: ignore[no-untyped-def]
+def _float_of_cond(x: float, y: float):  # type: ignore[no-untyped-def]
     # float(x > y) must be exactly 0.0 or 1.0; feeding it into arithmetic gives a clean gate.
     return float(x > y) * 10.0 + 1.0
 
@@ -398,7 +398,7 @@ def test_float_of_bool_is_exactly_zero_or_one_feeding_arithmetic() -> None:
         assert got.bits == want.bits, f"float({x}>{y})*10+1 bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _cross_domain_chain(x, y):  # type: ignore[no-untyped-def]
+def _cross_domain_chain(x: float, y: float):  # type: ignore[no-untyped-def]
     # A float compared, the bool cast to float, then multiplied by a float: a full float->bool->float round trip.
     return float(x > y) * (x + y)
 
@@ -412,7 +412,7 @@ def test_compare_cast_multiply_cross_domain_chain() -> None:
         assert got.bits == want.bits, f"cross chain ({x},{y}) bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _bool_of_float(x):  # type: ignore[no-untyped-def]
+def _bool_of_float(x: float):  # type: ignore[no-untyped-def]
     # bool(x) truthiness: nonzero -> True, +0 -> False.
     return bool(x)
 
@@ -427,7 +427,7 @@ def test_bool_of_float_truthiness() -> None:
     assert sim.run(_val(1 << frac_bits))[0] is True
 
 
-def _fold_to_zero(x):  # type: ignore[no-untyped-def]
+def _fold_to_zero(x: float):  # type: ignore[no-untyped-def]
     # The subexpression 2*3 - 6 folds to 0.0 at compile time, so x + 0.0 == x exactly for every representable x.
     return x + (2.0 * 3.0 - 6.0)
 
@@ -439,7 +439,7 @@ def test_constant_subexpression_folds_to_zero() -> None:
         assert out.bits == bits, f"x + (2*3-6) changed bits: 0x{out.bits:x} vs 0x{bits:x}"
 
 
-def _dead_arm_divides_by_zero(x):  # type: ignore[no-untyped-def]
+def _dead_arm_divides_by_zero(x: float):  # type: ignore[no-untyped-def]
     # 3.0 < 2.0 folds to False; the THEN arm (which divides by a compile-time 0.0) must be pruned, never lowered.
     if 3.0 < 2.0:
         r = x / 0.0
@@ -462,7 +462,7 @@ class _AttributeConfig:
     def __init__(self, threshold: float) -> None:
         self._threshold = threshold
 
-    def __call__(self, x):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float):  # type: ignore[no-untyped-def]
         if self._threshold > 2.0:  # _threshold == 3.0 is a compile-time snapshot -> the condition folds to True
             r = x + 1.0
         else:
@@ -478,7 +478,7 @@ def test_read_only_attribute_folds_in_condition() -> None:
         assert got.bits == want.bits, f"attr-fold x+1: {x} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _horner_loop(x):  # type: ignore[no-untyped-def]
+def _horner_loop(x: float):  # type: ignore[no-untyped-def]
     # A bounded for-loop that fully unrolls a Horner evaluation of 1*x^4 + 1*x^3 + 1*x^2 + 1*x + 1.
     acc = 0.0
     for _ in range(5):
@@ -486,7 +486,7 @@ def _horner_loop(x):  # type: ignore[no-untyped-def]
     return acc
 
 
-def _horner_unrolled(x):  # type: ignore[no-untyped-def]
+def _horner_unrolled(x: float):  # type: ignore[no-untyped-def]
     # The SAME Horner recurrence written out straight-line: identical op order, so the bits must match exactly.
     acc = 0.0
     acc = acc * x + 1.0

--- a/tests/test_arithmetic_behavior.py
+++ b/tests/test_arithmetic_behavior.py
@@ -39,6 +39,7 @@ Python float, and outputs are compared on ``.bits`` so the assertions cannot sil
 """
 
 import math
+from collections.abc import Callable
 
 import holoso
 from holoso import (
@@ -63,7 +64,7 @@ def _ops() -> OpConfig:
     )
 
 
-def _sim(fn, name: str) -> holoso.NumericalSimulator:  # type: ignore[no-untyped-def]
+def _sim(fn: Callable[..., object], name: str) -> holoso.NumericalSimulator:
     return holoso.synthesize(fn, _ops(), name=name).numerical_model.elaborate()
 
 
@@ -82,15 +83,15 @@ def _round(value: float) -> float:
 _EDGES = format_edge_bits(FMT)  # zero, ±0.5, ±1, ±smallest-normal, ±largest-finite (9 patterns)
 
 
-def _add(a: float, b: float):  # type: ignore[no-untyped-def]
+def _add(a: float, b: float) -> float:
     return a + b
 
 
-def _mul(a: float, b: float):  # type: ignore[no-untyped-def]
+def _mul(a: float, b: float) -> float:
     return a * b
 
 
-def _neg_self(x: float):  # type: ignore[no-untyped-def]
+def _neg_self(x: float) -> float:
     return x + (-x)
 
 
@@ -119,7 +120,7 @@ def test_mul_by_zero_is_positive_zero_over_edges() -> None:
         assert out.bits == 0 and out.sign == 0, f"x*0.0 not +0: bits=0x{out.bits:x} sign={out.sign}"
 
 
-def _abs_via_select(x: float):  # type: ignore[no-untyped-def]
+def _abs_via_select(x: float) -> float:
     # abs via a sign-select: -x if x < 0 else x. The magnitude must equal |x| exactly (a pure sign-bit clear in ZKF).
     return -x if x < 0.0 else x
 
@@ -133,7 +134,7 @@ def test_abs_via_select_clears_sign_over_edges() -> None:
         assert out.bits == want.bits, f"abs(0x{bits:x}) bits=0x{out.bits:x} vs 0x{want.bits:x}"
 
 
-def _double_neg(x: float):  # type: ignore[no-untyped-def]
+def _double_neg(x: float) -> float:
     return -(-x)
 
 
@@ -173,7 +174,7 @@ def _largest_finite() -> FloatValue:
     return _val((max_exp << frac_bits) | ((1 << frac_bits) - 1))
 
 
-def _overflow_then_mul(x: float, y: float):  # type: ignore[no-untyped-def]
+def _overflow_then_mul(x: float, y: float) -> float:
     # (x + x) overflows to +inf at the extreme; multiplying by y must keep it inf (inf * finite-positive == inf).
     return (x + x) * y
 
@@ -189,7 +190,7 @@ def test_overflow_to_inf_and_stays_inf() -> None:
     assert math.isinf(float(out)) and float(out) > 0.0, f"overflow chain not +inf: {float(out)} (bits 0x{out.bits:x})"
 
 
-def _div(a: float, b: float):  # type: ignore[no-untyped-def]
+def _div(a: float, b: float) -> float:
     return a / b
 
 
@@ -200,27 +201,27 @@ def test_divide_by_zero_emits_inf_error_path() -> None:
     assert math.isinf(float(out)) and float(out) > 0.0, f"1.0/0.0 not +inf: {float(out)} (bits 0x{out.bits:x})"
 
 
-def _k_lt(x: float, y: float):  # type: ignore[no-untyped-def]
+def _k_lt(x: float, y: float) -> bool:
     return x < y
 
 
-def _k_le(x: float, y: float):  # type: ignore[no-untyped-def]
+def _k_le(x: float, y: float) -> bool:
     return x <= y
 
 
-def _k_gt(x: float, y: float):  # type: ignore[no-untyped-def]
+def _k_gt(x: float, y: float) -> bool:
     return x > y
 
 
-def _k_ge(x: float, y: float):  # type: ignore[no-untyped-def]
+def _k_ge(x: float, y: float) -> bool:
     return x >= y
 
 
-def _k_eq(x: float, y: float):  # type: ignore[no-untyped-def]
+def _k_eq(x: float, y: float) -> bool:
     return x == y
 
 
-def _k_ne(x: float, y: float):  # type: ignore[no-untyped-def]
+def _k_ne(x: float, y: float) -> bool:
     return x != y
 
 
@@ -246,7 +247,7 @@ def test_all_six_relational_operators_exact_at_boundary() -> None:
             assert got is want, f"{name}({x}, {y}) = {got}, want {want}"
 
 
-def _chained(lo: float, x: float, hi: float):  # type: ignore[no-untyped-def]
+def _chained(lo: float, x: float, hi: float) -> bool:
     # lo < x < hi lowers to two comparators AND-fused; must match Python's chained-comparison semantics exactly.
     return lo < x < hi
 
@@ -273,23 +274,23 @@ def test_equality_bit_equal_vs_bit_different() -> None:
     assert sim_ne.run(same, other)[0] is True
 
 
-def _x_times_2(x: float):  # type: ignore[no-untyped-def]
+def _x_times_2(x: float) -> float:
     return x * 2.0
 
 
-def _x_times_half(x: float):  # type: ignore[no-untyped-def]
+def _x_times_half(x: float) -> float:
     return x * 0.5
 
 
-def _x_times_8(x: float):  # type: ignore[no-untyped-def]
+def _x_times_8(x: float) -> float:
     return x * 8.0
 
 
-def _x_times_eighth(x: float):  # type: ignore[no-untyped-def]
+def _x_times_eighth(x: float) -> float:
     return x * 0.125
 
 
-def _x_times_2_pow_neg5(x: float):  # type: ignore[no-untyped-def]
+def _x_times_2_pow_neg5(x: float) -> float:
     return x * 2.0**-5
 
 
@@ -310,7 +311,7 @@ def test_power_of_two_strength_reduction_is_exact() -> None:
             assert got.bits == want.bits, f"{name}: {x}*{factor} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _x_times_3(x: float):  # type: ignore[no-untyped-def]
+def _x_times_3(x: float) -> float:
     # 3.0 is NOT a power of two, so this stays an ordinary fmul; still must round-correctly.
     return x * 3.0
 
@@ -337,15 +338,15 @@ def test_power_of_two_overflow_and_underflow_edges() -> None:
     assert under.bits == 0, f"smallest_normal*0.125 not +0: bits=0x{under.bits:x} ({float(under)})"
 
 
-def _k_and(a: bool, b: bool):  # type: ignore[no-untyped-def]
+def _k_and(a: bool, b: bool) -> bool:
     return a and b
 
 
-def _k_or(a: bool, b: bool):  # type: ignore[no-untyped-def]
+def _k_or(a: bool, b: bool) -> bool:
     return a or b
 
 
-def _k_and_or(a: bool, b: bool, c: bool):  # type: ignore[no-untyped-def]
+def _k_and_or(a: bool, b: bool, c: bool) -> bool:
     return a and b or c  # (a and b) or c by Python precedence
 
 
@@ -366,11 +367,11 @@ def test_boolean_and_or_compound_truth_table() -> None:
                 assert sim.run(a, b, c)[0] is ((a and b) or c), f"and_or({a},{b},{c})"
 
 
-def _demorgan_lhs(a: bool, b: bool):  # type: ignore[no-untyped-def]
+def _demorgan_lhs(a: bool, b: bool) -> bool:
     return not (a and b)
 
 
-def _demorgan_rhs(a: bool, b: bool):  # type: ignore[no-untyped-def]
+def _demorgan_rhs(a: bool, b: bool) -> bool:
     return (not a) or (not b)
 
 
@@ -385,7 +386,7 @@ def test_de_morgan_equivalence_full_truth_table() -> None:
             assert lhs is want and rhs is want, f"de morgan ({a},{b}): lhs={lhs} rhs={rhs} want={want}"
 
 
-def _float_of_cond(x: float, y: float):  # type: ignore[no-untyped-def]
+def _float_of_cond(x: float, y: float) -> float:
     # float(x > y) must be exactly 0.0 or 1.0; feeding it into arithmetic gives a clean gate.
     return float(x > y) * 10.0 + 1.0
 
@@ -398,7 +399,7 @@ def test_float_of_bool_is_exactly_zero_or_one_feeding_arithmetic() -> None:
         assert got.bits == want.bits, f"float({x}>{y})*10+1 bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _cross_domain_chain(x: float, y: float):  # type: ignore[no-untyped-def]
+def _cross_domain_chain(x: float, y: float) -> float:
     # A float compared, the bool cast to float, then multiplied by a float: a full float->bool->float round trip.
     return float(x > y) * (x + y)
 
@@ -412,7 +413,7 @@ def test_compare_cast_multiply_cross_domain_chain() -> None:
         assert got.bits == want.bits, f"cross chain ({x},{y}) bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _bool_of_float(x: float):  # type: ignore[no-untyped-def]
+def _bool_of_float(x: float) -> bool:
     # bool(x) truthiness: nonzero -> True, +0 -> False.
     return bool(x)
 
@@ -427,7 +428,7 @@ def test_bool_of_float_truthiness() -> None:
     assert sim.run(_val(1 << frac_bits))[0] is True
 
 
-def _fold_to_zero(x: float):  # type: ignore[no-untyped-def]
+def _fold_to_zero(x: float) -> float:
     # The subexpression 2*3 - 6 folds to 0.0 at compile time, so x + 0.0 == x exactly for every representable x.
     return x + (2.0 * 3.0 - 6.0)
 
@@ -439,7 +440,7 @@ def test_constant_subexpression_folds_to_zero() -> None:
         assert out.bits == bits, f"x + (2*3-6) changed bits: 0x{out.bits:x} vs 0x{bits:x}"
 
 
-def _dead_arm_divides_by_zero(x: float):  # type: ignore[no-untyped-def]
+def _dead_arm_divides_by_zero(x: float) -> float:
     # 3.0 < 2.0 folds to False; the THEN arm (which divides by a compile-time 0.0) must be pruned, never lowered.
     if 3.0 < 2.0:
         r = x / 0.0
@@ -462,7 +463,7 @@ class _AttributeConfig:
     def __init__(self, threshold: float) -> None:
         self._threshold = threshold
 
-    def __call__(self, x: float):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float) -> float:
         if self._threshold > 2.0:  # _threshold == 3.0 is a compile-time snapshot -> the condition folds to True
             r = x + 1.0
         else:
@@ -478,7 +479,7 @@ def test_read_only_attribute_folds_in_condition() -> None:
         assert got.bits == want.bits, f"attr-fold x+1: {x} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
 
-def _horner_loop(x: float):  # type: ignore[no-untyped-def]
+def _horner_loop(x: float) -> float:
     # A bounded for-loop that fully unrolls a Horner evaluation of 1*x^4 + 1*x^3 + 1*x^2 + 1*x + 1.
     acc = 0.0
     for _ in range(5):
@@ -486,7 +487,7 @@ def _horner_loop(x: float):  # type: ignore[no-untyped-def]
     return acc
 
 
-def _horner_unrolled(x: float):  # type: ignore[no-untyped-def]
+def _horner_unrolled(x: float) -> float:
     # The SAME Horner recurrence written out straight-line: identical op order, so the bits must match exactly.
     acc = 0.0
     acc = acc * x + 1.0

--- a/tests/test_arithmetic_behavior.py
+++ b/tests/test_arithmetic_behavior.py
@@ -99,6 +99,7 @@ def test_additive_inverse_is_zero_over_edges() -> None:
     sim = _sim(_neg_self, "add_inverse")
     for bits in _EDGES:
         out = sim.run(_val(bits))[0]
+        assert isinstance(out, FloatValue)
         # x + (-x) == +0 for every finite edge; the largest-finite case does not overflow (it cancels exactly).
         assert out.bits == 0, f"x=0x{bits:x} ({float(_val(bits))}): x+(-x) bits=0x{out.bits:x} ({float(out)})"
 
@@ -108,6 +109,7 @@ def test_mul_by_one_is_identity_over_edges() -> None:
     one = FloatValue.from_float(FMT, 1.0)
     for bits in _EDGES:
         out = sim.run(_val(bits), one)[0]
+        assert isinstance(out, FloatValue)
         assert out.bits == bits, f"x*1.0 changed bits: 0x{out.bits:x} vs 0x{bits:x}"
 
 
@@ -117,6 +119,7 @@ def test_mul_by_zero_is_positive_zero_over_edges() -> None:
     zero = FloatValue.from_float(FMT, 0.0)
     for bits in _EDGES:
         out = sim.run(_val(bits), zero)[0]
+        assert isinstance(out, FloatValue)
         assert out.bits == 0 and out.sign == 0, f"x*0.0 not +0: bits=0x{out.bits:x} sign={out.sign}"
 
 
@@ -130,6 +133,7 @@ def test_abs_via_select_clears_sign_over_edges() -> None:
     for bits in _EDGES:
         x = _val(bits)
         out = sim.run(x)[0]
+        assert isinstance(out, FloatValue)
         want = x.apply_sign(negate=False, absolute=True)
         assert out.bits == want.bits, f"abs(0x{bits:x}) bits=0x{out.bits:x} vs 0x{want.bits:x}"
 
@@ -142,6 +146,7 @@ def test_double_negation_is_identity_over_edges() -> None:
     sim = _sim(_double_neg, "double_neg")
     for bits in _EDGES:
         out = sim.run(_val(bits))[0]
+        assert isinstance(out, FloatValue)
         assert out.bits == bits, f"-(-x) changed bits: 0x{out.bits:x} vs 0x{bits:x}"
 
 
@@ -152,6 +157,7 @@ def test_addition_commutes_bit_identical_over_edges() -> None:
         for bb in _EDGES:
             forward = sim.run(_val(ab), _val(bb))[0]
             reverse = sim.run(_val(bb), _val(ab))[0]
+            assert isinstance(forward, FloatValue) and isinstance(reverse, FloatValue)
             assert (
                 forward.bits == reverse.bits
             ), f"a+b != b+a: a=0x{ab:x} b=0x{bb:x}: 0x{forward.bits:x} vs 0x{reverse.bits:x}"
@@ -163,6 +169,7 @@ def test_multiplication_commutes_bit_identical_over_edges() -> None:
         for bb in _EDGES:
             forward = sim.run(_val(ab), _val(bb))[0]
             reverse = sim.run(_val(bb), _val(ab))[0]
+            assert isinstance(forward, FloatValue) and isinstance(reverse, FloatValue)
             assert (
                 forward.bits == reverse.bits
             ), f"a*b != b*a: a=0x{ab:x} b=0x{bb:x}: 0x{forward.bits:x} vs 0x{reverse.bits:x}"
@@ -184,6 +191,7 @@ def test_overflow_to_inf_and_stays_inf() -> None:
     lf = _largest_finite()
     one = FloatValue.from_float(FMT, 1.0)
     out = sim.run(lf, one)[0]
+    assert isinstance(out, FloatValue)
     # largest + largest overflows: the ZKF-accurate reference is round(2*largest) == +inf, and inf*1 stays inf.
     want = _round(_round(2.0 * float(lf)) * 1.0)
     assert math.isinf(want) and want > 0.0  # guard the reference itself
@@ -198,6 +206,7 @@ def test_divide_by_zero_emits_inf_error_path() -> None:
     # 1.0 / 0.0 is the error path; its OUTPUT value is +inf (err_pc is not model-observable, so it is not asserted).
     sim = _sim(_div, "div_zero")
     out = sim.run(FloatValue.from_float(FMT, 1.0), FloatValue.from_float(FMT, 0.0))[0]
+    assert isinstance(out, FloatValue)
     assert math.isinf(float(out)) and float(out) > 0.0, f"1.0/0.0 not +inf: {float(out)} (bits 0x{out.bits:x})"
 
 
@@ -232,14 +241,15 @@ def test_all_six_relational_operators_exact_at_boundary() -> None:
     below = float(_val(pivot_bits - 1))
     above = float(_val(pivot_bits + 1))
     pairs = [(pivot, pivot), (below, pivot), (above, pivot), (pivot, below), (pivot, above), (-pivot, pivot)]
-    for fn, py, name in [
+    cases: list[tuple[Callable[[float, float], bool], Callable[[float, float], bool], str]] = [
         (_k_lt, lambda a, b: a < b, "lt"),
         (_k_le, lambda a, b: a <= b, "le"),
         (_k_gt, lambda a, b: a > b, "gt"),
         (_k_ge, lambda a, b: a >= b, "ge"),
         (_k_eq, lambda a, b: a == b, "eq"),
         (_k_ne, lambda a, b: a != b, "ne"),
-    ]:
+    ]
+    for fn, py, name in cases:
         sim = _sim(fn, f"rel_{name}")
         for x, y in pairs:
             got = sim.run(FloatValue.from_float(FMT, x), FloatValue.from_float(FMT, y))[0]
@@ -307,6 +317,7 @@ def test_power_of_two_strength_reduction_is_exact() -> None:
         sim = _sim(fn, f"pow2_{name}")
         for x in (-3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0, 17.0):
             got = sim.run(FloatValue.from_float(FMT, x))[0]
+            assert isinstance(got, FloatValue)
             want = FloatValue.from_float(FMT, _round(x * factor))
             assert got.bits == want.bits, f"{name}: {x}*{factor} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
@@ -320,6 +331,7 @@ def test_non_power_of_two_stays_ordinary_fmul_and_correct() -> None:
     sim = _sim(_x_times_3, "mul3")
     for x in (-3.0, -1.0, 0.0, 0.5, 1.0, 3.0, 17.0, 100.0):
         got = sim.run(FloatValue.from_float(FMT, x))[0]
+        assert isinstance(got, FloatValue)
         want = FloatValue.from_float(FMT, _round(x * 3.0))
         assert got.bits == want.bits, f"x*3.0: {x} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
@@ -334,6 +346,7 @@ def test_power_of_two_overflow_and_underflow_edges() -> None:
     frac_bits = FMT.wman - 1
     smallest_normal = _val(1 << frac_bits)  # exponent 1, zero fraction
     under = sim_quarter.run(smallest_normal)[0]
+    assert isinstance(under, FloatValue)
     # smallest_normal * 0.125 underflows below the half-MIN_NORMAL boundary -> rounds to +0 (the format's own rule).
     assert under.bits == 0, f"smallest_normal*0.125 not +0: bits=0x{under.bits:x} ({float(under)})"
 
@@ -395,6 +408,7 @@ def test_float_of_bool_is_exactly_zero_or_one_feeding_arithmetic() -> None:
     sim = _sim(_float_of_cond, "float_cond")
     for x, y in [(3.0, 1.0), (1.0, 3.0), (2.0, 2.0)]:
         got = sim.run(FloatValue.from_float(FMT, x), FloatValue.from_float(FMT, y))[0]
+        assert isinstance(got, FloatValue)
         want = FloatValue.from_float(FMT, (10.0 if x > y else 0.0) + 1.0)
         assert got.bits == want.bits, f"float({x}>{y})*10+1 bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
@@ -408,6 +422,7 @@ def test_compare_cast_multiply_cross_domain_chain() -> None:
     sim = _sim(_cross_domain_chain, "cross_chain")
     for x, y in [(3.0, 1.0), (1.0, 3.0), (2.0, 2.0), (-1.0, -2.0)]:
         got = sim.run(FloatValue.from_float(FMT, x), FloatValue.from_float(FMT, y))[0]
+        assert isinstance(got, FloatValue)
         gate = 1.0 if x > y else 0.0
         want = FloatValue.from_float(FMT, _round(gate * _round(x + y)))  # the sum rounds, then the (exact) gate scales
         assert got.bits == want.bits, f"cross chain ({x},{y}) bits=0x{got.bits:x} vs 0x{want.bits:x}"
@@ -437,6 +452,7 @@ def test_constant_subexpression_folds_to_zero() -> None:
     sim = _sim(_fold_to_zero, "fold_zero")
     for bits in _EDGES:
         out = sim.run(_val(bits))[0]
+        assert isinstance(out, FloatValue)
         assert out.bits == bits, f"x + (2*3-6) changed bits: 0x{out.bits:x} vs 0x{bits:x}"
 
 
@@ -453,6 +469,7 @@ def test_constant_condition_drops_divide_by_zero_dead_arm() -> None:
     sim = _sim(_dead_arm_divides_by_zero, "dead_arm")
     for x in (-3.0, 0.0, 1.0, 5.0, 7.0):
         got = sim.run(FloatValue.from_float(FMT, x))[0]
+        assert isinstance(got, FloatValue)
         want = FloatValue.from_float(FMT, _round(x + 1.0))
         assert got.bits == want.bits, f"x+1 (dead arm pruned): {x} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
@@ -475,6 +492,7 @@ def test_read_only_attribute_folds_in_condition() -> None:
     sim = _sim(_AttributeConfig(3.0).__call__, "attr_fold")
     for x in (-2.0, 0.0, 3.0, 9.0):
         got = sim.run(FloatValue.from_float(FMT, x))[0]
+        assert isinstance(got, FloatValue)
         want = FloatValue.from_float(FMT, _round(x + 1.0))
         assert got.bits == want.bits, f"attr-fold x+1: {x} bits=0x{got.bits:x} vs 0x{want.bits:x}"
 
@@ -504,6 +522,7 @@ def test_bounded_for_loop_unrolls_to_straight_line_bit_identical() -> None:
     for x in (-2.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 3.0):
         looped = sim_loop.run(FloatValue.from_float(FMT, x))[0]
         flat = sim_flat.run(FloatValue.from_float(FMT, x))[0]
+        assert isinstance(looped, FloatValue) and isinstance(flat, FloatValue)
         assert (
             looped.bits == flat.bits
         ), f"unrolled loop != straight-line at x={x}: 0x{looped.bits:x} vs 0x{flat.bits:x}"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -15,6 +15,7 @@ from holoso import (
     FCmpOperator,
     FDivOperator,
     FloatFormat,
+    FloatValue,
     FMulILog2OperatorFamily,
     FMulOperator,
     OpConfig,
@@ -300,6 +301,7 @@ def test_both_bank_lane_write_commit_rides_the_commit_step() -> None:
         write_codebook,
         write_events,
     )
+    from holoso._operators import BoolInversion
     from ._modelref import branch_boundary_kernel, fcmp_staged_ops
 
     fmt = FloatFormat(6, 18)
@@ -311,7 +313,12 @@ def test_both_bank_lane_write_commit_rides_the_commit_step() -> None:
     for op in lir.ops:
         for write in op.writes:
             is_wide = not isinstance(write.dst, BoolRegRef)
-            source = OpWriteSource(op.inst, write.port, False if is_wide else write.conditioner.invert)
+            if is_wide:
+                invert = False
+            else:
+                assert isinstance(write.conditioner, BoolInversion)
+                invert = write.conditioner.invert
+            source = OpWriteSource(op.inst, write.port, invert)
             code = write_books[write.dst].code(source)
             assert (
                 fields[f_op(write.dst)].values[pooled_write_word(op.commit_cycle)] == code
@@ -358,7 +365,7 @@ def test_wide_multi_output_operator_elaborates_with_per_port_lanes(tmp_path: Pat
         boundary_step,
     )
     from holoso._lir._ir import BoolRegFileLayout
-    from holoso._operators import FloatHardwareOperator, FloatSignControl, FloatValue
+    from holoso._operators import FloatHardwareOperator, FloatSignControl
     from holoso._type import ScalarSignature, FloatType as ScalarFloatType
 
     _FETCH_LAG = 2  # datapath lag matching the 3-stage control fetch: one less than fetch_stages

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -65,7 +65,7 @@ def _elaborate(name: str, verilog: str, tmp_path: Path) -> None:
 
 
 def test_operator_instance_names_include_hardware_identity() -> None:
-    def scale(a, b):  # type: ignore[no-untyped-def]
+    def scale(a: float, b: float):  # type: ignore[no-untyped-def]
         return a * 4.0 + b * 8.0
 
     fmt = FloatFormat(6, 18)
@@ -85,7 +85,7 @@ def test_comparisons_share_one_pooled_fcmp_instance() -> None:
     # Comparisons live in mutually-exclusive blocks and execute sequentially, so they share a single holoso_fcmp
     # (the one-instance-per-operator pooling convention), its operands riding the ordinary microcode read-mux
     # lanes -- not one instance per comparison.
-    def kernel(x):  # type: ignore[no-untyped-def]
+    def kernel(x: float):  # type: ignore[no-untyped-def]
         if x > 1.0:
             y = x + 1.0
         elif x < -1.0:
@@ -127,7 +127,7 @@ endmodule
 
 @requires_iverilog
 def test_small_kernel_elaborates(tmp_path: Path) -> None:
-    def kernel(a, b):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     fmt = FloatFormat(8, 24)
@@ -137,7 +137,7 @@ def test_small_kernel_elaborates(tmp_path: Path) -> None:
 
 @requires_iverilog
 def test_kernel_with_division_elaborates(tmp_path: Path) -> None:
-    def blend(a, b, c):  # type: ignore[no-untyped-def]
+    def blend(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return a / b + c * 2.0
 
     fmt = FloatFormat(6, 18)
@@ -164,7 +164,7 @@ def test_boolean_output_port_is_one_bit_and_assigned() -> None:
             self.low = -1.0
             self.y = False
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if x > self.high:
                 self.y = True
             elif x < self.low:
@@ -225,7 +225,7 @@ def test_boolean_only_stateful_module_elaborates(tmp_path: Path) -> None:
 def test_parameter_name_colliding_with_control_port_is_rejected() -> None:
     # A parameter named 'valid'/'ready' becomes data port in_valid/in_ready, colliding with the control ports and
     # producing un-elaboratable Verilog; LIR construction must reject it instead of emitting duplicate ports.
-    def collide(valid, ready):  # type: ignore[no-untyped-def]
+    def collide(valid: float, ready: float):  # type: ignore[no-untyped-def]
         return valid + ready
 
     fmt = FloatFormat(6, 18)
@@ -234,7 +234,7 @@ def test_parameter_name_colliding_with_control_port_is_rejected() -> None:
 
 
 def test_kernel_without_outputs_is_rejected() -> None:
-    def empty(x):  # type: ignore[no-untyped-def]
+    def empty(x: float):  # type: ignore[no-untyped-def]
         return ()
 
     fmt = FloatFormat(6, 18)
@@ -252,7 +252,7 @@ def test_state_slot_folded_sign_coexists_with_sibling_port(tmp_path: Path) -> No
             self.y_d = 0.0
             self._p = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.y_d = self._p
             self.y = -self._p  # sign-flipped state boundary copy -> inline holoso_fsgnop() in the state install
             self._p = x
@@ -465,7 +465,7 @@ def _and_gate(a: bool, b: bool, /):  # type: ignore[no-untyped-def]
     return a and b
 
 
-def _madd_only(a, b, c):  # type: ignore[no-untyped-def]
+def _madd_only(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
     return a * b + c
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -24,7 +24,7 @@ from holoso._backend.verilog import generate
 from holoso._frontend import lower
 from holoso._hir import optimize
 from holoso._lir import BoolRegRef, RegRef, build, pooled_write_word
-from holoso._mir import lower as lower_to_mir
+from holoso._mir import Mir, lower as lower_to_mir
 
 from .hdl.hdl_float_oracle import HDL_DIR, sources
 
@@ -37,7 +37,7 @@ def _ops(fmt: FloatFormat) -> OpConfig:
     )
 
 
-def _run(target, ops: OpConfig):  # type: ignore[no-untyped-def]
+def _run(target: object, ops: OpConfig) -> Mir:
     return lower_to_mir(optimize(lower(target)), ops)
 
 
@@ -65,7 +65,7 @@ def _elaborate(name: str, verilog: str, tmp_path: Path) -> None:
 
 
 def test_operator_instance_names_include_hardware_identity() -> None:
-    def scale(a: float, b: float):  # type: ignore[no-untyped-def]
+    def scale(a: float, b: float) -> float:
         return a * 4.0 + b * 8.0
 
     fmt = FloatFormat(6, 18)
@@ -85,7 +85,7 @@ def test_comparisons_share_one_pooled_fcmp_instance() -> None:
     # Comparisons live in mutually-exclusive blocks and execute sequentially, so they share a single holoso_fcmp
     # (the one-instance-per-operator pooling convention), its operands riding the ordinary microcode read-mux
     # lanes -- not one instance per comparison.
-    def kernel(x: float):  # type: ignore[no-untyped-def]
+    def kernel(x: float) -> float:
         if x > 1.0:
             y = x + 1.0
         elif x < -1.0:
@@ -127,7 +127,7 @@ endmodule
 
 @requires_iverilog
 def test_small_kernel_elaborates(tmp_path: Path) -> None:
-    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     fmt = FloatFormat(8, 24)
@@ -137,7 +137,7 @@ def test_small_kernel_elaborates(tmp_path: Path) -> None:
 
 @requires_iverilog
 def test_kernel_with_division_elaborates(tmp_path: Path) -> None:
-    def blend(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def blend(a: float, b: float, c: float) -> float:
         return a / b + c * 2.0
 
     fmt = FloatFormat(6, 18)
@@ -149,7 +149,7 @@ def test_kernel_with_division_elaborates(tmp_path: Path) -> None:
 def test_constant_only_module_elaborates(tmp_path: Path) -> None:
     # No inputs and an all-constant output => zero registers; NREG must floor to >=1 so the regfile parameter
     # guard does not instantiate its error stub (BUG1 regression).
-    def const_only():  # type: ignore[no-untyped-def]
+    def const_only() -> float:
         return 3.5
 
     fmt = FloatFormat(8, 24)
@@ -164,7 +164,7 @@ def test_boolean_output_port_is_one_bit_and_assigned() -> None:
             self.low = -1.0
             self.y = False
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> bool:
             if x > self.high:
                 self.y = True
             elif x < self.low:
@@ -182,7 +182,7 @@ def test_boolean_output_port_is_one_bit_and_assigned() -> None:
 
 
 def test_boolean_input_port_is_one_bit_and_loaded() -> None:
-    def passthrough(flag: bool):  # type: ignore[no-untyped-def]
+    def passthrough(flag: bool) -> bool:
         return flag
 
     fmt = FloatFormat(8, 24)
@@ -225,7 +225,7 @@ def test_boolean_only_stateful_module_elaborates(tmp_path: Path) -> None:
 def test_parameter_name_colliding_with_control_port_is_rejected() -> None:
     # A parameter named 'valid'/'ready' becomes data port in_valid/in_ready, colliding with the control ports and
     # producing un-elaboratable Verilog; LIR construction must reject it instead of emitting duplicate ports.
-    def collide(valid: float, ready: float):  # type: ignore[no-untyped-def]
+    def collide(valid: float, ready: float) -> float:
         return valid + ready
 
     fmt = FloatFormat(6, 18)
@@ -234,7 +234,7 @@ def test_parameter_name_colliding_with_control_port_is_rejected() -> None:
 
 
 def test_kernel_without_outputs_is_rejected() -> None:
-    def empty(x: float):  # type: ignore[no-untyped-def]
+    def empty(x: float) -> tuple[()]:
         return ()
 
     fmt = FloatFormat(6, 18)
@@ -252,7 +252,7 @@ def test_state_slot_folded_sign_coexists_with_sibling_port(tmp_path: Path) -> No
             self.y_d = 0.0
             self._p = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self.y_d = self._p
             self.y = -self._p  # sign-flipped state boundary copy -> inline holoso_fsgnop() in the state install
             self._p = x
@@ -358,7 +358,7 @@ def test_wide_multi_output_operator_elaborates_with_per_port_lanes(tmp_path: Pat
         boundary_step,
     )
     from holoso._lir._ir import BoolRegFileLayout
-    from holoso._operators import FloatHardwareOperator, FloatSignControl
+    from holoso._operators import FloatHardwareOperator, FloatSignControl, FloatValue
     from holoso._type import ScalarSignature, FloatType as ScalarFloatType
 
     _FETCH_LAG = 2  # datapath lag matching the 3-stage control fetch: one less than fetch_stages
@@ -383,7 +383,9 @@ def test_wide_multi_output_operator_elaborates_with_per_port_lanes(tmp_path: Pat
         def hdl_params(self) -> dict[str, int]:
             return {}
 
-        def evaluate(self, *operands, immediates=()):  # type: ignore[no-untyped-def]
+        def evaluate(
+            self, *operands: FloatValue | bool, immediates: tuple[int, ...] = ()
+        ) -> tuple[FloatValue | bool, ...]:
             a, b = self._validated_operands(operands, 2)
             return (a, b)  # semantics are irrelevant here; only the lane structure is under test
 
@@ -461,11 +463,11 @@ endmodule
     assert result.returncode == 0, result.stderr
 
 
-def _and_gate(a: bool, b: bool, /):  # type: ignore[no-untyped-def]
+def _and_gate(a: bool, b: bool, /) -> bool:
     return a and b
 
 
-def _madd_only(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+def _madd_only(a: float, b: float, c: float) -> float:
     return a * b + c
 
 

--- a/tests/test_cosim.py
+++ b/tests/test_cosim.py
@@ -1,6 +1,7 @@
 """Functional cosimulation: drive generated modules and check their outputs bit-for-bit against the model backend."""
 
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 import numpy as np
@@ -44,7 +45,7 @@ pytestmark = pytest.mark.cosim
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_small_kernel(sim: str) -> None:
-    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     run_cosim(sim, kernel, FloatFormat(8, 24), "kernel")
@@ -52,7 +53,7 @@ def test_cosim_small_kernel(sim: str) -> None:
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_division(sim: str) -> None:
-    def blend(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def blend(a: float, b: float, c: float) -> float:
         return a / b + c * 2.0
 
     run_cosim(sim, blend, FloatFormat(6, 18), "blend")
@@ -87,7 +88,7 @@ def test_cosim_ekf1_stateful(sim: str) -> None:
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_staged_kernel(sim: str) -> None:
-    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     fmt = FloatFormat(8, 24)
@@ -103,7 +104,7 @@ def test_cosim_staged_kernel(sim: str) -> None:
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_staged_division(sim: str) -> None:
-    def blend(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def blend(a: float, b: float, c: float) -> float:
         return a / b + (a - c)
 
     # Exercise the STAGE_ALIGN (fadd) and STAGE_INPUT (fdiv) knobs end-to-end -- the combos the staged-kernel misses.
@@ -191,7 +192,7 @@ def test_cosim_min_max(sim: str) -> None:
     # Binary min/max lower to holoso_fsort. Taking BOTH min and max of one pair fuses to a SINGLE firing that writes
     # two wide registers at once -- the first operator to do so -- so this proves the generated RTL lands both results
     # bit-exactly against the model. The |a|,|b| sort in a second firing exercises the operand sign conditioners.
-    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float) -> list[float]:
         return [min(a, b), max(a, b), min(abs(a), abs(b))]
 
     fmt = FloatFormat(8, 24)
@@ -250,7 +251,7 @@ class _UnusedBoolInputAccumulator:
     def __init__(self) -> None:
         self.y = 0.0
 
-    def __call__(self, flag: bool, x: float):  # type: ignore[no-untyped-def]
+    def __call__(self, flag: bool, x: float) -> float:
         self.y = self.y + x + 1.0
         return self.y
 
@@ -269,7 +270,7 @@ def test_cosim_shift_register_backpressure(sim: str, config: OperatorCase) -> No
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_unused_bool_input_keeps_cfg_state_timing(sim: str, config: OperatorCase) -> None:
     fmt = FloatFormat(6, 18)
-    vectors = [
+    vectors: list[Mapping[str, int]] = [
         {"flag": 0, "x": fmt.encode(2.0)},
         {"flag": 1, "x": fmt.encode(4.0)},
     ]
@@ -285,7 +286,7 @@ def test_cosim_unused_bool_input_keeps_cfg_state_timing(sim: str, config: Operat
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_new_operator_stages(sim: str) -> None:
-    def kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float, c: float) -> float:
         return (a - b) / c + a * b * 0.25  # fadd, fdiv, fmul, and fmul_ilog2 (the 2^-2 scale) all in one kernel
 
     # Exercise the newly-shipped ZKF knobs end-to-end: fadd STAGE_INPUT/STAGE_NORMALIZE/STAGE_PACK, fmul STAGE_PACK,
@@ -353,7 +354,7 @@ async def div0_errpc(dut):
 @pytest.mark.parametrize("config", PIPELINE_OP_CASES, ids=lambda config: config.label)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_div0_error(sim: str, config: OperatorCase) -> None:
-    def kdiv(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kdiv(a: float, b: float) -> float:
         return a / b
 
     fmt = FloatFormat(6, 18)
@@ -487,7 +488,7 @@ def test_cosim_mirrored_comparisons_swap_orientation(sim: str, config: OperatorC
     # RTL twin of test_schedule.test_commutative_comparator_swap_permutes_output_taps: mirrored comparisons over one
     # operand pair make the port assignment orient one comparator firing swapped (its lt tap moving to gt), so the
     # emitted module must still produce both relations bit-exactly through the permuted lane.
-    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float) -> list[float]:
         below = a < b
         above = b < a
         return [float(below), float(above)]
@@ -510,7 +511,7 @@ def test_cosim_chained_slots_keep_the_old_value_across_the_install(sim: str, con
 def test_cosim_select_kernels(sim: str, config: OperatorCase) -> None:
     # If-converted selects in RTL: both polarities of a max kernel, an arm-sign select (the negation rides the
     # operand conditioner), and a comparison -> select -> arithmetic cross-bank chain, in one kernel.
-    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float) -> float:
         m = a if a > b else b
         s = a if b > 0.0 else -a
         return m * 2.0 + s
@@ -537,7 +538,7 @@ def test_cosim_not_folding_sinks(sim: str, config: OperatorCase) -> None:
         def __init__(self) -> None:
             self._flip = False
 
-        def step(self, a: float, b: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float, b: float) -> float:
             old = self._flip
             self._flip = not self._flip
             gate = not (a > b)
@@ -553,7 +554,7 @@ def test_cosim_not_folding_sinks(sim: str, config: OperatorCase) -> None:
 def test_cosim_inverted_bool_phi_arm(sim: str, config: OperatorCase) -> None:
     # RTL twin of test_schedule.test_inverted_bool_phi_arm_installs_with_opposite_polarities: the conditional flag
     # negation rides the phi-arm install's inversion.
-    def kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float, c: float) -> list[float]:
         flag = a > b
         if c > 0.0:
             flag = not flag
@@ -574,7 +575,7 @@ def test_cosim_phi_coalescing_residual_install_conflict(sim: str, config: Operat
     # residual sign-folded else-arm install writes that register, so the soundness fixpoint de-coalesces ``a``. This
     # proves the de-coalesced residual install is bit-exact in RTL, not only against the Python cycle model. The
     # division keeps the diamond a real branch (un-if-converted), which is what creates the phi merge.
-    def kernel(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
+    def kernel(x: float, b: float, cc: float) -> list[float]:
         if b < cc:
             a = x
             z = 1.0
@@ -599,7 +600,7 @@ def test_cosim_not_over_loop_phi_and_inverted_public_state(sim: str, config: Ope
         def __init__(self) -> None:
             self.armed = False
 
-        def step(self, x: float):  # type: ignore[no-untyped-def]
+        def step(self, x: float) -> float:
             flag = x > 0.0
             w = x
             while w > 1.0:

--- a/tests/test_cosim.py
+++ b/tests/test_cosim.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.cosim
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_small_kernel(sim: str) -> None:
-    def kernel(a, b):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     run_cosim(sim, kernel, FloatFormat(8, 24), "kernel")
@@ -52,7 +52,7 @@ def test_cosim_small_kernel(sim: str) -> None:
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_division(sim: str) -> None:
-    def blend(a, b, c):  # type: ignore[no-untyped-def]
+    def blend(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return a / b + c * 2.0
 
     run_cosim(sim, blend, FloatFormat(6, 18), "blend")
@@ -87,7 +87,7 @@ def test_cosim_ekf1_stateful(sim: str) -> None:
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_staged_kernel(sim: str) -> None:
-    def kernel(a, b):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     fmt = FloatFormat(8, 24)
@@ -103,7 +103,7 @@ def test_cosim_staged_kernel(sim: str) -> None:
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_staged_division(sim: str) -> None:
-    def blend(a, b, c):  # type: ignore[no-untyped-def]
+    def blend(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return a / b + (a - c)
 
     # Exercise the STAGE_ALIGN (fadd) and STAGE_INPUT (fdiv) knobs end-to-end -- the combos the staged-kernel misses.
@@ -191,7 +191,7 @@ def test_cosim_min_max(sim: str) -> None:
     # Binary min/max lower to holoso_fsort. Taking BOTH min and max of one pair fuses to a SINGLE firing that writes
     # two wide registers at once -- the first operator to do so -- so this proves the generated RTL lands both results
     # bit-exactly against the model. The |a|,|b| sort in a second firing exercises the operand sign conditioners.
-    def kernel(a, b):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         return [min(a, b), max(a, b), min(abs(a), abs(b))]
 
     fmt = FloatFormat(8, 24)
@@ -250,7 +250,7 @@ class _UnusedBoolInputAccumulator:
     def __init__(self) -> None:
         self.y = 0.0
 
-    def __call__(self, flag: bool, x):  # type: ignore[no-untyped-def]
+    def __call__(self, flag: bool, x: float):  # type: ignore[no-untyped-def]
         self.y = self.y + x + 1.0
         return self.y
 
@@ -285,7 +285,7 @@ def test_cosim_unused_bool_input_keeps_cfg_state_timing(sim: str, config: Operat
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_new_operator_stages(sim: str) -> None:
-    def kernel(a, b, c):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return (a - b) / c + a * b * 0.25  # fadd, fdiv, fmul, and fmul_ilog2 (the 2^-2 scale) all in one kernel
 
     # Exercise the newly-shipped ZKF knobs end-to-end: fadd STAGE_INPUT/STAGE_NORMALIZE/STAGE_PACK, fmul STAGE_PACK,
@@ -353,7 +353,7 @@ async def div0_errpc(dut):
 @pytest.mark.parametrize("config", PIPELINE_OP_CASES, ids=lambda config: config.label)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_cosim_div0_error(sim: str, config: OperatorCase) -> None:
-    def kdiv(a, b):  # type: ignore[no-untyped-def]
+    def kdiv(a: float, b: float):  # type: ignore[no-untyped-def]
         return a / b
 
     fmt = FloatFormat(6, 18)
@@ -487,7 +487,7 @@ def test_cosim_mirrored_comparisons_swap_orientation(sim: str, config: OperatorC
     # RTL twin of test_schedule.test_commutative_comparator_swap_permutes_output_taps: mirrored comparisons over one
     # operand pair make the port assignment orient one comparator firing swapped (its lt tap moving to gt), so the
     # emitted module must still produce both relations bit-exactly through the permuted lane.
-    def kernel(a, b):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         below = a < b
         above = b < a
         return [float(below), float(above)]
@@ -510,7 +510,7 @@ def test_cosim_chained_slots_keep_the_old_value_across_the_install(sim: str, con
 def test_cosim_select_kernels(sim: str, config: OperatorCase) -> None:
     # If-converted selects in RTL: both polarities of a max kernel, an arm-sign select (the negation rides the
     # operand conditioner), and a comparison -> select -> arithmetic cross-bank chain, in one kernel.
-    def kernel(a, b):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         m = a if a > b else b
         s = a if b > 0.0 else -a
         return m * 2.0 + s
@@ -537,7 +537,7 @@ def test_cosim_not_folding_sinks(sim: str, config: OperatorCase) -> None:
         def __init__(self) -> None:
             self._flip = False
 
-        def step(self, a, b):  # type: ignore[no-untyped-def]
+        def step(self, a: float, b: float):  # type: ignore[no-untyped-def]
             old = self._flip
             self._flip = not self._flip
             gate = not (a > b)
@@ -553,7 +553,7 @@ def test_cosim_not_folding_sinks(sim: str, config: OperatorCase) -> None:
 def test_cosim_inverted_bool_phi_arm(sim: str, config: OperatorCase) -> None:
     # RTL twin of test_schedule.test_inverted_bool_phi_arm_installs_with_opposite_polarities: the conditional flag
     # negation rides the phi-arm install's inversion.
-    def kernel(a, b, c):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         flag = a > b
         if c > 0.0:
             flag = not flag
@@ -574,7 +574,7 @@ def test_cosim_phi_coalescing_residual_install_conflict(sim: str, config: Operat
     # residual sign-folded else-arm install writes that register, so the soundness fixpoint de-coalesces ``a``. This
     # proves the de-coalesced residual install is bit-exact in RTL, not only against the Python cycle model. The
     # division keeps the diamond a real branch (un-if-converted), which is what creates the phi merge.
-    def kernel(x, b, cc):  # type: ignore[no-untyped-def]
+    def kernel(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
         if b < cc:
             a = x
             z = 1.0
@@ -599,7 +599,7 @@ def test_cosim_not_over_loop_phi_and_inverted_public_state(sim: str, config: Ope
         def __init__(self) -> None:
             self.armed = False
 
-        def step(self, x):  # type: ignore[no-untyped-def]
+        def step(self, x: float):  # type: ignore[no-untyped-def]
             flag = x > 0.0
             w = x
             while w > 1.0:

--- a/tests/test_cosim_examples.py
+++ b/tests/test_cosim_examples.py
@@ -24,6 +24,8 @@ Still-excluded examples are frontend feature gaps (not verification scope), conf
   - finite_set_current_controller: ``UnsupportedConstruct`` -- nested/foreign attribute access.
 """
 
+from collections.abc import Mapping
+
 import pytest
 
 from holoso import FloatFormat
@@ -50,4 +52,5 @@ _SPEC_FORMATS = [
 @pytest.mark.parametrize("spec,fmt", _SPEC_FORMATS)
 def test_example_cosim(spec: ExampleSpec, fmt: FloatFormat, config: OperatorCase, sim: str) -> None:
     name = f"{spec.name}_{config.label}_e{fmt.wexp}m{fmt.wman}"
-    run_cosim(sim, spec.make_kernel(), fmt, name, ops=config.make_ops(fmt), vectors=spec.vectors(fmt))
+    vectors: list[Mapping[str, int]] = list(spec.vectors(fmt))
+    run_cosim(sim, spec.make_kernel(), fmt, name, ops=config.make_ops(fmt), vectors=vectors)

--- a/tests/test_cosim_sign.py
+++ b/tests/test_cosim_sign.py
@@ -16,7 +16,7 @@ class SignHold:
     def __init__(self) -> None:
         self.acc = 0.0
 
-    def __call__(self, a):
+    def __call__(self, a: float):
         prev = self.acc
         self.acc = -a
         return -prev

--- a/tests/test_cosim_sign.py
+++ b/tests/test_cosim_sign.py
@@ -16,7 +16,7 @@ class SignHold:
     def __init__(self) -> None:
         self.acc = 0.0
 
-    def __call__(self, a: float):
+    def __call__(self, a: float) -> float:
         prev = self.acc
         self.acc = -a
         return -prev

--- a/tests/test_cycle_model.py
+++ b/tests/test_cycle_model.py
@@ -120,7 +120,7 @@ def test_deep_loop_runs_in_bounded_memory() -> None:
     assert not model._pending  # noqa: SLF001
 
 
-def _count_down(n: float):  # type: ignore[no-untyped-def]
+def _count_down(n: float) -> float:
     # A runtime-trip-count loop: subtract 1.0 until the value is no longer positive. The trip count is the input, so
     # it can be made arbitrarily large to stress the model's bounded state.
     while n > 0.0:

--- a/tests/test_cycle_model.py
+++ b/tests/test_cycle_model.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 
 from holoso import FloatFormat
-from holoso._backend.numerical import NumericalSimulator
+from holoso._backend.numerical import ModelInput, ModelOutput, NumericalSimulator
 from holoso._frontend import lower
 from holoso._hir import optimize
 from holoso._lir import Lir, build
@@ -41,14 +41,14 @@ from schmitt_trigger import SchmittTrigger  # noqa: E402
 _FMT = FloatFormat(8, 36)
 
 
-def _random_inputs(lir: Lir, rng: random.Random) -> list[object]:
+def _random_inputs(lir: Lir, rng: random.Random) -> list[ModelInput]:
     return [
         bool(rng.randint(0, 1)) if type(load).__name__ == "BoolInputLoad" else rng.uniform(-3.0, 3.0)
         for load in lir.inputs
     ]
 
 
-def _drive(model: NumericalSimulator, inputs: list[object]) -> tuple[tuple[object, ...], int]:
+def _drive(model: NumericalSimulator, inputs: list[ModelInput]) -> tuple[list[ModelOutput], int]:
     model.set_inputs(*inputs)
     while not model.in_ready:
         model.tick(in_valid=False, out_ready=True)
@@ -81,12 +81,13 @@ def test_tick_and_call_agree(name: str, factory: Callable[[], Callable[..., obje
 def test_single_path_latency_is_the_static_initiation_interval(name: str) -> None:
     # A kernel with one forward path takes exactly ``initiation_interval - 1`` cycles from the accept edge (pc==1) to
     # out_valid (pc==LASTPC) -- the cycle count a caller recovers by counting ticks, here the static lower bound.
-    factory = {
+    factories: dict[str, Callable[[], Callable[..., object]]] = {
         "madd": lambda: madd.madd,
         "poly3": lambda: poly3.poly3,
         "cordic_sincos": lambda: CordicSinCos().__call__,
         "ekf1_stateless": lambda: update_x_P,
-    }[name]
+    }
+    factory = factories[name]
     lir = build(lower_to_mir(optimize(lower(factory())), default_ops(_FMT)), name, fetch_stages=3)
     model = NumericalSimulator(lir)
     rng = random.Random(7)
@@ -113,7 +114,7 @@ def test_deep_loop_runs_in_bounded_memory() -> None:
     shallow_cycles = _drive(NumericalSimulator(lir), [10.0])[1]
     model = NumericalSimulator(lir)
     out, deep_cycles = _drive(model, [20000.0])
-    assert abs(float(out[0])) <= 1e-3  # type: ignore[arg-type]
+    assert abs(float(out[0])) <= 1e-3
     assert deep_cycles > shallow_cycles * 100, "the deep run must genuinely iterate thousands of times"
     # The in-flight landing buffers drain every cycle, so after the transaction they hold nothing -- the state the
     # model retains does not grow with the trip count, which is what keeps an arbitrarily deep loop bounded.
@@ -141,7 +142,7 @@ def _count_down(n: float) -> float:
 # path is unified away, yet every realized transaction is the steady-state 20 cycles, which only this guard pins -- the
 # static metrics gate sees only the raised min_ii).
 _T, _F = True, False
-_WORST_CASE_LATENCY: dict[str, tuple[Callable[[], Callable[..., object]], list[list[object]], int]] = {
+_WORST_CASE_LATENCY: dict[str, tuple[Callable[[], Callable[..., object]], list[list[ModelInput]], int]] = {
     "schmitt_trigger": (lambda: SchmittTrigger().__call__, [[2.0], [-2.0], [0.0], [0.5], [-0.5], [3.0]], 6),
     "iir1_lpf": (lambda: IIR1LPF().__call__, [[1.0], [-2.0], [0.5], [3.0], [-1.5], [0.0]], 20),
     "quadrature_encoder": (

--- a/tests/test_cycle_model.py
+++ b/tests/test_cycle_model.py
@@ -120,7 +120,7 @@ def test_deep_loop_runs_in_bounded_memory() -> None:
     assert not model._pending  # noqa: SLF001
 
 
-def _count_down(n):  # type: ignore[no-untyped-def]
+def _count_down(n: float):  # type: ignore[no-untyped-def]
     # A runtime-trip-count loop: subtract 1.0 until the value is no longer positive. The trip count is the input, so
     # it can be made arbitrarily large to stress the model's bounded state.
     while n > 0.0:

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -34,7 +34,7 @@ class TwoCarried:
         self.s1 = -1.0
         self._s2 = 2.0
 
-    def step(self, a):  # type: ignore[no-untyped-def]
+    def step(self, a: float):  # type: ignore[no-untyped-def]
         w = 2.0
         while w > 0.0:
             if a > w:
@@ -45,7 +45,7 @@ class TwoCarried:
         return self.s1 + self._s2
 
 
-def coalesce_conflict(x, b, cc):  # type: ignore[no-untyped-def]
+def coalesce_conflict(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
     """
     The phi-coalescing residual-install hazard: ``a`` coalesces onto ``x`` while ``x`` is still live as ``z``'s arm,
     so the soundness fixpoint must de-coalesce. The fixpoint's de-coalescing is set-driven, so this exercises that its

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -34,7 +34,7 @@ class TwoCarried:
         self.s1 = -1.0
         self._s2 = 2.0
 
-    def step(self, a: float):  # type: ignore[no-untyped-def]
+    def step(self, a: float) -> float:
         w = 2.0
         while w > 0.0:
             if a > w:
@@ -45,7 +45,7 @@ class TwoCarried:
         return self.s1 + self._s2
 
 
-def coalesce_conflict(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
+def coalesce_conflict(x: float, b: float, cc: float) -> tuple[float, float, float]:
     """
     The phi-coalescing residual-install hazard: ``a`` coalesces onto ``x`` while ``x`` is still live as ``z``'s arm,
     so the soundness fixpoint must de-coalesce. The fixpoint's de-coalescing is set-driven, so this exercises that its

--- a/tests/test_example_reference.py
+++ b/tests/test_example_reference.py
@@ -49,7 +49,7 @@ def _quantize(value: float | bool, fmt: FloatFormat) -> float | bool:
     return value if isinstance(value, bool) else fmt.decode(fmt.encode(value))
 
 
-def _model_for(spec: ExampleSpec, fmt: FloatFormat):  # type: ignore[no-untyped-def]
+def _model_for(spec: ExampleSpec, fmt: FloatFormat) -> holoso.NumericalSimulator:
     # Built through the public facade, exactly as a user would; ``_lir.ops`` (read once below for the tolerance op
     # count) is the only internal datum the result does not expose publicly.
     return holoso.synthesize(spec.make_kernel(), default_ops(fmt), name=spec.name).numerical_model.elaborate()

--- a/tests/test_extended_operators.py
+++ b/tests/test_extended_operators.py
@@ -5,6 +5,7 @@ and asserts on observable output values against an INDEPENDENT reference.
 """
 
 import math
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -48,7 +49,7 @@ def _ops(*, with_round: bool = True, with_fma: bool = True, with_sort: bool = Tr
     )
 
 
-def _sim(fn, name: str):  # type: ignore[no-untyped-def]
+def _sim(fn: Callable[..., object], name: str) -> holoso.NumericalSimulator:
     return holoso.synthesize(fn, _ops(), name=name).numerical_model.elaborate()
 
 
@@ -100,7 +101,7 @@ _ROUND_VECTORS = [
 
 
 def test_round_modes_match_reference() -> None:
-    def kernel(x: float) -> float:
+    def kernel(x: float) -> tuple[float, float, float, float]:
         return (math.floor(x), math.ceil(x), math.trunc(x), round(x))
 
     sim = _sim(kernel, "round_all_modes")
@@ -113,7 +114,7 @@ def test_round_modes_match_reference() -> None:
 
 def test_round_dispatch_numpy_and_bare_name() -> None:
     # numpy.<name> under an alias, and bare names imported via ``from math import ...`` must both dispatch.
-    def kernel(x: float) -> float:
+    def kernel(x: float) -> tuple[float, float, float, float, float, float]:
         return (np.floor(x), np.ceil(x), np.trunc(x), floor(x), ceil(x), trunc(x))
 
     sim = _sim(kernel, "round_dispatch")
@@ -126,7 +127,7 @@ def test_round_dispatch_numpy_and_bare_name() -> None:
 def test_round_sign_folds_into_operand() -> None:
     # The input sign chain folds onto the rounder operand and is applied BEFORE rounding: floor(-x) is the rounder fed
     # -x, NOT a negation of floor(x). Asserts the directional modes against the directly-negated reference.
-    def kernel(x: float) -> float:
+    def kernel(x: float) -> tuple[float, float, float]:
         return (math.floor(-x), math.ceil(abs(x)), math.trunc(-x))
 
     sim = _sim(kernel, "round_sign_fold")
@@ -197,7 +198,7 @@ def test_fma_unconfigured_is_rejected() -> None:
 def test_intrinsic_dispatch_resolves_aliased_imports() -> None:
     # An aliased import binds a non-canonical local name to the real function object; dispatch resolves by callee
     # identity, so ``aliased_floor`` (= math.floor) lowers as floor and ``aliased_fma`` (= math.fma) as fma.
-    def kernel(a: float, b: float, c: float) -> float:
+    def kernel(a: float, b: float, c: float) -> tuple[float, float]:
         return (aliased_floor(a), aliased_fma(a, b, c))
 
     sim = _sim(kernel, "aliased_intrinsics")
@@ -246,7 +247,7 @@ def test_implicit_mul_add_contracts_to_fma_only_with_ffma() -> None:
 def test_implicit_fma_not_contracted_when_product_is_shared() -> None:
     # A product used by more than the add (here also returned) must NOT contract -- the rounded product is observed
     # elsewhere, so the add keeps double-rounding semantics even with ffma configured.
-    def kernel(a: float, b: float, c: float) -> float:
+    def kernel(a: float, b: float, c: float) -> tuple[float, float]:
         p = a * b
         return p + c, p
 
@@ -332,7 +333,7 @@ def test_min_max_match_reference() -> None:
     # min(a,b) and max(a,b) over the same pair fuse into one sorter firing that writes two wide registers at once;
     # both outputs are checked against the bit-preserving reference (FloatValue.sort), which the HDL bench anchors to
     # the RTL. The equal and infinity pairs pin the tie direction and the total-order handling of the extrema.
-    def kernel(a: float, b: float) -> float:
+    def kernel(a: float, b: float) -> tuple[float, float]:
         return (min(a, b), max(a, b))
 
     sim = _sim(kernel, "min_max_pair")
@@ -352,7 +353,7 @@ def test_min_max_match_reference() -> None:
 def test_min_max_sign_folds_into_operands() -> None:
     # Each operand's sign chain folds onto its sorter operand and is applied BEFORE the sort: min(-a, |b|) is the
     # sorter fed (-a, |b|). This drives the operand conditioners on a commutative multi-output operator.
-    def kernel(a: float, b: float) -> float:
+    def kernel(a: float, b: float) -> tuple[float, float]:
         return (min(-a, abs(b)), max(abs(a), -b))
 
     sim = _sim(kernel, "min_max_signs")
@@ -368,7 +369,7 @@ def test_min_max_sign_folds_into_operands() -> None:
 
 def test_min_max_dispatch_numpy() -> None:
     # numpy.minimum/maximum are the binary elementwise forms and must dispatch by callee identity to the sorter.
-    def kernel(a: float, b: float) -> float:
+    def kernel(a: float, b: float) -> tuple[float, float]:
         return (np.minimum(a, b), np.maximum(a, b))
 
     sim = _sim(kernel, "min_max_numpy")
@@ -399,7 +400,7 @@ def test_min_max_is_not_bit_commutative() -> None:
     # bit-commutative: swapping operands can flip the sign of a zero. Two mirrored mins over the same pair must each
     # keep their source operand order (the operator must not be marked commutative), or out_0's zero sign diverges
     # from the reference. At x=0, sign conditioning makes -0, exposing the tie.
-    def kernel(x: float, y: float) -> float:
+    def kernel(x: float, y: float) -> tuple[float, float]:
         return (min(-x, y), min(y, -x))
 
     sim = _sim(kernel, "min_max_mirror")

--- a/tests/test_extended_operators.py
+++ b/tests/test_extended_operators.py
@@ -53,6 +53,11 @@ def _sim(fn: Callable[..., object], name: str) -> holoso.NumericalSimulator:
     return holoso.synthesize(fn, _ops(), name=name).numerical_model.elaborate()
 
 
+def _bits(value: FloatValue | bool) -> int:
+    assert isinstance(value, FloatValue)
+    return value.bits
+
+
 def _round_ref(value: float, mode: int) -> int:
     """Independent reference: round the in-format value with Python's math/round, then re-encode. Exact at binary32."""
     fv = FloatValue.from_float(FMT, value)
@@ -109,7 +114,7 @@ def test_round_modes_match_reference() -> None:
     for value in _ROUND_VECTORS:
         out = sim.run(value)
         for index, mode in enumerate(modes_by_output):
-            assert out[index].bits == _round_ref(value, mode), f"value={value} output={index} mode={mode}"
+            assert _bits(out[index]) == _round_ref(value, mode), f"value={value} output={index} mode={mode}"
 
 
 def test_round_dispatch_numpy_and_bare_name() -> None:
@@ -121,7 +126,7 @@ def test_round_dispatch_numpy_and_bare_name() -> None:
     for value in _ROUND_VECTORS:
         out = sim.run(value)
         for index, mode in enumerate((1, 2, 3, 1, 2, 3)):
-            assert out[index].bits == _round_ref(value, mode), f"value={value} output={index}"
+            assert _bits(out[index]) == _round_ref(value, mode), f"value={value} output={index}"
 
 
 def test_round_sign_folds_into_operand() -> None:
@@ -133,9 +138,9 @@ def test_round_sign_folds_into_operand() -> None:
     sim = _sim(kernel, "round_sign_fold")
     for value in _ROUND_VECTORS:
         out = sim.run(value)
-        assert out[0].bits == _round_ref(-value, 1), f"floor(-x) value={value}"
-        assert out[1].bits == _round_ref(abs(value), 2), f"ceil(|x|) value={value}"
-        assert out[2].bits == _round_ref(-value, 3), f"trunc(-x) value={value}"
+        assert _bits(out[0]) == _round_ref(-value, 1), f"floor(-x) value={value}"
+        assert _bits(out[1]) == _round_ref(abs(value), 2), f"ceil(|x|) value={value}"
+        assert _bits(out[2]) == _round_ref(-value, 3), f"trunc(-x) value={value}"
 
 
 def test_round_ndigits_is_rejected() -> None:
@@ -169,7 +174,7 @@ def test_fma_matches_single_rounded_reference() -> None:
         ref = FloatValue.fma(
             FloatValue.from_float(FMT, a), FloatValue.from_float(FMT, b), FloatValue.from_float(FMT, c)
         )
-        assert sim.run(a, b, c)[0].bits == ref.bits, f"a={a} b={b} c={c}"
+        assert _bits(sim.run(a, b, c)[0]) == ref.bits, f"a={a} b={b} c={c}"
 
 
 def test_fma_sign_folds_per_operand() -> None:
@@ -184,7 +189,7 @@ def test_fma_sign_folds_per_operand() -> None:
         ref = FloatValue.fma(
             FloatValue.from_float(FMT, -a), FloatValue.from_float(FMT, abs(b)), FloatValue.from_float(FMT, -c)
         )
-        assert sim.run(a, b, c)[0].bits == ref.bits, f"a={a} b={b} c={c}"
+        assert _bits(sim.run(a, b, c)[0]) == ref.bits, f"a={a} b={b} c={c}"
 
 
 def test_fma_unconfigured_is_rejected() -> None:
@@ -204,8 +209,8 @@ def test_intrinsic_dispatch_resolves_aliased_imports() -> None:
     sim = _sim(kernel, "aliased_intrinsics")
     for a, b, c in [(2.7, 3.0, 1.0), (-1.5, 2.0, -0.5), (0.3, -4.0, 2.0), (-100.7, 1.5, 3.5)]:
         out = sim.run(a, b, c)
-        assert out[0].bits == _round_ref(a, 1), f"floor alias a={a}"
-        assert out[1].bits == FloatValue.fma(_v(a), _v(b), _v(c)).bits, f"fma alias a={a} b={b} c={c}"
+        assert _bits(out[0]) == _round_ref(a, 1), f"floor alias a={a}"
+        assert _bits(out[1]) == FloatValue.fma(_v(a), _v(b), _v(c)).bits, f"fma alias a={a} b={b} c={c}"
 
 
 @pytest.mark.skipif(hasattr(np, "fma"), reason="np.fma exists on this numpy and correctly dispatches to ffma")
@@ -213,7 +218,7 @@ def test_numpy_fma_is_rejected() -> None:
     # ``np.fma`` does not exist on this numpy, so it does not resolve to a real function and must not dispatch to ffma
     # by spelling alone (it would not run as plain Python either); the skip guards the numpy versions that do define it.
     def kernel(a: float, b: float, c: float) -> float:
-        return np.fma(a, b, c)  # type: ignore[attr-defined]
+        return np.fma(a, b, c)  # type: ignore[attr-defined, no-any-return]
 
     with pytest.raises(UnsupportedConstruct):
         holoso.synthesize(kernel, _ops(), name="numpy_fma")
@@ -238,8 +243,8 @@ def test_implicit_mul_add_contracts_to_fma_only_with_ffma() -> None:
         a, b, c = (float(np.float32(rng.standard_normal() * 9)) for _ in range(3))
         single = FloatValue.fma(_v(a), _v(b), _v(c)).bits
         double = ((_v(a) * _v(b)) + _v(c)).bits
-        assert fused.run(a, b, c)[0].bits == single, f"fused a={a} b={b} c={c}"
-        assert separate.run(a, b, c)[0].bits == double, f"separate a={a} b={b} c={c}"
+        assert _bits(fused.run(a, b, c)[0]) == single, f"fused a={a} b={b} c={c}"
+        assert _bits(separate.run(a, b, c)[0]) == double, f"separate a={a} b={b} c={c}"
         diverged += single != double
     assert diverged > 0, "expected single- and double-rounded results to differ on some inputs"
 
@@ -256,8 +261,8 @@ def test_implicit_fma_not_contracted_when_product_is_shared() -> None:
     for _ in range(5000):
         a, b, c = (float(np.float32(rng.standard_normal() * 9)) for _ in range(3))
         product = _v(a) * _v(b)
-        assert sim.run(a, b, c)[0].bits == (product + _v(c)).bits, f"add a={a} b={b} c={c}"
-        assert sim.run(a, b, c)[1].bits == product.bits, f"product a={a} b={b} c={c}"
+        assert _bits(sim.run(a, b, c)[0]) == (product + _v(c)).bits, f"add a={a} b={b} c={c}"
+        assert _bits(sim.run(a, b, c)[1]) == product.bits, f"product a={a} b={b} c={c}"
 
 
 def test_implicit_fma_contracts_across_blocks() -> None:
@@ -278,7 +283,7 @@ def test_implicit_fma_contracts_across_blocks() -> None:
     for _ in range(4000):
         a, b, c = (float(np.float32(rng.standard_normal() * 9 + 1e-3)) for _ in range(3))
         single = FloatValue.fma(_v(a), _v(b), _v(c)).bits
-        assert sim.run(a, b, c, True)[0].bits == single, f"taken-arm a={a} b={b} c={c}"
+        assert _bits(sim.run(a, b, c, True)[0]) == single, f"taken-arm a={a} b={b} c={c}"
         diverged += single != ((_v(a) * _v(b)) + _v(c)).bits
     assert (
         diverged > 0
@@ -298,7 +303,7 @@ def test_implicit_fma_distributes_product_sign() -> None:
     def k_neg_abs(a: float, b: float, c: float) -> float:
         return -abs(a * b) + c
 
-    cases = [
+    cases: list[tuple[Callable[[float, float, float], float], Callable[[float, float, float], int]]] = [
         (k_neg, lambda a, b, c: FloatValue.fma(_v(-a), _v(b), _v(c)).bits),
         (k_abs, lambda a, b, c: FloatValue.fma(_v(abs(a)), _v(abs(b)), _v(c)).bits),
         (k_neg_abs, lambda a, b, c: FloatValue.fma(_v(-abs(a)), _v(abs(b)), _v(c)).bits),
@@ -308,7 +313,7 @@ def test_implicit_fma_distributes_product_sign() -> None:
         sim = holoso.synthesize(kernel, _ops(with_fma=True), name=kernel.__name__).numerical_model.elaborate()
         for _ in range(2000):
             a, b, c = (float(np.float32(rng.standard_normal() * 9)) for _ in range(3))
-            assert sim.run(a, b, c)[0].bits == reference(a, b, c), f"{kernel.__name__} a={a} b={b} c={c}"
+            assert _bits(sim.run(a, b, c)[0]) == reference(a, b, c), f"{kernel.__name__} a={a} b={b} c={c}"
 
 
 # Pairs spanning equal values, both infinities, sign-crossing, zero, and ordinary magnitudes.
@@ -340,14 +345,14 @@ def test_min_max_match_reference() -> None:
     for a, b in _MINMAX_VECTORS:
         lo, hi = FloatValue.sort(_v(a), _v(b))
         out = sim.run(a, b)
-        assert out[0].bits == lo.bits, f"min a={a} b={b}"
-        assert out[1].bits == hi.bits, f"max a={a} b={b}"
+        assert _bits(out[0]) == lo.bits, f"min a={a} b={b}"
+        assert _bits(out[1]) == hi.bits, f"max a={a} b={b}"
     rng = np.random.default_rng(0x504)
     for _ in range(4000):
         a, b = (float(np.float32(rng.standard_normal() * 12)) for _ in range(2))
         lo, hi = FloatValue.sort(_v(a), _v(b))
         out = sim.run(a, b)
-        assert out[0].bits == lo.bits and out[1].bits == hi.bits, f"a={a} b={b}"
+        assert _bits(out[0]) == lo.bits and _bits(out[1]) == hi.bits, f"a={a} b={b}"
 
 
 def test_min_max_sign_folds_into_operands() -> None:
@@ -363,8 +368,8 @@ def test_min_max_sign_folds_into_operands() -> None:
         lo, _ignore = FloatValue.sort(_v(-a), _v(abs(b)))
         _ignore2, hi = FloatValue.sort(_v(abs(a)), _v(-b))
         out = sim.run(a, b)
-        assert out[0].bits == lo.bits, f"min(-a,|b|) a={a} b={b}"
-        assert out[1].bits == hi.bits, f"max(|a|,-b) a={a} b={b}"
+        assert _bits(out[0]) == lo.bits, f"min(-a,|b|) a={a} b={b}"
+        assert _bits(out[1]) == hi.bits, f"max(|a|,-b) a={a} b={b}"
 
 
 def test_min_max_dispatch_numpy() -> None:
@@ -376,7 +381,7 @@ def test_min_max_dispatch_numpy() -> None:
     for a, b in _MINMAX_VECTORS:
         lo, hi = FloatValue.sort(_v(a), _v(b))
         out = sim.run(a, b)
-        assert out[0].bits == lo.bits and out[1].bits == hi.bits, f"a={a} b={b}"
+        assert _bits(out[0]) == lo.bits and _bits(out[1]) == hi.bits, f"a={a} b={b}"
 
 
 def test_min_max_wrong_arity_is_rejected() -> None:
@@ -409,8 +414,8 @@ def test_min_max_is_not_bit_commutative() -> None:
         ref0 = FloatValue.sort(neg_x, _v(y))[0]
         ref1 = FloatValue.sort(_v(y), neg_x)[0]
         out = sim.run(x, y)
-        assert out[0].bits == ref0.bits, f"min(-x,y) x={x} y={y}"
-        assert out[1].bits == ref1.bits, f"min(y,-x) x={x} y={y}"
+        assert _bits(out[0]) == ref0.bits, f"min(-x,y) x={x} y={y}"
+        assert _bits(out[1]) == ref1.bits, f"min(y,-x) x={x} y={y}"
 
 
 def test_min_max_of_constants_fold() -> None:
@@ -422,7 +427,7 @@ def test_min_max_of_constants_fold() -> None:
     sim = holoso.synthesize(kernel, _ops(with_sort=False), name="min_max_fold").numerical_model.elaborate()
     for x in [0.0, 3.0, -1.5, 100.25]:
         ref = (_v(x) + _v(1.5)) + _v(2.5)
-        assert sim.run(x)[0].bits == ref.bits, f"x={x}"
+        assert _bits(sim.run(x)[0]) == ref.bits, f"x={x}"
 
 
 def test_min_max_nonfinite_constant_is_rejected() -> None:

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -100,7 +100,7 @@ def test_flatten_value_returns_leaves() -> None:
 
 
 def test_small_kernel_inputs_outputs_and_ops() -> None:
-    def kernel(a, b):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     hir = lower(kernel)
@@ -141,6 +141,15 @@ def test_unsupported_scalar_parameter_annotation_is_rejected() -> None:
         lower(passthrough)
 
 
+def test_missing_parameter_annotation_is_rejected() -> None:
+    # An unannotated parameter is rejected: there is no implicit float default.
+    def passthrough(value):  # type: ignore[no-untyped-def]
+        return value
+
+    with pytest.raises(UnsupportedConstruct, match="requires an explicit type annotation"):
+        lower(passthrough)
+
+
 def test_assert_is_ignored_with_info_message(caplog: pytest.LogCaptureFixture) -> None:
     # The whole test subtree -- the comparison and its nested call -- is dropped, so neither op reaches HIR.
     def with_assert(x: float):  # type: ignore[no-untyped-def]
@@ -178,7 +187,7 @@ def test_dropped_assert_walrus_used_later_is_unknown_name() -> None:
 
 
 def test_pow_expands_to_multiply_chain() -> None:
-    def cube(a):  # type: ignore[no-untyped-def]
+    def cube(a: float):  # type: ignore[no-untyped-def]
         return a**3
 
     hir = lower(cube)
@@ -186,7 +195,7 @@ def test_pow_expands_to_multiply_chain() -> None:
 
 
 def test_abs_lowers_to_semantic_operation() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return abs(a)
 
     hir = lower(f)
@@ -195,7 +204,7 @@ def test_abs_lowers_to_semantic_operation() -> None:
 
 
 def test_division_lowers_to_div() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a / b
 
     hir = lower(f)
@@ -215,7 +224,7 @@ def test_ekf1_stateless_structure() -> None:
 
 
 def test_static_for_loop_unrolls() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a
         for _ in range(3):
             x = x + a
@@ -227,7 +236,7 @@ def test_static_for_loop_unrolls() -> None:
 
 def test_for_loop_counter_is_a_compile_time_constant() -> None:
     # The counter indexes a constant table and sets a power-of-two shift exponent; both fold per unrolled trip.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         table = (1.0, 2.0, 4.0)
         y = a
         for i in range(3):
@@ -246,7 +255,7 @@ def test_dead_arm_attr_write_does_not_block_readonly_fold() -> None:
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self._flag:  # _flag is read-only False -> folds away; the return arm is dead
                 return x
             if False:
@@ -266,7 +275,7 @@ def test_static_comparison_dead_arm_does_not_block_readonly_fold() -> None:
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if 1.0 < 0.0:
                 self._flag = True  # noqa -- dead arm (statically-false comparison): must not assign _flag
             if self._flag:
@@ -286,7 +295,7 @@ def test_over_threshold_for_in_statically_dead_arm_is_skipped() -> None:
             self.flag = True
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.flag:
                 y = x
             else:
@@ -307,7 +316,7 @@ def test_zero_trip_for_write_does_not_mark_attribute_assigned() -> None:
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for _ in range(0):
                 self._flag = True  # noqa -- zero-trip loop: never runs
             if self._flag:
@@ -328,7 +337,7 @@ def test_zero_trip_self_attr_range_write_does_not_mark_attribute_assigned() -> N
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for _ in range(self.iterations):
                 self._flag = True  # noqa -- zero-trip loop: never runs
             if self._flag:
@@ -343,7 +352,7 @@ def test_zero_trip_self_attr_range_write_does_not_mark_attribute_assigned() -> N
 def test_nested_function_scope_does_not_shadow_global() -> None:
     # Regression (Codex): a name bound in a nested (here dead) def is a separate scope; it must not make the OUTER
     # function treat that name as local, which would shadow the numpy alias (or a builtin) at an earlier use.
-    def kernel(x):  # type: ignore[no-untyped-def]
+    def kernel(x: float):  # type: ignore[no-untyped-def]
         y = np.asarray([x])
         return y[0]
 
@@ -363,7 +372,7 @@ def test_globally_shadowed_range_is_rejected(tmp_path: Path) -> None:
     source = textwrap.dedent("""
         range = lambda n: [0, 0, 0]
 
-        def kernel(a):
+        def kernel(a: float):
             y = a
             for _ in range(3):
                 y = y + 1.0
@@ -375,7 +384,7 @@ def test_globally_shadowed_range_is_rejected(tmp_path: Path) -> None:
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    with pytest.raises(UnsupportedConstruct, match="range"):
+    with pytest.raises(UnsupportedConstruct, match="for-loop must iterate over range"):
         lower(module.kernel)
 
 
@@ -387,7 +396,7 @@ def test_constant_boolean_attribute_branch_folds() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.flag:
                 self.y = x
             return self.y
@@ -405,7 +414,7 @@ def test_numpy_boolean_attribute_branch_folds() -> None:
             self.flag = np.bool_(False)
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.flag:
                 self.y = x
             return self.y
@@ -423,7 +432,7 @@ def test_static_integer_comparison_branch_folds() -> None:
         def __init__(self) -> None:
             self.x = 0.0
 
-        def __call__(self, v):  # type: ignore[no-untyped-def]
+        def __call__(self, v: float):  # type: ignore[no-untyped-def]
             for i in range(3):
                 if i > 5:  # never true over range(3): x must not become state
                     self.x = v
@@ -437,7 +446,7 @@ def test_static_integer_comparison_branch_folds() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, v):  # type: ignore[no-untyped-def]
+        def __call__(self, v: float):  # type: ignore[no-untyped-def]
             for i in range(3):
                 if i > 0:  # true for i in {1, 2}: acc genuinely accumulates
                     self.acc = self.acc + v
@@ -459,7 +468,7 @@ def test_static_float_comparison_branch_folds() -> None:
             self.gain = 2.0
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.threshold > 1.0:
                 self.y = x
             if self.gain * 3.0 > 10.0:  # 6.0 > 10.0 is statically false
@@ -475,7 +484,7 @@ def test_static_float_comparison_branch_folds() -> None:
             self.threshold = 5.0
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.threshold > 1.0:  # 5.0 > 1.0 statically true: the write is taken
                 self.y = x
             return self.y
@@ -493,7 +502,7 @@ def test_dead_assignment_after_return_does_not_suppress_fold() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.flag:  # flag is read-only -> folds to the (empty) else arm
                 self.y = x
             result = self.y
@@ -529,7 +538,7 @@ def test_public_boolean_state_attribute_is_output() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, a, b):  # type: ignore[no-untyped-def]
+        def __call__(self, a: float, b: float):  # type: ignore[no-untyped-def]
             self.flag = a < b
             self.y = a
             return self.y
@@ -541,7 +550,7 @@ def test_public_boolean_state_attribute_is_output() -> None:
 
 def test_while_loop_lowers_to_back_edge() -> None:
     # A while loop lowers to preheader -> header(loop phi + exit branch) -> body(back-edge jump) -> exit(ret).
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a
         while x < 10.0:
             x = x + 1.0
@@ -558,7 +567,7 @@ def test_while_loop_lowers_to_back_edge() -> None:
 
 
 def test_while_loop_with_else_is_unsupported() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a
         while x < 10.0:
             x = x + 1.0
@@ -582,7 +591,7 @@ def test_loop_else_write_keeps_attribute_assigned_so_the_loop_else_is_rejected()
             self.flag = True
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.flag:
                 self.y = x
             else:
@@ -605,7 +614,7 @@ def test_while_else_write_keeps_attribute_assigned_so_the_while_else_is_rejected
             self.flag = True
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.flag:
                 self.y = x
             else:
@@ -620,7 +629,7 @@ def test_while_else_write_keeps_attribute_assigned_so_the_while_else_is_rejected
 
 
 def test_return_inside_while_is_unsupported() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a
         while x < 10.0:
             return x
@@ -630,7 +639,7 @@ def test_return_inside_while_is_unsupported() -> None:
         lower(f)
 
 
-def _helper_with_return_in_while(a):  # type: ignore[no-untyped-def]
+def _helper_with_return_in_while(a: float):  # type: ignore[no-untyped-def]
     while a > 0.0:
         return a
     return a + 1.0
@@ -640,7 +649,7 @@ def test_return_inside_inlined_callee_while_is_unsupported() -> None:
     # Regression (user): a return inside an inlined callee's while body is exempt from _reject_nested_return (the
     # callee's own return is consumed locally), so _lower_while must reject it on the body's lowered-a-return result --
     # otherwise the back-edge is emitted and the early return is silently dropped (the model would not reach Ret).
-    def kernel(x):  # type: ignore[no-untyped-def]
+    def kernel(x: float):  # type: ignore[no-untyped-def]
         return _helper_with_return_in_while(x)
 
     with pytest.raises(UnsupportedConstruct, match="return"):
@@ -654,7 +663,7 @@ def test_statically_false_while_is_skipped() -> None:
         def __init__(self) -> None:
             self.s = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             while False:
                 self.s = 1.0
             return x
@@ -664,7 +673,7 @@ def test_statically_false_while_is_skipped() -> None:
     assert [o.name for o in hir.outputs] == ["out_0"]
     assert len(hir.blocks) == 1  # the loop is skipped, no back-edge emitted
 
-    def dead_while_return(a):  # type: ignore[no-untyped-def]
+    def dead_while_return(a: float):  # type: ignore[no-untyped-def]
         while False:
             return a
         return a + 1.0
@@ -674,7 +683,7 @@ def test_statically_false_while_is_skipped() -> None:
 
 
 def test_for_loop_over_unroll_threshold_is_unsupported() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a
         for _ in range(1000):
             x = x + a
@@ -687,7 +696,7 @@ def test_for_loop_over_unroll_threshold_is_unsupported() -> None:
 def test_enormous_range_is_rejected_not_crashed() -> None:
     # Regression (Codex F10): a trip count beyond a C ssize_t must be rejected cleanly, not crash with OverflowError
     # from len(range(...)) (the unroll threshold is checked with a big-integer trip count).
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a
         for _ in range(100000000000000000000000000000000000000):
             x = x + a
@@ -698,7 +707,7 @@ def test_enormous_range_is_rejected_not_crashed() -> None:
 
 
 def test_range_zero_step_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a
         for _ in range(0, 10, 0):
             x = x + a
@@ -711,7 +720,7 @@ def test_range_zero_step_is_rejected() -> None:
 def test_divergent_loop_counter_as_static_index_is_rejected() -> None:
     # A counter left differing by the two branch arms must not leak as a trusted compile-time index: using it to index
     # a table afterwards is path-dependent and must be rejected, not silently compiled to one arm's value.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         table = (10.0, 20.0)
         if a > 0.0:
             for i in range(1):  # leaves i == 0
@@ -727,7 +736,7 @@ def test_divergent_loop_counter_as_static_index_is_rejected() -> None:
 
 def test_agreeing_loop_counter_as_static_index_after_branch() -> None:
     # When both arms leave the same counter value, it stays a usable compile-time index past the merge.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         table = (10.0, 20.0)
         if a > 0.0:
             for i in range(1):
@@ -750,7 +759,7 @@ def test_attribute_written_only_in_while_is_not_read_only() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             c = 3.0
             while c > 0.0:
                 self.acc = self.acc + x
@@ -776,7 +785,7 @@ def test_loop_carried_attr_in_statically_dead_arm_does_not_crash() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             c = 2.0
             while c > 0.0:
                 if 0.5 > 1.0:  # statically false: the only write of acc is unreachable
@@ -795,7 +804,7 @@ def test_loop_carried_attr_written_only_in_live_folded_arm() -> None:
         def __init__(self) -> None:
             self.b = 0.5
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             h = 1.0
             while h > 0.0:
                 if 1.5 <= 2.0:  # statically true: this arm's write is the reachable one
@@ -810,7 +819,7 @@ def test_loop_carried_attr_written_only_in_live_folded_arm() -> None:
 
 
 def test_unknown_global_is_unsupported() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a + UNDEFINED_GLOBAL  # type: ignore[name-defined]  # noqa: F821
 
     with pytest.raises(UnsupportedConstruct):
@@ -818,7 +827,7 @@ def test_unknown_global_is_unsupported() -> None:
 
 
 def test_missing_intrinsic_message() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return math.sqrt(a)
 
     with pytest.raises(MissingIntrinsic, match="sqrt"):
@@ -852,7 +861,7 @@ def test_returned_public_state_alias_is_deduped() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.y = x
             y = self.y
             return y
@@ -866,7 +875,7 @@ def test_mixed_return_dedupes_public_alias_keeps_distinct_leaf() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.y = x * 2.0
             a = self.y
             return (a, x)  # a aliases public self.y (deduped to state_y); x is distinct (keeps its positional out_1)
@@ -883,7 +892,7 @@ def test_return_value_equal_to_public_state_is_deduped_even_without_aliasing() -
         def __init__(self) -> None:
             self.last = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.last = x
             return x
 
@@ -898,7 +907,7 @@ def test_unreachable_state_write_is_ignored() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             return x
             self.y = x  # unreachable
 
@@ -914,7 +923,7 @@ def test_attribute_written_only_in_dead_code_reads_as_constant() -> None:
         def __init__(self) -> None:
             self.y = 5.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             r = x + self.y  # y folds to its snapshot 5.0 -- its only write is dead
             return r
             self.y = x  # unreachable
@@ -990,7 +999,7 @@ def test_nested_attribute_access_is_rejected() -> None:
 
 
 def test_tuple_build_and_index() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         z = a, b
         return [z[1], z[0]]
 
@@ -998,7 +1007,7 @@ def test_tuple_build_and_index() -> None:
 
 
 def test_list_slice() -> None:
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         v = [a, b, c]
         return v[1:3]
 
@@ -1006,7 +1015,7 @@ def test_list_slice() -> None:
 
 
 def test_vector_scalar_broadcast() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         v = [a, b]
         return v * 0.5
 
@@ -1016,7 +1025,7 @@ def test_vector_scalar_broadcast() -> None:
 
 
 def test_flatten_collapses_nesting() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         m = [[a], [b]]
         return m.flatten()
 
@@ -1024,7 +1033,7 @@ def test_flatten_collapses_nesting() -> None:
 
 
 def test_index_out_of_range_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         v = [a]
         return v[3]
 
@@ -1033,7 +1042,7 @@ def test_index_out_of_range_is_rejected() -> None:
 
 
 def test_indexing_a_scalar_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a[0]
 
     with pytest.raises(UnsupportedConstruct, match="index or slice a scalar"):
@@ -1041,7 +1050,7 @@ def test_indexing_a_scalar_is_rejected() -> None:
 
 
 def test_star_unpacking_a_scalar_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return [*a]
 
     with pytest.raises(UnsupportedConstruct, match="unpack"):
@@ -1050,7 +1059,7 @@ def test_star_unpacking_a_scalar_is_rejected() -> None:
 
 def test_tuple_unpacking_routes_values() -> None:
     # The right-hand side is built once before any binding, so a swap reads both sources first (no clobber).
-    def swap(a, b):  # type: ignore[no-untyped-def]
+    def swap(a: float, b: float):  # type: ignore[no-untyped-def]
         x, y = b, a
         return [x, y]
 
@@ -1060,7 +1069,7 @@ def test_tuple_unpacking_routes_values() -> None:
 
 
 def test_starred_and_nested_unpacking_route_values() -> None:
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         first, *rest = [a, b, c]
         r0, r1 = rest
         return [first, r0, r1]
@@ -1070,7 +1079,7 @@ def test_starred_and_nested_unpacking_route_values() -> None:
 
 
 def test_chained_assignment_binds_every_target() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = y = a + a
         return [x, y]
 
@@ -1080,7 +1089,7 @@ def test_chained_assignment_binds_every_target() -> None:
 
 
 def test_unpacking_a_scalar_source_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x, y = a
         return x + y
 
@@ -1089,7 +1098,7 @@ def test_unpacking_a_scalar_source_is_rejected() -> None:
 
 
 def test_unpacking_arity_mismatch_is_rejected() -> None:
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         x, y = [a, b, c]
         return x + y
 
@@ -1104,7 +1113,7 @@ def test_stateful_tuple_assignment_to_attributes() -> None:
             self.x = 1.0
             self.y = 2.0
 
-        def step(self, k):  # type: ignore[no-untyped-def]
+        def step(self, k: float):  # type: ignore[no-untyped-def]
             self.x, self.y = self.y, self.x + k
             return self.x
 
@@ -1116,7 +1125,7 @@ def test_stateful_tuple_assignment_to_attributes() -> None:
 def test_unpacked_name_shadows_global_callable() -> None:
     # A name bound only via tuple unpacking is local, so a same-named global function is not inlined at a call site;
     # this exercises _collect_local_names descending into unpacking targets.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         _addmul, b = a, a  # _addmul is now a local value (Python would raise 'float not callable' when called)
         return _addmul(b)
 
@@ -1124,12 +1133,12 @@ def test_unpacked_name_shadows_global_callable() -> None:
         lower(f)
 
 
-def _addmul(p, q):  # type: ignore[no-untyped-def]
+def _addmul(p: float, q: float):  # type: ignore[no-untyped-def]
     return [p + q, p * q]
 
 
 def test_inlined_global_function() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return _addmul(a, b)
 
     hir = lower(f)
@@ -1138,7 +1147,7 @@ def test_inlined_global_function() -> None:
 
 
 def test_inlined_global_with_star_args() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         v = [a, b]
         return _addmul(*v)
 
@@ -1147,20 +1156,20 @@ def test_inlined_global_with_star_args() -> None:
 
 
 def test_inline_arity_mismatch_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return _addmul(a)
 
     with pytest.raises(UnsupportedConstruct, match="positional arguments"):
         lower(f)
 
 
-def cbrt(x):  # type: ignore[no-untyped-def]
+def cbrt(x: float):  # type: ignore[no-untyped-def]
     return x * x  # a user-defined global whose name collides with the same-named intrinsic placeholder
 
 
 def test_user_global_function_shadows_intrinsic_name() -> None:
     # A module-level def named like an intrinsic is the caller's own function; Python would call it, so it is inlined.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return cbrt(a)
 
     assert _arith_count(lower(f), FloatMul) == 1  # the inlined x * x, not a MissingIntrinsic rejection
@@ -1168,7 +1177,7 @@ def test_user_global_function_shadows_intrinsic_name() -> None:
 
 def test_local_name_shadows_global_callable() -> None:
     # A parameter named like a global function refers to the parameter (a value), which is not callable.
-    def f(_addmul, a):  # type: ignore[no-untyped-def]
+    def f(_addmul: float, a: float):  # type: ignore[no-untyped-def]
         return _addmul(a)
 
     with pytest.raises(UnsupportedConstruct, match="not a callable"):
@@ -1176,7 +1185,7 @@ def test_local_name_shadows_global_callable() -> None:
 
 
 def test_flatten_on_a_scalar_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a.flatten()
 
     with pytest.raises(UnsupportedConstruct, match="aggregate"):
@@ -1194,7 +1203,7 @@ def test_boolean_in_float_arithmetic_is_rejected() -> None:
 
 
 def test_abs_accepts_a_star_unpacked_argument() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         v = [a]
         return abs(*v)
 
@@ -1202,12 +1211,12 @@ def test_abs_accepts_a_star_unpacked_argument() -> None:
 
 
 def test_unary_plus_is_scalar_identity_and_rejects_aggregates() -> None:
-    def scalar_ok(a):  # type: ignore[no-untyped-def]
+    def scalar_ok(a: float):  # type: ignore[no-untyped-def]
         return +a
 
     assert [o.name for o in lower(scalar_ok).outputs] == ["out_0"]
 
-    def aggregate_bad(a, b):  # type: ignore[no-untyped-def]
+    def aggregate_bad(a: float, b: float):  # type: ignore[no-untyped-def]
         v = [a, b]
         return +v
 
@@ -1218,7 +1227,7 @@ def test_unary_plus_is_scalar_identity_and_rejects_aggregates() -> None:
 def test_method_style_abs_call_is_rejected() -> None:
     # Only a bare-name abs(...) is the builtin; a method-style a.abs(b) must not be silently treated as it (which would
     # drop the receiver) -- there is no supported scalar method, so it is an unsupported call.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a.abs(b)
 
     with pytest.raises(UnsupportedConstruct, match="abs"):
@@ -1227,21 +1236,23 @@ def test_method_style_abs_call_is_rejected() -> None:
 
 def _rebind_globals(fn, **overrides):  # type: ignore[no-untyped-def]
     """A copy of ``fn`` whose module globals carry ``overrides`` (its source stays retrievable via the shared code)."""
-    return types.FunctionType(
+    copy = types.FunctionType(
         fn.__code__, {**fn.__globals__, **overrides}, fn.__name__, fn.__defaults__, fn.__closure__
     )
+    copy.__annotations__ = dict(fn.__annotations__)  # FunctionType does not copy these; the entry point reads them
+    return copy
 
 
 def test_noncallable_global_shadowing_builtin_is_rejected() -> None:
     # A non-callable global shadows the built-in (Python raises TypeError on the call), so the name is not the builtin
     # it spells; holoso must reject rather than silently emitting FloatAbs / the list-tuple identity.
-    def use_abs(a):  # type: ignore[no-untyped-def]
+    def use_abs(a: float):  # type: ignore[no-untyped-def]
         return abs(a)
 
-    def use_list(a):  # type: ignore[no-untyped-def]
+    def use_list(a: float):  # type: ignore[no-untyped-def]
         return list((a, a))
 
-    def use_tuple(a):  # type: ignore[no-untyped-def]
+    def use_tuple(a: float):  # type: ignore[no-untyped-def]
         return tuple((a, a))
 
     # ``None`` shadows too -- it is present-but-non-callable, distinct from an absent global (the _ABSENT sentinel).
@@ -1254,7 +1265,7 @@ def test_noncallable_global_shadowing_builtin_is_rejected() -> None:
 def test_callable_global_shadowing_abs_is_inlined_not_floatabs() -> None:
     # A callable global named ``abs`` is the caller's own function; Python would call it, so holoso inlines it instead
     # of emitting the FloatAbs builtin -- the non-callable guard must not disturb this legitimate shadow.
-    def use_abs(a):  # type: ignore[no-untyped-def]
+    def use_abs(a: float):  # type: ignore[no-untyped-def]
         return abs(a)
 
     hir = lower(_rebind_globals(use_abs, abs=cbrt))
@@ -1268,7 +1279,7 @@ def test_numpy_array_state_decomposes_like_a_list() -> None:
     class Filt:
         v: npt.NDArray[np.float64]  # shape-less annotation: holoso infers the length from the reset value
 
-        def step(self, a):  # type: ignore[no-untyped-def]
+        def step(self, a: float):  # type: ignore[no-untyped-def]
             self.v = self.v * a
 
     hir = lower(Filt(np.array([1.0, 2.0, 3.0])).step)
@@ -1283,7 +1294,7 @@ def test_jaxtyping_array_field_lowers_and_is_validated() -> None:
     class Filt:
         v: Float64[np.ndarray, "3"]
 
-        def step(self, a):  # type: ignore[no-untyped-def]
+        def step(self, a: float):  # type: ignore[no-untyped-def]
             self.v = self.v * a
 
     assert {s.name for s in lower(Filt(np.array([1.0, 2.0, 3.0])).step).state_slots} == {"v_0", "v_1", "v_2"}
@@ -1296,21 +1307,21 @@ def test_numpy_integer_array_values_coerce_to_real() -> None:
     class Filt:
         v: np.ndarray  # type: ignore[type-arg]
 
-        def step(self, a):  # type: ignore[no-untyped-def]
+        def step(self, a: float):  # type: ignore[no-untyped-def]
             self.v = self.v * a
 
     assert {s.name for s in lower(Filt(np.array([2, 3])).step).state_slots} == {"v_0", "v_1"}
 
 
 def test_numpy_asarray_is_identity_on_an_aggregate() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return np.asarray([a, b]).flatten()  # asarray of an array-like is identity in this compile-time model
 
     assert [o.name for o in lower(f).outputs] == ["out_0", "out_1"]
 
 
 def test_list_is_identity_on_an_aggregate() -> None:
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         v = [a, b, c]
         return list(v[0:2])
 
@@ -1318,7 +1329,7 @@ def test_list_is_identity_on_an_aggregate() -> None:
 
 
 def test_list_of_a_scalar_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return list(a)  # Python: list(scalar) is a TypeError -- a scalar is not iterable
 
     with pytest.raises(UnsupportedConstruct, match="list"):
@@ -1326,7 +1337,7 @@ def test_list_of_a_scalar_is_rejected() -> None:
 
 
 def test_tuple_is_identity_on_an_aggregate() -> None:
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         v = [a, b, c]
         return tuple(v[0:2])
 
@@ -1335,7 +1346,7 @@ def test_tuple_is_identity_on_an_aggregate() -> None:
 
 def test_numpy_alias_shadowed_by_a_local_is_not_numpy() -> None:
     # ``np`` is rebound to a local value, so ``np.asarray`` is a method call on that value, not the numpy function.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         np = [a]
         return np.asarray([a])
 
@@ -1346,7 +1357,7 @@ def test_numpy_alias_shadowed_by_a_local_is_not_numpy() -> None:
 def test_name_assigned_later_is_local_before_its_assignment() -> None:
     # A name assigned anywhere in a function is local throughout (Python's rule); using it as a global/builtin/numpy
     # before that assignment is invalid Python (UnboundLocalError), so holoso rejects it rather than seeing the global.
-    def shadows_numpy(a):  # type: ignore[no-untyped-def]
+    def shadows_numpy(a: float):  # type: ignore[no-untyped-def]
         y = np.asarray([a])
         np = [a]  # noqa: F841  # makes np local for the whole body
         return y
@@ -1354,7 +1365,7 @@ def test_name_assigned_later_is_local_before_its_assignment() -> None:
     with pytest.raises(UnsupportedConstruct):
         lower(shadows_numpy)
 
-    def shadows_builtin(a):  # type: ignore[no-untyped-def]
+    def shadows_builtin(a: float):  # type: ignore[no-untyped-def]
         y = abs(a)
         abs = [a]  # noqa: F841  # makes abs local for the whole body
         return y
@@ -1368,7 +1379,7 @@ def test_multidimensional_array_state_is_rejected() -> None:
     class Filt:
         m: np.ndarray  # type: ignore[type-arg]
 
-        def step(self, a):  # type: ignore[no-untyped-def]
+        def step(self, a: float):  # type: ignore[no-untyped-def]
             self.m = self.m * a
 
     with pytest.raises(UnsupportedConstruct, match="1-D"):
@@ -1396,7 +1407,7 @@ def test_vector_state_decomposes_to_per_element_slots() -> None:
         def __init__(self) -> None:
             self.v = [1.0, 2.0, 3.0]
 
-        def update(self, a):  # type: ignore[no-untyped-def]
+        def update(self, a: float):  # type: ignore[no-untyped-def]
             self.v = [self.v[0] + a, self.v[1], self.v[2]]
 
     hir = lower(Vec().update)
@@ -1409,7 +1420,7 @@ def test_vector_state_shape_mismatch_is_rejected() -> None:
         def __init__(self) -> None:
             self.v = [0.0, 0.0]
 
-        def update(self, a):  # type: ignore[no-untyped-def]
+        def update(self, a: float):  # type: ignore[no-untyped-def]
             self.v = [a]
 
     with pytest.raises(UnsupportedConstruct, match="2-element vector"):
@@ -1423,7 +1434,7 @@ def test_vector_state_nested_shape_is_rejected() -> None:
         def __init__(self) -> None:
             self.v = [0.0, 0.0]
 
-        def update(self, a, b):  # type: ignore[no-untyped-def]
+        def update(self, a: float, b: float):  # type: ignore[no-untyped-def]
             self.v = [[a, b]]
 
     with pytest.raises(UnsupportedConstruct, match="incompatible shape"):
@@ -1437,7 +1448,7 @@ def test_vector_state_slot_name_collision_is_rejected() -> None:
             self.v = [1.0]
             self.v_0 = 2.0
 
-        def update(self, a):  # type: ignore[no-untyped-def]
+        def update(self, a: float):  # type: ignore[no-untyped-def]
             self.v = [a]
             self.v_0 = a + 1.0
 
@@ -1446,7 +1457,7 @@ def test_vector_state_slot_name_collision_is_rejected() -> None:
 
 
 def test_keyword_only_params_become_inputs() -> None:
-    def f(a, *, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, *, b: float, c: float):  # type: ignore[no-untyped-def]
         return a + b + c
 
     assert lower(f).input_names() == ["a", "b", "c"]
@@ -1458,7 +1469,7 @@ def test_dataclass_instance_is_stateful() -> None:
         total: float
         gain: list  # type: ignore[type-arg]
 
-        def step(self, x):  # type: ignore[no-untyped-def]
+        def step(self, x: float):  # type: ignore[no-untyped-def]
             self.total = self.total + x * self.gain[0]
 
     hir = lower(Acc(0.0, [2.0]).step)
@@ -1476,7 +1487,7 @@ def test_first_sample_branch_if_converts_to_one_block() -> None:
             self.y = 0.0
             self._first = True
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self._first:
                 self._first = False
                 self.y = x
@@ -1502,7 +1513,7 @@ def test_nested_if_lowers_through_optimize() -> None:
         def __init__(self):  # type: ignore[no-untyped-def]
             self.y = 0.0
 
-        def __call__(self, x, w):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float, w: float):  # type: ignore[no-untyped-def]
             if x > 0.0:
                 if w > 0.0:
                     self.y = x
@@ -1525,7 +1536,7 @@ def test_attribute_written_on_one_arm_becomes_a_phi() -> None:
         def __init__(self):  # type: ignore[no-untyped-def]
             self.acc = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if x > 0.0:
                 self.acc = x
             return self.acc
@@ -1545,7 +1556,7 @@ def _op_count(hir, op_type):  # type: ignore[no-untyped-def]
 
 
 def test_boolean_and_in_condition_lowers_to_combinational_bool_and() -> None:
-    def f(x, a, b):  # type: ignore[no-untyped-def]
+    def f(x: float, a: float, b: float):  # type: ignore[no-untyped-def]
         return 1.0 if (x > a and x < b) else 0.0
 
     hir = lower(f)
@@ -1554,7 +1565,7 @@ def test_boolean_and_in_condition_lowers_to_combinational_bool_and() -> None:
 
 
 def test_boolean_or_lowers_to_combinational_bool_or() -> None:
-    def f(x, a, b):  # type: ignore[no-untyped-def]
+    def f(x: float, a: float, b: float):  # type: ignore[no-untyped-def]
         return 1.0 if (x < a or x > b) else 0.0
 
     hir = lower(f)
@@ -1563,7 +1574,7 @@ def test_boolean_or_lowers_to_combinational_bool_or() -> None:
 
 
 def test_not_lowers_to_combinational_bool_not() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return -1.0 if not (x > 0.0) else 1.0
 
     hir = lower(f)
@@ -1572,7 +1583,7 @@ def test_not_lowers_to_combinational_bool_not() -> None:
 
 
 def test_chained_comparison_lowers_to_two_comparisons_and_one_and() -> None:
-    def f(x, lo, hi):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         return 0.0 if lo < x < hi else x
 
     hir = lower(f)
@@ -1582,7 +1593,7 @@ def test_chained_comparison_lowers_to_two_comparisons_and_one_and() -> None:
 
 def test_chained_comparison_evaluates_each_operand_once() -> None:
     # The shared middle operand ``x`` feeds both comparisons but is evaluated once: only one Sub (x - 0.5) is built.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         x = a - 0.5
         return 0.0 if 0.0 < x < 1.0 else x
 
@@ -1598,20 +1609,20 @@ def test_nested_if_without_else_folds_into_one_and_branch() -> None:
     # ``if A: (if B: S)`` with no ``else`` on either is exactly ``if (A and B): S``: the frontend folds it to a single
     # branch (one combinational ``and``), NOT two nested jumps. Folded repeatedly, ``if A: if B: if C: S`` collapses to
     # one ``A and B and C`` branch. Regression: the nested form must compile identically to the hand-written ``and``.
-    def nested(x, lo, hi):  # type: ignore[no-untyped-def]
+    def nested(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         r = 0.0
         if x > lo:
             if x < hi:
                 r = 1.0
         return r
 
-    def manual(x, lo, hi):  # type: ignore[no-untyped-def]
+    def manual(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         r = 0.0
         if x > lo and x < hi:
             r = 1.0
         return r
 
-    def triple(x, lo, hi):  # type: ignore[no-untyped-def]
+    def triple(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         r = 0.0
         if x > lo:
             if x < hi:
@@ -1630,7 +1641,7 @@ def test_nested_if_with_outer_else_does_not_fold() -> None:
     # The fold must NOT trigger when the outer ``if`` has an ``else``: ``if A: (if B: S) else: T`` is not
     # ``if (A and B): S``, because T runs whenever ``not A``, whereas ``not (A and B)`` also covers A-and-not-B. Both
     # branches must survive and no spurious conjunction is synthesized.
-    def f(x, lo, hi):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         r = 0.0
         if x > lo:
             if x < hi:
@@ -1646,7 +1657,7 @@ def test_nested_if_with_outer_else_does_not_fold() -> None:
 def test_nested_if_fold_is_suppressed_when_the_inner_test_has_a_walrus() -> None:
     # The fold must NOT absorb an inner test that carries a walrus: nested, the walrus binds only when the outer test
     # holds, but ``A and B`` evaluates B unconditionally -- folding would over-bind it. The two branches must survive.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         r = 0.0
         if x > 0.0:
             if (t := x * 3.0) < 100.0:
@@ -1658,7 +1669,7 @@ def test_nested_if_fold_is_suppressed_when_the_inner_test_has_a_walrus() -> None
 
 def test_walrus_in_conditional_expression_arm_is_rejected() -> None:
     # A ternary arm is evaluated only when selected; a walrus binding there cannot leak across arms, so it is rejected.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return (t := 1.0) if x > 0.0 else (t := 2.0)
 
     with pytest.raises(UnsupportedConstruct, match="walrus"):
@@ -1669,7 +1680,7 @@ def test_walrus_in_and_or_operand_is_rejected() -> None:
     # An ``and``/``or`` operand may be short-circuited (statically dropped by the connective fold, or unevaluated in
     # Python), so whether its walrus binds cannot be reconciled between the scans and lowering -- rejected. (Regression:
     # the scan invalidated the target unconditionally while lowering short-circuited past it, desyncing the two.)
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         if x > 0.0 and (t := y) > 0.0:
             return t
         return 0.0
@@ -1679,7 +1690,7 @@ def test_walrus_in_and_or_operand_is_rejected() -> None:
 
 
 def test_walrus_in_chained_comparison_is_rejected() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         if x < 0.0 < (t := 5.0):
             return t
         return 0.0
@@ -1695,7 +1706,7 @@ def test_walrus_in_dead_or_unsupported_statement_still_scopes_the_name_local() -
     # Local-name collection is syntactic, as in Python: a walrus target is a function local throughout the body even in
     # dead or out-of-subset code, so it shadows a same-named global. Here the earlier ``range(_DEAD_WALRUS_GLOBAL)``
     # must see the runtime local (rejected), NOT silently fold the module int 3 from the global.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         v = x
         for _ in range(_DEAD_WALRUS_GLOBAL):
             v = v + 1.0
@@ -1710,7 +1721,7 @@ def test_walrus_in_a_nested_scope_default_scopes_the_name_in_the_enclosing_funct
     # A nested def/lambda is a separate scope, but its default-argument expressions execute in the ENCLOSING scope, so a
     # walrus there binds an enclosing local (as in Python). The earlier ``range(_DEAD_WALRUS_GLOBAL)`` must therefore
     # see the runtime local, not the module int -- even though the lambda is dead code that lowering never reaches.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         v = x
         for _ in range(_DEAD_WALRUS_GLOBAL):
             v = v + 1.0
@@ -1724,7 +1735,7 @@ def test_walrus_in_a_nested_scope_default_scopes_the_name_in_the_enclosing_funct
 def test_walrus_in_while_condition_is_rejected() -> None:
     # A while-condition walrus rebinds every iteration and its post-test value is the loop-exit value, which the header
     # phi does not capture; rejected rather than miscompiled.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         while (x := x - 1.0) > 0.0:
             pass
         return x
@@ -1739,7 +1750,7 @@ _WALRUS_SHADOWED_INT = 3  # a module global an inner walrus shadows in the test 
 def test_walrus_target_shadowing_a_global_int_is_a_runtime_local() -> None:
     # Python makes a walrus target a function local for the whole body, shadowing a same-named module global. Using it
     # as a static range bound must therefore see the runtime local (rejected), NOT silently fold the global's value.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         v = x
         if (_WALRUS_SHADOWED_INT := x) > 0.0:
             for _ in range(_WALRUS_SHADOWED_INT):  # the local float, not the module int 3
@@ -1757,7 +1768,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self = x
             return self.a
 
@@ -1765,7 +1776,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             y = (self := x)
             return self.a + y
 
@@ -1773,7 +1784,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self += x
             return self.a
 
@@ -1781,7 +1792,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for self in range(2):
                 pass
             return self.a
@@ -1790,7 +1801,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self, y = x, x
             return self.a + y
 
@@ -1806,13 +1817,13 @@ def test_writing_a_self_attribute_and_a_plain_local_named_self_are_accepted() ->
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.a = self.a + x
             return self.a
 
     lower(_StateWrite().__call__)  # no exception
 
-    def plain(x):  # type: ignore[no-untyped-def]
+    def plain(x: float):  # type: ignore[no-untyped-def]
         self = x  # an ordinary local in a plain function (no instance)
         return self + 1.0
 
@@ -1820,7 +1831,7 @@ def test_writing_a_self_attribute_and_a_plain_local_named_self_are_accepted() ->
 
 
 def test_conditional_expression_lowers_to_branch_and_phi() -> None:
-    def f(x, y, c):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
         return x if c > 0.0 else y
 
     hir = lower(f)
@@ -1829,7 +1840,7 @@ def test_conditional_expression_lowers_to_branch_and_phi() -> None:
 
 
 def test_nested_conditional_expression_clamp_lowers() -> None:
-    def f(x, lo, hi):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         return hi if x > hi else (lo if x < lo else x)
 
     hir = lower(f)
@@ -1838,7 +1849,7 @@ def test_nested_conditional_expression_clamp_lowers() -> None:
 
 
 def test_statically_true_connective_in_condition_does_not_branch() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return 1.0 if (1.0 < 2.0 and 3.0 > 2.0) else 0.0
 
     hir = lower(f)
@@ -1848,7 +1859,7 @@ def test_statically_true_connective_in_condition_does_not_branch() -> None:
 
 
 def test_statically_true_connective_operand_is_dropped() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return 1.0 if (True and x > 0.0) else 0.0
 
     hir = lower(f)
@@ -1859,7 +1870,7 @@ def test_statically_true_connective_operand_is_dropped() -> None:
 def test_non_boolean_connective_operand_is_rejected() -> None:
     # Python's value-returning ``and``/``or`` over non-booleans is out of subset: a float operand in a boolean
     # position must raise rather than silently feed a non-boolean into the logic.
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         return 1.0 if (x and y) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
@@ -1872,7 +1883,7 @@ def test_chained_comparison_with_boolean_operand_is_rejected() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             return 1.0 if 0.0 < self.flag < 1.0 else self.y  # noqa -- exercising the rejection
 
     with pytest.raises(UnsupportedConstruct, match="floating-point"):
@@ -1880,7 +1891,7 @@ def test_chained_comparison_with_boolean_operand_is_rejected() -> None:
 
 
 def test_not_of_non_boolean_is_rejected() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return 1.0 if not x else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
@@ -1888,7 +1899,7 @@ def test_not_of_non_boolean_is_rejected() -> None:
 
 
 def test_bool_cast_lowers_to_float_to_bool() -> None:
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         return 1.0 if bool(x) else y
 
     hir = lower(f)
@@ -1896,7 +1907,7 @@ def test_bool_cast_lowers_to_float_to_bool() -> None:
 
 
 def test_bool_of_a_boolean_is_identity() -> None:
-    def f(x, a):  # type: ignore[no-untyped-def]
+    def f(x: float, a: float):  # type: ignore[no-untyped-def]
         return 1.0 if bool(x > a) else 0.0
 
     hir = lower(f)
@@ -1905,7 +1916,7 @@ def test_bool_of_a_boolean_is_identity() -> None:
 
 
 def test_bool_cast_rejects_aggregate_argument() -> None:
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         return 1.0 if bool((x, y)) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="scalar"):
@@ -1913,7 +1924,7 @@ def test_bool_cast_rejects_aggregate_argument() -> None:
 
 
 def test_bool_cast_rejects_multiple_arguments() -> None:
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         return 1.0 if bool(x, y) else 0.0  # type: ignore[call-arg, arg-type]
 
     with pytest.raises(UnsupportedConstruct, match="single scalar"):
@@ -1921,7 +1932,7 @@ def test_bool_cast_rejects_multiple_arguments() -> None:
 
 
 def test_float_cast_of_bool_lowers_to_bool_to_float() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return float(x > 0.0)
 
     hir = lower(f)
@@ -1930,7 +1941,7 @@ def test_float_cast_of_bool_lowers_to_bool_to_float() -> None:
 
 
 def test_float_cast_of_float_is_identity() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return float(x) + 1.0
 
     hir = lower(f)
@@ -1939,7 +1950,7 @@ def test_float_cast_of_float_is_identity() -> None:
 
 
 def test_cross_domain_cast_chain_lowers() -> None:
-    def f(x, k):  # type: ignore[no-untyped-def]
+    def f(x: float, k: float):  # type: ignore[no-untyped-def]
         return float(x > 0.0) * k
 
     hir = lower(f)
@@ -1949,7 +1960,7 @@ def test_cross_domain_cast_chain_lowers() -> None:
 
 
 def test_float_cast_rejects_aggregate_argument() -> None:
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         return float((x, y))[0]  # type: ignore[index]
 
     with pytest.raises(UnsupportedConstruct, match="scalar"):
@@ -1960,7 +1971,7 @@ def test_non_boolean_or_operand_before_absorbing_constant_is_rejected() -> None:
     # Regression (Codex): ``x or True`` with a float x must be rejected, not folded to constant True. Python evaluates
     # x first and returns it when falsy, so a non-boolean operand reached before the absorbing constant cannot be
     # silently folded away -- it must be lowered and type-checked.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return 1.0 if (x or True) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
@@ -1981,11 +1992,11 @@ def test_callable_global_shadowing_bool_is_not_treated_as_the_builtin() -> None:
     # Regression (Codex): a callable global named ``bool`` (e.g. a callable instance) is what Python would call, so the
     # bare-name ``bool(x)`` must NOT be lowered as the builtin float->bool cast; it is rejected as an unsupported call.
     class AlwaysFalse:
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             return False
 
-    f = _fn_with_globals("f", "def f(x):\n    return 1.0 if bool(x) else 0.0\n", {"bool": AlwaysFalse()})
-    with pytest.raises(UnsupportedConstruct, match="bool"):
+    f = _fn_with_globals("f", "def f(x: float):\n    return 1.0 if bool(x) else 0.0\n", {"bool": AlwaysFalse()})
+    with pytest.raises(UnsupportedConstruct, match="unsupported call"):
         lower(f)
 
 
@@ -1993,7 +2004,7 @@ def test_static_bool_sees_through_bool_cast_so_return_in_branch_folds() -> None:
     # Regression (Codex round 2): the static evaluator must see through ``bool(<static bool>)`` so a guard like
     # ``if bool(True):`` folds to the taken arm with no branch -- otherwise the return in the dead arm is wrongly
     # rejected as a return-inside-a-branch.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         if bool(True):
             return 1.0
         return x  # unreachable; must not force a branch nor a return-in-branch rejection
@@ -2005,7 +2016,7 @@ def test_static_bool_sees_through_bool_cast_so_return_in_branch_folds() -> None:
 def test_static_bool_cast_short_circuits_a_dead_non_boolean_operand() -> None:
     # ``bool(False) and x`` short-circuits to False exactly like ``False and x``; the dead float operand is not
     # evaluated and must not be rejected (the static evaluator folds the bool() cast of a static bool).
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return 1.0 if (bool(False) and x) else 0.0
 
     hir = lower(f)
@@ -2015,7 +2026,7 @@ def test_static_bool_cast_short_circuits_a_dead_non_boolean_operand() -> None:
 
 def test_static_float_sees_through_float_cast_of_a_bool() -> None:
     # ``float(True) > 0.5`` folds: float(<static bool>) is 1.0/0.0, so the comparison and the ternary fold statically.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return x if float(True) > 0.5 else 0.0
 
     hir = lower(f)
@@ -2026,7 +2037,7 @@ def test_static_float_sees_through_float_cast_of_a_bool() -> None:
 def test_or_true_in_a_condition_folds_and_permits_a_return() -> None:
     # Regression (user): ``X or True`` (X a valid boolean) is the constant True, so the guard must fold to its taken
     # arm with no branch -- including allowing the return in that arm, which a runtime branch would reject.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         if x > 0.0 or True:
             return 1.0
         return x  # unreachable
@@ -2037,7 +2048,7 @@ def test_or_true_in_a_condition_folds_and_permits_a_return() -> None:
 
 
 def test_and_false_in_a_condition_folds_to_the_else_arm() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         if x > 0.0 and False:
             y = 1.0
         else:
@@ -2052,7 +2063,7 @@ def test_and_false_in_a_condition_folds_to_the_else_arm() -> None:
 def test_chained_comparison_with_a_static_true_link_collapses_the_dead_and() -> None:
     # ``0.0 < 1.0 < x`` is ``(0 < 1) and (1 < x)``; the static-true link folds, and the constant folder's identity
     # element collapses ``True and (1 < x)`` to just ``1 < x`` -- no residual dead AND.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return 1.0 if 0.0 < 1.0 < x else 0.0
 
     hir = optimize(lower(f))
@@ -2064,7 +2075,7 @@ def test_statically_false_while_still_type_checks_its_condition() -> None:
     # Regression (review): a statically-false ``while`` is skipped, but its condition must still be type-checked --
     # ``while x and False:`` with a non-boolean x must be rejected (symmetric with ``if x and False:``), not silently
     # accepted because the loop never runs.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         while x and False:
             x = x + 1.0
         return x
@@ -2074,7 +2085,7 @@ def test_statically_false_while_still_type_checks_its_condition() -> None:
 
 
 def test_statically_false_while_with_a_boolean_condition_is_skipped() -> None:
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         while x > 0.0 and False:  # a valid boolean condition that is statically false: the loop never runs
             x = x + 1.0
         return x
@@ -2085,7 +2096,7 @@ def test_statically_false_while_with_a_boolean_condition_is_skipped() -> None:
 def test_reachability_folds_through_a_bool_cast_of_a_connective() -> None:
     # ``bool(X or True)`` carries the truthiness of ``X or True`` (= True), so the guard folds and the return is
     # allowed.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         if bool(x > 0.0 or True):
             return 1.0
         return x
@@ -2096,7 +2107,7 @@ def test_reachability_folds_through_a_bool_cast_of_a_connective() -> None:
 def test_ternary_condition_with_equal_arms_folds() -> None:
     # ``True if x > 0.0 else True`` is True regardless of the (runtime) test, so the enclosing guard folds and the
     # return is not rejected as branch-nested (the inner ternary still lowers, but the outer ``if`` takes no branch).
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         if True if x > 0.0 else True:
             return 1.0
         return x
@@ -2113,7 +2124,7 @@ def test_readonly_scan_stops_at_a_returning_folded_arm() -> None:
             self.gate = True
             self.y = 0.0
 
-        def __call__(self, u):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float):  # type: ignore[no-untyped-def]
             if self.gate:
                 return u + 1.0
             self.y = u
@@ -2132,7 +2143,7 @@ def test_float_cast_connective_comparison_condition_folds_without_spurious_state
             self.y = 0.0
             self.z = 0.0
 
-        def __call__(self, u):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float):  # type: ignore[no-untyped-def]
             if float(u > 0.0 or True) > 0.5:
                 self.y = u
             else:
@@ -2155,7 +2166,7 @@ def test_absorbing_attribute_connective_keeps_a_dead_arm_attribute_read_only() -
             self.y = 0.0
             self.z = 0.0
 
-        def __call__(self, u):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float):  # type: ignore[no-untyped-def]
             if self.flag or True:
                 pass
             else:
@@ -2173,7 +2184,7 @@ def test_absorbing_attribute_connective_keeps_a_dead_arm_attribute_read_only() -
 def test_equal_arm_ternary_condition_leaves_no_dead_branch() -> None:
     # Regression (review #4): a ternary whose arms agree is that value with no branch, so a statically-false loop
     # guarded by one is skipped cleanly (no dead diamond left in the CFG).
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         while False if x > 0.0 else False:
             x = x + 1.0
         return x
@@ -2186,7 +2197,7 @@ def test_equal_arm_ternary_value_fold_does_not_bypass_operand_type_checks() -> N
     # reachability one. ``(float(x or True) > 0.5) if c else (float(x or True) > 0.5)`` has equal arms, but folding it
     # without lowering would skip type-checking ``x or True`` -- accepting a non-boolean x and miscompiling. It must
     # be rejected, exactly as the un-wrapped ``float(x or True) > 0.5`` is.
-    def f(x, c):  # type: ignore[no-untyped-def]
+    def f(x: float, c: float):  # type: ignore[no-untyped-def]
         return 1.0 if ((float(x or True) > 0.5) if c > 0.0 else (float(x or True) > 0.5)) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
@@ -2204,7 +2215,7 @@ def test_read_only_scan_does_not_misfold_a_reassigned_for_counter() -> None:
             self.y = 0.0
             self.z = 0.0
 
-        def __call__(self, u):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float):  # type: ignore[no-untyped-def]
             for i in range(1):
                 i = u  # the loop counter is reassigned to a runtime value
                 if i > 0.0:
@@ -2222,7 +2233,7 @@ def test_read_only_scan_does_not_misfold_a_reassigned_for_counter() -> None:
 def test_ternary_with_mismatched_scalar_arm_types_is_cleanly_rejected() -> None:
     # Regression (review): a conditional whose arms have different scalar types (a boolean and a float) is out of
     # subset; it must be rejected with a clear UnsupportedConstruct, not leak an internal phi type-mismatch error.
-    def f(x, c):  # type: ignore[no-untyped-def]
+    def f(x: float, c: float):  # type: ignore[no-untyped-def]
         return 1.0 if (False if c > 0.0 else x) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="different scalar types"):

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -31,6 +31,7 @@ from holoso._hir import (
     FloatRelational,
     FloatToBool,
     FloatType,
+    Hir,
     InPort,
     Jump,
     Operation,
@@ -44,7 +45,7 @@ from holoso._hir import (
 from ._modelref import flatten_value, output_names
 
 
-def _arith_count(hir, op_type):  # type: ignore[no-untyped-def]
+def _arith_count(hir: Hir, op_type: type) -> int:
     return sum(1 for n in hir.nodes.values() if isinstance(n, Operation) and type(n.operator) is op_type)
 
 
@@ -100,7 +101,7 @@ def test_flatten_value_returns_leaves() -> None:
 
 
 def test_small_kernel_inputs_outputs_and_ops() -> None:
-    def kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     hir = lower(kernel)
@@ -112,7 +113,7 @@ def test_small_kernel_inputs_outputs_and_ops() -> None:
 
 
 def test_bool_parameter_annotation_becomes_bool_input() -> None:
-    def passthrough(flag: bool):  # type: ignore[no-untyped-def]
+    def passthrough(flag: bool) -> bool:
         return flag
 
     hir = lower(passthrough)
@@ -124,7 +125,7 @@ def test_bool_parameter_annotation_becomes_bool_input() -> None:
 
 
 def test_float_parameter_annotation_remains_float_input() -> None:
-    def passthrough(value: float):  # type: ignore[no-untyped-def]
+    def passthrough(value: float) -> float:
         return value
 
     hir = lower(passthrough)
@@ -134,7 +135,7 @@ def test_float_parameter_annotation_remains_float_input() -> None:
 
 
 def test_unsupported_scalar_parameter_annotation_is_rejected() -> None:
-    def passthrough(value: int):  # type: ignore[no-untyped-def]
+    def passthrough(value: int) -> float:
         return value
 
     with pytest.raises(UnsupportedConstruct, match="parameter annotation"):
@@ -152,7 +153,7 @@ def test_missing_parameter_annotation_is_rejected() -> None:
 
 def test_assert_is_ignored_with_info_message(caplog: pytest.LogCaptureFixture) -> None:
     # The whole test subtree -- the comparison and its nested call -- is dropped, so neither op reaches HIR.
-    def with_assert(x: float):  # type: ignore[no-untyped-def]
+    def with_assert(x: float) -> float:
         assert abs(x) > 0.0
         return x + 1.0
 
@@ -166,7 +167,7 @@ def test_assert_is_ignored_with_info_message(caplog: pytest.LogCaptureFixture) -
 def test_walrus_in_assert_is_ignored_not_rejected() -> None:
     # A walrus even inside an and/or in an assert is ignored, not caught by the short-circuit-walrus pre-pass: the
     # assert is dropped and the unused binding simply vanishes, as under -O.
-    def unused_walrus(x: float):  # type: ignore[no-untyped-def]
+    def unused_walrus(x: float) -> float:
         assert (ok := x > 0.0) and True
         return x + 1.0
 
@@ -178,7 +179,7 @@ def test_dropped_assert_walrus_used_later_is_unknown_name() -> None:
     # syntactically), so a later use is a clean unknown-name error that shadows the same-named global rather than
     # silently reading it -- mirroring Python -O, which keeps the local and raises UnboundLocalError. The injected
     # ``y`` global is what makes this discriminating: were the target NOT kept local, the read would resolve to it.
-    def used_later(x: float):  # type: ignore[no-untyped-def]
+    def used_later(x: float) -> float:
         assert (y := x * 2.0) > 0.0
         return y
 
@@ -187,7 +188,7 @@ def test_dropped_assert_walrus_used_later_is_unknown_name() -> None:
 
 
 def test_pow_expands_to_multiply_chain() -> None:
-    def cube(a: float):  # type: ignore[no-untyped-def]
+    def cube(a: float) -> float:
         return a**3
 
     hir = lower(cube)
@@ -195,7 +196,7 @@ def test_pow_expands_to_multiply_chain() -> None:
 
 
 def test_abs_lowers_to_semantic_operation() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return abs(a)
 
     hir = lower(f)
@@ -204,7 +205,7 @@ def test_abs_lowers_to_semantic_operation() -> None:
 
 
 def test_division_lowers_to_div() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a / b
 
     hir = lower(f)
@@ -224,7 +225,7 @@ def test_ekf1_stateless_structure() -> None:
 
 
 def test_static_for_loop_unrolls() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a
         for _ in range(3):
             x = x + a
@@ -236,7 +237,7 @@ def test_static_for_loop_unrolls() -> None:
 
 def test_for_loop_counter_is_a_compile_time_constant() -> None:
     # The counter indexes a constant table and sets a power-of-two shift exponent; both fold per unrolled trip.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         table = (1.0, 2.0, 4.0)
         y = a
         for i in range(3):
@@ -255,7 +256,7 @@ def test_dead_arm_attr_write_does_not_block_readonly_fold() -> None:
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self._flag:  # _flag is read-only False -> folds away; the return arm is dead
                 return x
             if False:
@@ -275,7 +276,7 @@ def test_static_comparison_dead_arm_does_not_block_readonly_fold() -> None:
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if 1.0 < 0.0:
                 self._flag = True  # noqa -- dead arm (statically-false comparison): must not assign _flag
             if self._flag:
@@ -295,7 +296,7 @@ def test_over_threshold_for_in_statically_dead_arm_is_skipped() -> None:
             self.flag = True
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.flag:
                 y = x
             else:
@@ -316,7 +317,7 @@ def test_zero_trip_for_write_does_not_mark_attribute_assigned() -> None:
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for _ in range(0):
                 self._flag = True  # noqa -- zero-trip loop: never runs
             if self._flag:
@@ -337,7 +338,7 @@ def test_zero_trip_self_attr_range_write_does_not_mark_attribute_assigned() -> N
             self._flag = False
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for _ in range(self.iterations):
                 self._flag = True  # noqa -- zero-trip loop: never runs
             if self._flag:
@@ -352,11 +353,11 @@ def test_zero_trip_self_attr_range_write_does_not_mark_attribute_assigned() -> N
 def test_nested_function_scope_does_not_shadow_global() -> None:
     # Regression (Codex): a name bound in a nested (here dead) def is a separate scope; it must not make the OUTER
     # function treat that name as local, which would shadow the numpy alias (or a builtin) at an earlier use.
-    def kernel(x: float):  # type: ignore[no-untyped-def]
+    def kernel(x: float) -> float:
         y = np.asarray([x])
         return y[0]
 
-        def helper():  # type: ignore[no-untyped-def]  # noqa -- dead nested scope; its ``np`` is not the outer's
+        def helper() -> int:  # noqa -- dead nested scope; its ``np`` is not the outer's
             np = 1
             return np
 
@@ -372,7 +373,7 @@ def test_globally_shadowed_range_is_rejected(tmp_path: Path) -> None:
     source = textwrap.dedent("""
         range = lambda n: [0, 0, 0]
 
-        def kernel(a: float):
+        def kernel(a: float) -> float:
             y = a
             for _ in range(3):
                 y = y + 1.0
@@ -396,7 +397,7 @@ def test_constant_boolean_attribute_branch_folds() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.flag:
                 self.y = x
             return self.y
@@ -414,7 +415,7 @@ def test_numpy_boolean_attribute_branch_folds() -> None:
             self.flag = np.bool_(False)
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.flag:
                 self.y = x
             return self.y
@@ -432,7 +433,7 @@ def test_static_integer_comparison_branch_folds() -> None:
         def __init__(self) -> None:
             self.x = 0.0
 
-        def __call__(self, v: float):  # type: ignore[no-untyped-def]
+        def __call__(self, v: float) -> float:
             for i in range(3):
                 if i > 5:  # never true over range(3): x must not become state
                     self.x = v
@@ -446,7 +447,7 @@ def test_static_integer_comparison_branch_folds() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, v: float):  # type: ignore[no-untyped-def]
+        def __call__(self, v: float) -> float:
             for i in range(3):
                 if i > 0:  # true for i in {1, 2}: acc genuinely accumulates
                     self.acc = self.acc + v
@@ -468,7 +469,7 @@ def test_static_float_comparison_branch_folds() -> None:
             self.gain = 2.0
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.threshold > 1.0:
                 self.y = x
             if self.gain * 3.0 > 10.0:  # 6.0 > 10.0 is statically false
@@ -484,7 +485,7 @@ def test_static_float_comparison_branch_folds() -> None:
             self.threshold = 5.0
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.threshold > 1.0:  # 5.0 > 1.0 statically true: the write is taken
                 self.y = x
             return self.y
@@ -502,7 +503,7 @@ def test_dead_assignment_after_return_does_not_suppress_fold() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.flag:  # flag is read-only -> folds to the (empty) else arm
                 self.y = x
             result = self.y
@@ -538,7 +539,7 @@ def test_public_boolean_state_attribute_is_output() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, a: float, b: float):  # type: ignore[no-untyped-def]
+        def __call__(self, a: float, b: float) -> float:
             self.flag = a < b
             self.y = a
             return self.y
@@ -550,7 +551,7 @@ def test_public_boolean_state_attribute_is_output() -> None:
 
 def test_while_loop_lowers_to_back_edge() -> None:
     # A while loop lowers to preheader -> header(loop phi + exit branch) -> body(back-edge jump) -> exit(ret).
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a
         while x < 10.0:
             x = x + 1.0
@@ -567,7 +568,7 @@ def test_while_loop_lowers_to_back_edge() -> None:
 
 
 def test_while_loop_with_else_is_unsupported() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a
         while x < 10.0:
             x = x + 1.0
@@ -591,7 +592,7 @@ def test_loop_else_write_keeps_attribute_assigned_so_the_loop_else_is_rejected()
             self.flag = True
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.flag:
                 self.y = x
             else:
@@ -614,7 +615,7 @@ def test_while_else_write_keeps_attribute_assigned_so_the_while_else_is_rejected
             self.flag = True
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.flag:
                 self.y = x
             else:
@@ -629,7 +630,7 @@ def test_while_else_write_keeps_attribute_assigned_so_the_while_else_is_rejected
 
 
 def test_return_inside_while_is_unsupported() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a
         while x < 10.0:
             return x
@@ -639,7 +640,7 @@ def test_return_inside_while_is_unsupported() -> None:
         lower(f)
 
 
-def _helper_with_return_in_while(a: float):  # type: ignore[no-untyped-def]
+def _helper_with_return_in_while(a: float) -> float:
     while a > 0.0:
         return a
     return a + 1.0
@@ -649,7 +650,7 @@ def test_return_inside_inlined_callee_while_is_unsupported() -> None:
     # Regression (user): a return inside an inlined callee's while body is exempt from _reject_nested_return (the
     # callee's own return is consumed locally), so _lower_while must reject it on the body's lowered-a-return result --
     # otherwise the back-edge is emitted and the early return is silently dropped (the model would not reach Ret).
-    def kernel(x: float):  # type: ignore[no-untyped-def]
+    def kernel(x: float) -> float:
         return _helper_with_return_in_while(x)
 
     with pytest.raises(UnsupportedConstruct, match="return"):
@@ -663,7 +664,7 @@ def test_statically_false_while_is_skipped() -> None:
         def __init__(self) -> None:
             self.s = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             while False:
                 self.s = 1.0
             return x
@@ -673,7 +674,7 @@ def test_statically_false_while_is_skipped() -> None:
     assert [o.name for o in hir.outputs] == ["out_0"]
     assert len(hir.blocks) == 1  # the loop is skipped, no back-edge emitted
 
-    def dead_while_return(a: float):  # type: ignore[no-untyped-def]
+    def dead_while_return(a: float) -> float:
         while False:
             return a
         return a + 1.0
@@ -683,7 +684,7 @@ def test_statically_false_while_is_skipped() -> None:
 
 
 def test_for_loop_over_unroll_threshold_is_unsupported() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a
         for _ in range(1000):
             x = x + a
@@ -696,7 +697,7 @@ def test_for_loop_over_unroll_threshold_is_unsupported() -> None:
 def test_enormous_range_is_rejected_not_crashed() -> None:
     # Regression (Codex F10): a trip count beyond a C ssize_t must be rejected cleanly, not crash with OverflowError
     # from len(range(...)) (the unroll threshold is checked with a big-integer trip count).
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a
         for _ in range(100000000000000000000000000000000000000):
             x = x + a
@@ -707,7 +708,7 @@ def test_enormous_range_is_rejected_not_crashed() -> None:
 
 
 def test_range_zero_step_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a
         for _ in range(0, 10, 0):
             x = x + a
@@ -720,7 +721,7 @@ def test_range_zero_step_is_rejected() -> None:
 def test_divergent_loop_counter_as_static_index_is_rejected() -> None:
     # A counter left differing by the two branch arms must not leak as a trusted compile-time index: using it to index
     # a table afterwards is path-dependent and must be rejected, not silently compiled to one arm's value.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         table = (10.0, 20.0)
         if a > 0.0:
             for i in range(1):  # leaves i == 0
@@ -736,7 +737,7 @@ def test_divergent_loop_counter_as_static_index_is_rejected() -> None:
 
 def test_agreeing_loop_counter_as_static_index_after_branch() -> None:
     # When both arms leave the same counter value, it stays a usable compile-time index past the merge.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         table = (10.0, 20.0)
         if a > 0.0:
             for i in range(1):
@@ -759,7 +760,7 @@ def test_attribute_written_only_in_while_is_not_read_only() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             c = 3.0
             while c > 0.0:
                 self.acc = self.acc + x
@@ -785,7 +786,7 @@ def test_loop_carried_attr_in_statically_dead_arm_does_not_crash() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             c = 2.0
             while c > 0.0:
                 if 0.5 > 1.0:  # statically false: the only write of acc is unreachable
@@ -804,7 +805,7 @@ def test_loop_carried_attr_written_only_in_live_folded_arm() -> None:
         def __init__(self) -> None:
             self.b = 0.5
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             h = 1.0
             while h > 0.0:
                 if 1.5 <= 2.0:  # statically true: this arm's write is the reachable one
@@ -819,7 +820,7 @@ def test_loop_carried_attr_written_only_in_live_folded_arm() -> None:
 
 
 def test_unknown_global_is_unsupported() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a + UNDEFINED_GLOBAL  # type: ignore[name-defined]  # noqa: F821
 
     with pytest.raises(UnsupportedConstruct):
@@ -827,14 +828,14 @@ def test_unknown_global_is_unsupported() -> None:
 
 
 def test_missing_intrinsic_message() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return math.sqrt(a)
 
     with pytest.raises(MissingIntrinsic, match="sqrt"):
         lower(f)
 
 
-def _integrator_class():  # type: ignore[no-untyped-def]
+def _integrator_class() -> type:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from trapezoidal_leaky_streaming_integrator import TrapezoidalLeakyStreamingIntegrator
 
@@ -861,7 +862,7 @@ def test_returned_public_state_alias_is_deduped() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self.y = x
             y = self.y
             return y
@@ -875,7 +876,7 @@ def test_mixed_return_dedupes_public_alias_keeps_distinct_leaf() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> tuple[float, float]:
             self.y = x * 2.0
             a = self.y
             return (a, x)  # a aliases public self.y (deduped to state_y); x is distinct (keeps its positional out_1)
@@ -892,7 +893,7 @@ def test_return_value_equal_to_public_state_is_deduped_even_without_aliasing() -
         def __init__(self) -> None:
             self.last = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self.last = x
             return x
 
@@ -907,7 +908,7 @@ def test_unreachable_state_write_is_ignored() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             return x
             self.y = x  # unreachable
 
@@ -923,7 +924,7 @@ def test_attribute_written_only_in_dead_code_reads_as_constant() -> None:
         def __init__(self) -> None:
             self.y = 5.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             r = x + self.y  # y folds to its snapshot 5.0 -- its only write is dead
             return r
             self.y = x  # unreachable
@@ -999,7 +1000,7 @@ def test_nested_attribute_access_is_rejected() -> None:
 
 
 def test_tuple_build_and_index() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         z = a, b
         return [z[1], z[0]]
 
@@ -1007,7 +1008,7 @@ def test_tuple_build_and_index() -> None:
 
 
 def test_list_slice() -> None:
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> list[float]:
         v = [a, b, c]
         return v[1:3]
 
@@ -1015,7 +1016,7 @@ def test_list_slice() -> None:
 
 
 def test_vector_scalar_broadcast() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         v = [a, b]
         return v * 0.5
 
@@ -1025,7 +1026,7 @@ def test_vector_scalar_broadcast() -> None:
 
 
 def test_flatten_collapses_nesting() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         m = [[a], [b]]
         return m.flatten()
 
@@ -1033,7 +1034,7 @@ def test_flatten_collapses_nesting() -> None:
 
 
 def test_index_out_of_range_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         v = [a]
         return v[3]
 
@@ -1042,7 +1043,7 @@ def test_index_out_of_range_is_rejected() -> None:
 
 
 def test_indexing_a_scalar_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a[0]
 
     with pytest.raises(UnsupportedConstruct, match="index or slice a scalar"):
@@ -1050,7 +1051,7 @@ def test_indexing_a_scalar_is_rejected() -> None:
 
 
 def test_star_unpacking_a_scalar_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return [*a]
 
     with pytest.raises(UnsupportedConstruct, match="unpack"):
@@ -1059,7 +1060,7 @@ def test_star_unpacking_a_scalar_is_rejected() -> None:
 
 def test_tuple_unpacking_routes_values() -> None:
     # The right-hand side is built once before any binding, so a swap reads both sources first (no clobber).
-    def swap(a: float, b: float):  # type: ignore[no-untyped-def]
+    def swap(a: float, b: float) -> list[float]:
         x, y = b, a
         return [x, y]
 
@@ -1069,7 +1070,7 @@ def test_tuple_unpacking_routes_values() -> None:
 
 
 def test_starred_and_nested_unpacking_route_values() -> None:
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> list[float]:
         first, *rest = [a, b, c]
         r0, r1 = rest
         return [first, r0, r1]
@@ -1079,7 +1080,7 @@ def test_starred_and_nested_unpacking_route_values() -> None:
 
 
 def test_chained_assignment_binds_every_target() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> list[float]:
         x = y = a + a
         return [x, y]
 
@@ -1089,7 +1090,7 @@ def test_chained_assignment_binds_every_target() -> None:
 
 
 def test_unpacking_a_scalar_source_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x, y = a
         return x + y
 
@@ -1098,7 +1099,7 @@ def test_unpacking_a_scalar_source_is_rejected() -> None:
 
 
 def test_unpacking_arity_mismatch_is_rejected() -> None:
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> float:
         x, y = [a, b, c]
         return x + y
 
@@ -1113,7 +1114,7 @@ def test_stateful_tuple_assignment_to_attributes() -> None:
             self.x = 1.0
             self.y = 2.0
 
-        def step(self, k: float):  # type: ignore[no-untyped-def]
+        def step(self, k: float) -> float:
             self.x, self.y = self.y, self.x + k
             return self.x
 
@@ -1125,7 +1126,7 @@ def test_stateful_tuple_assignment_to_attributes() -> None:
 def test_unpacked_name_shadows_global_callable() -> None:
     # A name bound only via tuple unpacking is local, so a same-named global function is not inlined at a call site;
     # this exercises _collect_local_names descending into unpacking targets.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         _addmul, b = a, a  # _addmul is now a local value (Python would raise 'float not callable' when called)
         return _addmul(b)
 
@@ -1133,12 +1134,12 @@ def test_unpacked_name_shadows_global_callable() -> None:
         lower(f)
 
 
-def _addmul(p: float, q: float):  # type: ignore[no-untyped-def]
+def _addmul(p: float, q: float) -> list[float]:
     return [p + q, p * q]
 
 
 def test_inlined_global_function() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         return _addmul(a, b)
 
     hir = lower(f)
@@ -1147,7 +1148,7 @@ def test_inlined_global_function() -> None:
 
 
 def test_inlined_global_with_star_args() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         v = [a, b]
         return _addmul(*v)
 
@@ -1156,20 +1157,20 @@ def test_inlined_global_with_star_args() -> None:
 
 
 def test_inline_arity_mismatch_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return _addmul(a)
 
     with pytest.raises(UnsupportedConstruct, match="positional arguments"):
         lower(f)
 
 
-def cbrt(x: float):  # type: ignore[no-untyped-def]
+def cbrt(x: float) -> float:
     return x * x  # a user-defined global whose name collides with the same-named intrinsic placeholder
 
 
 def test_user_global_function_shadows_intrinsic_name() -> None:
     # A module-level def named like an intrinsic is the caller's own function; Python would call it, so it is inlined.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return cbrt(a)
 
     assert _arith_count(lower(f), FloatMul) == 1  # the inlined x * x, not a MissingIntrinsic rejection
@@ -1177,7 +1178,7 @@ def test_user_global_function_shadows_intrinsic_name() -> None:
 
 def test_local_name_shadows_global_callable() -> None:
     # A parameter named like a global function refers to the parameter (a value), which is not callable.
-    def f(_addmul: float, a: float):  # type: ignore[no-untyped-def]
+    def f(_addmul: float, a: float) -> float:
         return _addmul(a)
 
     with pytest.raises(UnsupportedConstruct, match="not a callable"):
@@ -1185,7 +1186,7 @@ def test_local_name_shadows_global_callable() -> None:
 
 
 def test_flatten_on_a_scalar_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a.flatten()
 
     with pytest.raises(UnsupportedConstruct, match="aggregate"):
@@ -1195,7 +1196,7 @@ def test_flatten_on_a_scalar_is_rejected() -> None:
 def test_boolean_in_float_arithmetic_is_rejected() -> None:
     # Boolean literals are supported as values (branch conditions, boolean state), but arithmetic on them is not:
     # negating a boolean fails the float operator's operand-type check.
-    def f():  # type: ignore[no-untyped-def]
+    def f() -> float:
         return -True
 
     with pytest.raises((UnsupportedConstruct, ValueError)):
@@ -1203,7 +1204,7 @@ def test_boolean_in_float_arithmetic_is_rejected() -> None:
 
 
 def test_abs_accepts_a_star_unpacked_argument() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         v = [a]
         return abs(*v)
 
@@ -1211,12 +1212,12 @@ def test_abs_accepts_a_star_unpacked_argument() -> None:
 
 
 def test_unary_plus_is_scalar_identity_and_rejects_aggregates() -> None:
-    def scalar_ok(a: float):  # type: ignore[no-untyped-def]
+    def scalar_ok(a: float) -> float:
         return +a
 
     assert [o.name for o in lower(scalar_ok).outputs] == ["out_0"]
 
-    def aggregate_bad(a: float, b: float):  # type: ignore[no-untyped-def]
+    def aggregate_bad(a: float, b: float) -> list[float]:
         v = [a, b]
         return +v
 
@@ -1227,14 +1228,14 @@ def test_unary_plus_is_scalar_identity_and_rejects_aggregates() -> None:
 def test_method_style_abs_call_is_rejected() -> None:
     # Only a bare-name abs(...) is the builtin; a method-style a.abs(b) must not be silently treated as it (which would
     # drop the receiver) -- there is no supported scalar method, so it is an unsupported call.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a.abs(b)
 
     with pytest.raises(UnsupportedConstruct, match="abs"):
         lower(f)
 
 
-def _rebind_globals(fn, **overrides):  # type: ignore[no-untyped-def]
+def _rebind_globals(fn: types.FunctionType, **overrides: object) -> types.FunctionType:
     """A copy of ``fn`` whose module globals carry ``overrides`` (its source stays retrievable via the shared code)."""
     copy = types.FunctionType(
         fn.__code__, {**fn.__globals__, **overrides}, fn.__name__, fn.__defaults__, fn.__closure__
@@ -1246,13 +1247,13 @@ def _rebind_globals(fn, **overrides):  # type: ignore[no-untyped-def]
 def test_noncallable_global_shadowing_builtin_is_rejected() -> None:
     # A non-callable global shadows the built-in (Python raises TypeError on the call), so the name is not the builtin
     # it spells; holoso must reject rather than silently emitting FloatAbs / the list-tuple identity.
-    def use_abs(a: float):  # type: ignore[no-untyped-def]
+    def use_abs(a: float) -> float:
         return abs(a)
 
-    def use_list(a: float):  # type: ignore[no-untyped-def]
+    def use_list(a: float) -> float:
         return list((a, a))
 
-    def use_tuple(a: float):  # type: ignore[no-untyped-def]
+    def use_tuple(a: float) -> float:
         return tuple((a, a))
 
     # ``None`` shadows too -- it is present-but-non-callable, distinct from an absent global (the _ABSENT sentinel).
@@ -1265,7 +1266,7 @@ def test_noncallable_global_shadowing_builtin_is_rejected() -> None:
 def test_callable_global_shadowing_abs_is_inlined_not_floatabs() -> None:
     # A callable global named ``abs`` is the caller's own function; Python would call it, so holoso inlines it instead
     # of emitting the FloatAbs builtin -- the non-callable guard must not disturb this legitimate shadow.
-    def use_abs(a: float):  # type: ignore[no-untyped-def]
+    def use_abs(a: float) -> float:
         return abs(a)
 
     hir = lower(_rebind_globals(use_abs, abs=cbrt))
@@ -1279,7 +1280,7 @@ def test_numpy_array_state_decomposes_like_a_list() -> None:
     class Filt:
         v: npt.NDArray[np.float64]  # shape-less annotation: holoso infers the length from the reset value
 
-        def step(self, a: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float) -> None:
             self.v = self.v * a
 
     hir = lower(Filt(np.array([1.0, 2.0, 3.0])).step)
@@ -1294,7 +1295,7 @@ def test_jaxtyping_array_field_lowers_and_is_validated() -> None:
     class Filt:
         v: Float64[np.ndarray, "3"]
 
-        def step(self, a: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float) -> None:
             self.v = self.v * a
 
     assert {s.name for s in lower(Filt(np.array([1.0, 2.0, 3.0])).step).state_slots} == {"v_0", "v_1", "v_2"}
@@ -1307,21 +1308,21 @@ def test_numpy_integer_array_values_coerce_to_real() -> None:
     class Filt:
         v: np.ndarray  # type: ignore[type-arg]
 
-        def step(self, a: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float) -> None:
             self.v = self.v * a
 
     assert {s.name for s in lower(Filt(np.array([2, 3])).step).state_slots} == {"v_0", "v_1"}
 
 
 def test_numpy_asarray_is_identity_on_an_aggregate() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         return np.asarray([a, b]).flatten()  # asarray of an array-like is identity in this compile-time model
 
     assert [o.name for o in lower(f).outputs] == ["out_0", "out_1"]
 
 
 def test_list_is_identity_on_an_aggregate() -> None:
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> list[float]:
         v = [a, b, c]
         return list(v[0:2])
 
@@ -1329,7 +1330,7 @@ def test_list_is_identity_on_an_aggregate() -> None:
 
 
 def test_list_of_a_scalar_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return list(a)  # Python: list(scalar) is a TypeError -- a scalar is not iterable
 
     with pytest.raises(UnsupportedConstruct, match="list"):
@@ -1337,7 +1338,7 @@ def test_list_of_a_scalar_is_rejected() -> None:
 
 
 def test_tuple_is_identity_on_an_aggregate() -> None:
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> list[float]:
         v = [a, b, c]
         return tuple(v[0:2])
 
@@ -1346,7 +1347,7 @@ def test_tuple_is_identity_on_an_aggregate() -> None:
 
 def test_numpy_alias_shadowed_by_a_local_is_not_numpy() -> None:
     # ``np`` is rebound to a local value, so ``np.asarray`` is a method call on that value, not the numpy function.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         np = [a]
         return np.asarray([a])
 
@@ -1357,7 +1358,7 @@ def test_numpy_alias_shadowed_by_a_local_is_not_numpy() -> None:
 def test_name_assigned_later_is_local_before_its_assignment() -> None:
     # A name assigned anywhere in a function is local throughout (Python's rule); using it as a global/builtin/numpy
     # before that assignment is invalid Python (UnboundLocalError), so holoso rejects it rather than seeing the global.
-    def shadows_numpy(a: float):  # type: ignore[no-untyped-def]
+    def shadows_numpy(a: float) -> float:
         y = np.asarray([a])
         np = [a]  # noqa: F841  # makes np local for the whole body
         return y
@@ -1365,7 +1366,7 @@ def test_name_assigned_later_is_local_before_its_assignment() -> None:
     with pytest.raises(UnsupportedConstruct):
         lower(shadows_numpy)
 
-    def shadows_builtin(a: float):  # type: ignore[no-untyped-def]
+    def shadows_builtin(a: float) -> float:
         y = abs(a)
         abs = [a]  # noqa: F841  # makes abs local for the whole body
         return y
@@ -1379,7 +1380,7 @@ def test_multidimensional_array_state_is_rejected() -> None:
     class Filt:
         m: np.ndarray  # type: ignore[type-arg]
 
-        def step(self, a: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float) -> None:
             self.m = self.m * a
 
     with pytest.raises(UnsupportedConstruct, match="1-D"):
@@ -1407,7 +1408,7 @@ def test_vector_state_decomposes_to_per_element_slots() -> None:
         def __init__(self) -> None:
             self.v = [1.0, 2.0, 3.0]
 
-        def update(self, a: float):  # type: ignore[no-untyped-def]
+        def update(self, a: float) -> None:
             self.v = [self.v[0] + a, self.v[1], self.v[2]]
 
     hir = lower(Vec().update)
@@ -1420,7 +1421,7 @@ def test_vector_state_shape_mismatch_is_rejected() -> None:
         def __init__(self) -> None:
             self.v = [0.0, 0.0]
 
-        def update(self, a: float):  # type: ignore[no-untyped-def]
+        def update(self, a: float) -> None:
             self.v = [a]
 
     with pytest.raises(UnsupportedConstruct, match="2-element vector"):
@@ -1434,7 +1435,7 @@ def test_vector_state_nested_shape_is_rejected() -> None:
         def __init__(self) -> None:
             self.v = [0.0, 0.0]
 
-        def update(self, a: float, b: float):  # type: ignore[no-untyped-def]
+        def update(self, a: float, b: float) -> None:
             self.v = [[a, b]]
 
     with pytest.raises(UnsupportedConstruct, match="incompatible shape"):
@@ -1448,7 +1449,7 @@ def test_vector_state_slot_name_collision_is_rejected() -> None:
             self.v = [1.0]
             self.v_0 = 2.0
 
-        def update(self, a: float):  # type: ignore[no-untyped-def]
+        def update(self, a: float) -> None:
             self.v = [a]
             self.v_0 = a + 1.0
 
@@ -1457,7 +1458,7 @@ def test_vector_state_slot_name_collision_is_rejected() -> None:
 
 
 def test_keyword_only_params_become_inputs() -> None:
-    def f(a: float, *, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, *, b: float, c: float) -> float:
         return a + b + c
 
     assert lower(f).input_names() == ["a", "b", "c"]
@@ -1469,7 +1470,7 @@ def test_dataclass_instance_is_stateful() -> None:
         total: float
         gain: list  # type: ignore[type-arg]
 
-        def step(self, x: float):  # type: ignore[no-untyped-def]
+        def step(self, x: float) -> None:
             self.total = self.total + x * self.gain[0]
 
     hir = lower(Acc(0.0, [2.0]).step)
@@ -1482,12 +1483,12 @@ def test_first_sample_branch_if_converts_to_one_block() -> None:
     # float phi (y) AND a boolean phi (_first), so it if-converts (the float phi to a select, the boolean phi to a
     # bool_select reduced by strength reduction) into a single straight-line block -- no branch survives.
     class Iir:
-        def __init__(self):  # type: ignore[no-untyped-def]
+        def __init__(self) -> None:
             self.alpha = 2**-16
             self.y = 0.0
             self._first = True
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self._first:
                 self._first = False
                 self.y = x
@@ -1510,10 +1511,10 @@ def test_nested_if_lowers_through_optimize() -> None:
     # Regression: block visitation must be topological -- an inner if's merge feeds the outer merge phi. The conditions
     # are dynamic comparisons (a read-only boolean attribute would fold to one arm and emit no branch).
     class C:
-        def __init__(self):  # type: ignore[no-untyped-def]
+        def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x: float, w: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float, w: float) -> float:
             if x > 0.0:
                 if w > 0.0:
                     self.y = x
@@ -1533,10 +1534,10 @@ def test_attribute_written_on_one_arm_becomes_a_phi() -> None:
     # The update lives in only one arm (anti-windup style); its live-out is a phi against the live-in. The condition is
     # a dynamic comparison so a real branch is emitted (a read-only boolean attribute would fold the branch away).
     class Clamp:
-        def __init__(self):  # type: ignore[no-untyped-def]
+        def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if x > 0.0:
                 self.acc = x
             return self.acc
@@ -1551,12 +1552,12 @@ def test_attribute_written_on_one_arm_becomes_a_phi() -> None:
     assert isinstance(live_out, Operation) and isinstance(live_out.operator, Select)
 
 
-def _op_count(hir, op_type):  # type: ignore[no-untyped-def]
+def _op_count(hir: Hir, op_type: type) -> int:
     return sum(1 for n in hir.nodes.values() if isinstance(n, Operation) and type(n.operator) is op_type)
 
 
 def test_boolean_and_in_condition_lowers_to_combinational_bool_and() -> None:
-    def f(x: float, a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(x: float, a: float, b: float) -> float:
         return 1.0 if (x > a and x < b) else 0.0
 
     hir = lower(f)
@@ -1565,7 +1566,7 @@ def test_boolean_and_in_condition_lowers_to_combinational_bool_and() -> None:
 
 
 def test_boolean_or_lowers_to_combinational_bool_or() -> None:
-    def f(x: float, a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(x: float, a: float, b: float) -> float:
         return 1.0 if (x < a or x > b) else 0.0
 
     hir = lower(f)
@@ -1574,7 +1575,7 @@ def test_boolean_or_lowers_to_combinational_bool_or() -> None:
 
 
 def test_not_lowers_to_combinational_bool_not() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return -1.0 if not (x > 0.0) else 1.0
 
     hir = lower(f)
@@ -1583,7 +1584,7 @@ def test_not_lowers_to_combinational_bool_not() -> None:
 
 
 def test_chained_comparison_lowers_to_two_comparisons_and_one_and() -> None:
-    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float) -> float:
         return 0.0 if lo < x < hi else x
 
     hir = lower(f)
@@ -1593,7 +1594,7 @@ def test_chained_comparison_lowers_to_two_comparisons_and_one_and() -> None:
 
 def test_chained_comparison_evaluates_each_operand_once() -> None:
     # The shared middle operand ``x`` feeds both comparisons but is evaluated once: only one Sub (x - 0.5) is built.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         x = a - 0.5
         return 0.0 if 0.0 < x < 1.0 else x
 
@@ -1601,7 +1602,7 @@ def test_chained_comparison_evaluates_each_operand_once() -> None:
     assert _op_count(hir, FloatAdd) == 1  # subtraction lowers to add(+neg); only one, so x was built once
 
 
-def _branch_count(hir) -> int:  # type: ignore[no-untyped-def]
+def _branch_count(hir: Hir) -> int:
     return sum(1 for block in hir.blocks if isinstance(block.terminator, Branch))
 
 
@@ -1609,20 +1610,20 @@ def test_nested_if_without_else_folds_into_one_and_branch() -> None:
     # ``if A: (if B: S)`` with no ``else`` on either is exactly ``if (A and B): S``: the frontend folds it to a single
     # branch (one combinational ``and``), NOT two nested jumps. Folded repeatedly, ``if A: if B: if C: S`` collapses to
     # one ``A and B and C`` branch. Regression: the nested form must compile identically to the hand-written ``and``.
-    def nested(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def nested(x: float, lo: float, hi: float) -> float:
         r = 0.0
         if x > lo:
             if x < hi:
                 r = 1.0
         return r
 
-    def manual(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def manual(x: float, lo: float, hi: float) -> float:
         r = 0.0
         if x > lo and x < hi:
             r = 1.0
         return r
 
-    def triple(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def triple(x: float, lo: float, hi: float) -> float:
         r = 0.0
         if x > lo:
             if x < hi:
@@ -1641,7 +1642,7 @@ def test_nested_if_with_outer_else_does_not_fold() -> None:
     # The fold must NOT trigger when the outer ``if`` has an ``else``: ``if A: (if B: S) else: T`` is not
     # ``if (A and B): S``, because T runs whenever ``not A``, whereas ``not (A and B)`` also covers A-and-not-B. Both
     # branches must survive and no spurious conjunction is synthesized.
-    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float) -> float:
         r = 0.0
         if x > lo:
             if x < hi:
@@ -1657,7 +1658,7 @@ def test_nested_if_with_outer_else_does_not_fold() -> None:
 def test_nested_if_fold_is_suppressed_when_the_inner_test_has_a_walrus() -> None:
     # The fold must NOT absorb an inner test that carries a walrus: nested, the walrus binds only when the outer test
     # holds, but ``A and B`` evaluates B unconditionally -- folding would over-bind it. The two branches must survive.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         r = 0.0
         if x > 0.0:
             if (t := x * 3.0) < 100.0:
@@ -1669,7 +1670,7 @@ def test_nested_if_fold_is_suppressed_when_the_inner_test_has_a_walrus() -> None
 
 def test_walrus_in_conditional_expression_arm_is_rejected() -> None:
     # A ternary arm is evaluated only when selected; a walrus binding there cannot leak across arms, so it is rejected.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return (t := 1.0) if x > 0.0 else (t := 2.0)
 
     with pytest.raises(UnsupportedConstruct, match="walrus"):
@@ -1680,7 +1681,7 @@ def test_walrus_in_and_or_operand_is_rejected() -> None:
     # An ``and``/``or`` operand may be short-circuited (statically dropped by the connective fold, or unevaluated in
     # Python), so whether its walrus binds cannot be reconciled between the scans and lowering -- rejected. (Regression:
     # the scan invalidated the target unconditionally while lowering short-circuited past it, desyncing the two.)
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         if x > 0.0 and (t := y) > 0.0:
             return t
         return 0.0
@@ -1690,7 +1691,7 @@ def test_walrus_in_and_or_operand_is_rejected() -> None:
 
 
 def test_walrus_in_chained_comparison_is_rejected() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         if x < 0.0 < (t := 5.0):
             return t
         return 0.0
@@ -1706,7 +1707,7 @@ def test_walrus_in_dead_or_unsupported_statement_still_scopes_the_name_local() -
     # Local-name collection is syntactic, as in Python: a walrus target is a function local throughout the body even in
     # dead or out-of-subset code, so it shadows a same-named global. Here the earlier ``range(_DEAD_WALRUS_GLOBAL)``
     # must see the runtime local (rejected), NOT silently fold the module int 3 from the global.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         v = x
         for _ in range(_DEAD_WALRUS_GLOBAL):
             v = v + 1.0
@@ -1721,7 +1722,7 @@ def test_walrus_in_a_nested_scope_default_scopes_the_name_in_the_enclosing_funct
     # A nested def/lambda is a separate scope, but its default-argument expressions execute in the ENCLOSING scope, so a
     # walrus there binds an enclosing local (as in Python). The earlier ``range(_DEAD_WALRUS_GLOBAL)`` must therefore
     # see the runtime local, not the module int -- even though the lambda is dead code that lowering never reaches.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         v = x
         for _ in range(_DEAD_WALRUS_GLOBAL):
             v = v + 1.0
@@ -1735,7 +1736,7 @@ def test_walrus_in_a_nested_scope_default_scopes_the_name_in_the_enclosing_funct
 def test_walrus_in_while_condition_is_rejected() -> None:
     # A while-condition walrus rebinds every iteration and its post-test value is the loop-exit value, which the header
     # phi does not capture; rejected rather than miscompiled.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         while (x := x - 1.0) > 0.0:
             pass
         return x
@@ -1750,7 +1751,7 @@ _WALRUS_SHADOWED_INT = 3  # a module global an inner walrus shadows in the test 
 def test_walrus_target_shadowing_a_global_int_is_a_runtime_local() -> None:
     # Python makes a walrus target a function local for the whole body, shadowing a same-named module global. Using it
     # as a static range bound must therefore see the runtime local (rejected), NOT silently fold the global's value.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         v = x
         if (_WALRUS_SHADOWED_INT := x) > 0.0:
             for _ in range(_WALRUS_SHADOWED_INT):  # the local float, not the module int 3
@@ -1768,7 +1769,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self = x
             return self.a
 
@@ -1776,7 +1777,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             y = (self := x)
             return self.a + y
 
@@ -1784,7 +1785,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self += x
             return self.a
 
@@ -1792,7 +1793,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for self in range(2):
                 pass
             return self.a
@@ -1801,7 +1802,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self, y = x, x
             return self.a + y
 
@@ -1817,13 +1818,13 @@ def test_writing_a_self_attribute_and_a_plain_local_named_self_are_accepted() ->
         def __init__(self) -> None:
             self.a = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self.a = self.a + x
             return self.a
 
     lower(_StateWrite().__call__)  # no exception
 
-    def plain(x: float):  # type: ignore[no-untyped-def]
+    def plain(x: float) -> float:
         self = x  # an ordinary local in a plain function (no instance)
         return self + 1.0
 
@@ -1831,7 +1832,7 @@ def test_writing_a_self_attribute_and_a_plain_local_named_self_are_accepted() ->
 
 
 def test_conditional_expression_lowers_to_branch_and_phi() -> None:
-    def f(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float, c: float) -> float:
         return x if c > 0.0 else y
 
     hir = lower(f)
@@ -1840,7 +1841,7 @@ def test_conditional_expression_lowers_to_branch_and_phi() -> None:
 
 
 def test_nested_conditional_expression_clamp_lowers() -> None:
-    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float) -> float:
         return hi if x > hi else (lo if x < lo else x)
 
     hir = lower(f)
@@ -1849,7 +1850,7 @@ def test_nested_conditional_expression_clamp_lowers() -> None:
 
 
 def test_statically_true_connective_in_condition_does_not_branch() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return 1.0 if (1.0 < 2.0 and 3.0 > 2.0) else 0.0
 
     hir = lower(f)
@@ -1859,7 +1860,7 @@ def test_statically_true_connective_in_condition_does_not_branch() -> None:
 
 
 def test_statically_true_connective_operand_is_dropped() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return 1.0 if (True and x > 0.0) else 0.0
 
     hir = lower(f)
@@ -1870,7 +1871,7 @@ def test_statically_true_connective_operand_is_dropped() -> None:
 def test_non_boolean_connective_operand_is_rejected() -> None:
     # Python's value-returning ``and``/``or`` over non-booleans is out of subset: a float operand in a boolean
     # position must raise rather than silently feed a non-boolean into the logic.
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         return 1.0 if (x and y) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
@@ -1883,7 +1884,7 @@ def test_chained_comparison_with_boolean_operand_is_rejected() -> None:
             self.flag = False
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             return 1.0 if 0.0 < self.flag < 1.0 else self.y  # noqa -- exercising the rejection
 
     with pytest.raises(UnsupportedConstruct, match="floating-point"):
@@ -1891,7 +1892,7 @@ def test_chained_comparison_with_boolean_operand_is_rejected() -> None:
 
 
 def test_not_of_non_boolean_is_rejected() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return 1.0 if not x else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
@@ -1899,7 +1900,7 @@ def test_not_of_non_boolean_is_rejected() -> None:
 
 
 def test_bool_cast_lowers_to_float_to_bool() -> None:
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         return 1.0 if bool(x) else y
 
     hir = lower(f)
@@ -1907,7 +1908,7 @@ def test_bool_cast_lowers_to_float_to_bool() -> None:
 
 
 def test_bool_of_a_boolean_is_identity() -> None:
-    def f(x: float, a: float):  # type: ignore[no-untyped-def]
+    def f(x: float, a: float) -> float:
         return 1.0 if bool(x > a) else 0.0
 
     hir = lower(f)
@@ -1916,7 +1917,7 @@ def test_bool_of_a_boolean_is_identity() -> None:
 
 
 def test_bool_cast_rejects_aggregate_argument() -> None:
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         return 1.0 if bool((x, y)) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="scalar"):
@@ -1924,7 +1925,7 @@ def test_bool_cast_rejects_aggregate_argument() -> None:
 
 
 def test_bool_cast_rejects_multiple_arguments() -> None:
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         return 1.0 if bool(x, y) else 0.0  # type: ignore[call-arg, arg-type]
 
     with pytest.raises(UnsupportedConstruct, match="single scalar"):
@@ -1932,7 +1933,7 @@ def test_bool_cast_rejects_multiple_arguments() -> None:
 
 
 def test_float_cast_of_bool_lowers_to_bool_to_float() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return float(x > 0.0)
 
     hir = lower(f)
@@ -1941,7 +1942,7 @@ def test_float_cast_of_bool_lowers_to_bool_to_float() -> None:
 
 
 def test_float_cast_of_float_is_identity() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return float(x) + 1.0
 
     hir = lower(f)
@@ -1950,7 +1951,7 @@ def test_float_cast_of_float_is_identity() -> None:
 
 
 def test_cross_domain_cast_chain_lowers() -> None:
-    def f(x: float, k: float):  # type: ignore[no-untyped-def]
+    def f(x: float, k: float) -> float:
         return float(x > 0.0) * k
 
     hir = lower(f)
@@ -1960,7 +1961,7 @@ def test_cross_domain_cast_chain_lowers() -> None:
 
 
 def test_float_cast_rejects_aggregate_argument() -> None:
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         return float((x, y))[0]  # type: ignore[index]
 
     with pytest.raises(UnsupportedConstruct, match="scalar"):
@@ -1971,14 +1972,14 @@ def test_non_boolean_or_operand_before_absorbing_constant_is_rejected() -> None:
     # Regression (Codex): ``x or True`` with a float x must be rejected, not folded to constant True. Python evaluates
     # x first and returns it when falsy, so a non-boolean operand reached before the absorbing constant cannot be
     # silently folded away -- it must be lowered and type-checked.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return 1.0 if (x or True) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
         lower(f)
 
 
-def _fn_with_globals(name, src, extra_globals):  # type: ignore[no-untyped-def]
+def _fn_with_globals(name: str, src: str, extra_globals: dict[str, object]) -> object:
     import linecache
 
     filename = f"<shadow_{name}>"
@@ -1992,10 +1993,12 @@ def test_callable_global_shadowing_bool_is_not_treated_as_the_builtin() -> None:
     # Regression (Codex): a callable global named ``bool`` (e.g. a callable instance) is what Python would call, so the
     # bare-name ``bool(x)`` must NOT be lowered as the builtin float->bool cast; it is rejected as an unsupported call.
     class AlwaysFalse:
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> bool:
             return False
 
-    f = _fn_with_globals("f", "def f(x: float):\n    return 1.0 if bool(x) else 0.0\n", {"bool": AlwaysFalse()})
+    f = _fn_with_globals(
+        "f", "def f(x: float) -> float:\n    return 1.0 if bool(x) else 0.0\n", {"bool": AlwaysFalse()}
+    )
     with pytest.raises(UnsupportedConstruct, match="unsupported call"):
         lower(f)
 
@@ -2004,7 +2007,7 @@ def test_static_bool_sees_through_bool_cast_so_return_in_branch_folds() -> None:
     # Regression (Codex round 2): the static evaluator must see through ``bool(<static bool>)`` so a guard like
     # ``if bool(True):`` folds to the taken arm with no branch -- otherwise the return in the dead arm is wrongly
     # rejected as a return-inside-a-branch.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         if bool(True):
             return 1.0
         return x  # unreachable; must not force a branch nor a return-in-branch rejection
@@ -2016,7 +2019,7 @@ def test_static_bool_sees_through_bool_cast_so_return_in_branch_folds() -> None:
 def test_static_bool_cast_short_circuits_a_dead_non_boolean_operand() -> None:
     # ``bool(False) and x`` short-circuits to False exactly like ``False and x``; the dead float operand is not
     # evaluated and must not be rejected (the static evaluator folds the bool() cast of a static bool).
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return 1.0 if (bool(False) and x) else 0.0
 
     hir = lower(f)
@@ -2026,7 +2029,7 @@ def test_static_bool_cast_short_circuits_a_dead_non_boolean_operand() -> None:
 
 def test_static_float_sees_through_float_cast_of_a_bool() -> None:
     # ``float(True) > 0.5`` folds: float(<static bool>) is 1.0/0.0, so the comparison and the ternary fold statically.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return x if float(True) > 0.5 else 0.0
 
     hir = lower(f)
@@ -2037,7 +2040,7 @@ def test_static_float_sees_through_float_cast_of_a_bool() -> None:
 def test_or_true_in_a_condition_folds_and_permits_a_return() -> None:
     # Regression (user): ``X or True`` (X a valid boolean) is the constant True, so the guard must fold to its taken
     # arm with no branch -- including allowing the return in that arm, which a runtime branch would reject.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         if x > 0.0 or True:
             return 1.0
         return x  # unreachable
@@ -2048,7 +2051,7 @@ def test_or_true_in_a_condition_folds_and_permits_a_return() -> None:
 
 
 def test_and_false_in_a_condition_folds_to_the_else_arm() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         if x > 0.0 and False:
             y = 1.0
         else:
@@ -2063,7 +2066,7 @@ def test_and_false_in_a_condition_folds_to_the_else_arm() -> None:
 def test_chained_comparison_with_a_static_true_link_collapses_the_dead_and() -> None:
     # ``0.0 < 1.0 < x`` is ``(0 < 1) and (1 < x)``; the static-true link folds, and the constant folder's identity
     # element collapses ``True and (1 < x)`` to just ``1 < x`` -- no residual dead AND.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return 1.0 if 0.0 < 1.0 < x else 0.0
 
     hir = optimize(lower(f))
@@ -2075,7 +2078,7 @@ def test_statically_false_while_still_type_checks_its_condition() -> None:
     # Regression (review): a statically-false ``while`` is skipped, but its condition must still be type-checked --
     # ``while x and False:`` with a non-boolean x must be rejected (symmetric with ``if x and False:``), not silently
     # accepted because the loop never runs.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         while x and False:
             x = x + 1.0
         return x
@@ -2085,7 +2088,7 @@ def test_statically_false_while_still_type_checks_its_condition() -> None:
 
 
 def test_statically_false_while_with_a_boolean_condition_is_skipped() -> None:
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         while x > 0.0 and False:  # a valid boolean condition that is statically false: the loop never runs
             x = x + 1.0
         return x
@@ -2096,7 +2099,7 @@ def test_statically_false_while_with_a_boolean_condition_is_skipped() -> None:
 def test_reachability_folds_through_a_bool_cast_of_a_connective() -> None:
     # ``bool(X or True)`` carries the truthiness of ``X or True`` (= True), so the guard folds and the return is
     # allowed.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         if bool(x > 0.0 or True):
             return 1.0
         return x
@@ -2107,7 +2110,7 @@ def test_reachability_folds_through_a_bool_cast_of_a_connective() -> None:
 def test_ternary_condition_with_equal_arms_folds() -> None:
     # ``True if x > 0.0 else True`` is True regardless of the (runtime) test, so the enclosing guard folds and the
     # return is not rejected as branch-nested (the inner ternary still lowers, but the outer ``if`` takes no branch).
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         if True if x > 0.0 else True:
             return 1.0
         return x
@@ -2120,11 +2123,11 @@ def test_readonly_scan_stops_at_a_returning_folded_arm() -> None:
     # must stop there, so an attribute assigned only afterwards is not wrongly counted as written. Here ``gate`` is
     # read-only, so the first guard folds and its return is permitted -- which fails if ``gate`` is mismarked.
     class K:
-        def __init__(self):
+        def __init__(self) -> None:
             self.gate = True
             self.y = 0.0
 
-        def __call__(self, u: float):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float) -> float:
             if self.gate:
                 return u + 1.0
             self.y = u
@@ -2139,11 +2142,11 @@ def test_float_cast_connective_comparison_condition_folds_without_spurious_state
     # Regression (review #2): ``float(X or True) > 0.5`` is the constant True; the guard must fold so the dead else-arm
     # write does NOT become a persistent-state slot (and output port).
     class K:
-        def __init__(self):
+        def __init__(self) -> None:
             self.y = 0.0
             self.z = 0.0
 
-        def __call__(self, u: float):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float) -> float:
             if float(u > 0.0 or True) > 0.5:
                 self.y = u
             else:
@@ -2160,13 +2163,13 @@ def test_absorbing_attribute_connective_keeps_a_dead_arm_attribute_read_only() -
     # decides it), so ``self.other`` -- written only in the dead else -- stays read-only, and the later guard on it
     # folds rather than leaking ``self.z`` as state.
     class K:
-        def __init__(self):
+        def __init__(self) -> None:
             self.flag = True
             self.other = True
             self.y = 0.0
             self.z = 0.0
 
-        def __call__(self, u: float):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float) -> float:
             if self.flag or True:
                 pass
             else:
@@ -2184,7 +2187,7 @@ def test_absorbing_attribute_connective_keeps_a_dead_arm_attribute_read_only() -
 def test_equal_arm_ternary_condition_leaves_no_dead_branch() -> None:
     # Regression (review #4): a ternary whose arms agree is that value with no branch, so a statically-false loop
     # guarded by one is skipped cleanly (no dead diamond left in the CFG).
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         while False if x > 0.0 else False:
             x = x + 1.0
         return x
@@ -2197,7 +2200,7 @@ def test_equal_arm_ternary_value_fold_does_not_bypass_operand_type_checks() -> N
     # reachability one. ``(float(x or True) > 0.5) if c else (float(x or True) > 0.5)`` has equal arms, but folding it
     # without lowering would skip type-checking ``x or True`` -- accepting a non-boolean x and miscompiling. It must
     # be rejected, exactly as the un-wrapped ``float(x or True) > 0.5`` is.
-    def f(x: float, c: float):  # type: ignore[no-untyped-def]
+    def f(x: float, c: float) -> float:
         return 1.0 if ((float(x or True) > 0.5) if c > 0.0 else (float(x or True) > 0.5)) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="boolean"):
@@ -2210,12 +2213,12 @@ def test_read_only_scan_does_not_misfold_a_reassigned_for_counter() -> None:
     # treat it as read-only, and fold the later ``if self._flag:`` to a fixed arm, diverging from lowering. The scan
     # leaves the counter unbound (conservative), so the body's writes are recorded and ``_flag`` stays state.
     class K:
-        def __init__(self):
+        def __init__(self) -> None:
             self._flag = False
             self.y = 0.0
             self.z = 0.0
 
-        def __call__(self, u: float):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float) -> float:
             for i in range(1):
                 i = u  # the loop counter is reassigned to a runtime value
                 if i > 0.0:
@@ -2233,8 +2236,151 @@ def test_read_only_scan_does_not_misfold_a_reassigned_for_counter() -> None:
 def test_ternary_with_mismatched_scalar_arm_types_is_cleanly_rejected() -> None:
     # Regression (review): a conditional whose arms have different scalar types (a boolean and a float) is out of
     # subset; it must be rejected with a clear UnsupportedConstruct, not leak an internal phi type-mismatch error.
-    def f(x: float, c: float):  # type: ignore[no-untyped-def]
+    def f(x: float, c: float) -> float:
         return 1.0 if (False if c > 0.0 else x) else 0.0
 
     with pytest.raises(UnsupportedConstruct, match="different scalar types"):
         lower(f)
+
+
+def test_missing_return_annotation_is_rejected() -> None:
+    def f(a: float):  # type: ignore[no-untyped-def]
+        return a + 1.0
+
+    with pytest.raises(UnsupportedConstruct, match="return type must be explicitly annotated"):
+        lower(f)
+
+
+def test_return_annotation_scalar_type_mismatch_is_rejected() -> None:
+    def f(a: float) -> bool:
+        return a + 1.0
+
+    with pytest.raises(UnsupportedConstruct, match="return type mismatch"):
+        lower(f)
+
+
+def test_return_annotation_bool_declared_float_inferred_is_rejected() -> None:
+    def f(a: float) -> float:
+        return a > 0.0
+
+    with pytest.raises(UnsupportedConstruct, match="return type mismatch"):
+        lower(f)
+
+
+def test_unsupported_return_annotation_is_rejected() -> None:
+    def f(a: float) -> int:
+        return a
+
+    with pytest.raises(UnsupportedConstruct, match="unsupported return annotation"):
+        lower(f)
+
+
+def test_scalar_declared_but_tuple_returned_is_rejected() -> None:
+    def f(a: float) -> float:
+        return a, a
+
+    with pytest.raises(UnsupportedConstruct, match="values are returned"):
+        lower(f)
+
+
+def test_return_tuple_arity_mismatch_is_rejected() -> None:
+    def f(a: float) -> tuple[float, float, float]:
+        return a, a
+
+    with pytest.raises(UnsupportedConstruct, match="arity mismatch"):
+        lower(f)
+
+
+def test_return_none_declared_but_value_returned_is_rejected() -> None:
+    def f(a: float) -> None:
+        return a
+
+    with pytest.raises(UnsupportedConstruct, match="a value is returned"):
+        lower(f)
+
+
+def test_return_value_declared_but_method_returns_nothing_is_rejected() -> None:
+    class Acc:
+        def __init__(self) -> None:
+            self._acc = 0.0
+
+        def update(self, x: float) -> float:
+            self._acc = self._acc + x
+
+    with pytest.raises(UnsupportedConstruct, match="returns no value"):
+        lower(Acc().update)
+
+
+def test_tuple_return_annotation_accepted() -> None:
+    def f(a: float, b: float) -> tuple[float, bool]:
+        return a + b, a > b
+
+    assert [port.name for port in lower(f).outputs] == ["out_0", "out_1"]
+
+
+def test_variadic_tuple_return_annotation_accepted() -> None:
+    def f(a: bool, b: bool) -> tuple[bool, ...]:
+        return a, b, a and b
+
+    assert [port.name for port in lower(f).outputs] == ["out_0", "out_1", "out_2"]
+
+
+def test_list_return_annotation_accepted() -> None:
+    def f(a: float, b: float) -> list[float]:
+        return [a, b]
+
+    assert [port.name for port in lower(f).outputs] == ["out_0", "out_1"]
+
+
+def test_none_return_annotation_accepted_for_stateful_method() -> None:
+    class Acc:
+        def __init__(self) -> None:
+            self._acc = 0.0
+
+        def update(self, x: float) -> None:
+            self._acc = self._acc + x
+
+    lower(Acc().update)
+
+
+def test_scalar_returned_but_tuple_declared_is_rejected() -> None:
+    def f(a: float) -> tuple[float, float]:
+        return a
+
+    with pytest.raises(UnsupportedConstruct, match="a single value is returned"):
+        lower(f)
+
+
+def test_malformed_list_return_annotation_is_rejected() -> None:
+    def f(a: float) -> list[float, float]:  # type: ignore[type-arg]
+        return [a, a]
+
+    with pytest.raises(UnsupportedConstruct, match="values are returned"):
+        lower(f)
+
+
+def test_nested_tuple_return_annotation_accepted() -> None:
+    def f(a: float, b: float) -> tuple[tuple[float, float], bool]:
+        return (a, b), a > b
+
+    assert [port.name for port in lower(f).outputs] == ["out_0_0", "out_0_1", "out_1"]
+
+
+def test_nested_tuple_return_shape_mismatch_is_rejected() -> None:
+    def f(a: float, b: float) -> tuple[tuple[float, float], float]:
+        return a, a + b
+
+    with pytest.raises(UnsupportedConstruct, match="a single value is returned"):
+        lower(f)
+
+
+def test_explicit_return_none_is_accepted_for_stateful_method() -> None:
+    class Acc:
+        def __init__(self) -> None:
+            self._acc = 0.0
+
+        def update(self, x: float) -> None:
+            self._acc = self._acc + x
+            return None
+
+    lower(Acc().update)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,6 +1,7 @@
 """Unit tests for the Python-to-HIR frontend."""
 
 import dataclasses
+import logging
 import math
 import sys
 import textwrap
@@ -138,6 +139,42 @@ def test_unsupported_scalar_parameter_annotation_is_rejected() -> None:
 
     with pytest.raises(UnsupportedConstruct, match="parameter annotation"):
         lower(passthrough)
+
+
+def test_assert_is_ignored_with_info_message(caplog: pytest.LogCaptureFixture) -> None:
+    # The whole test subtree -- the comparison and its nested call -- is dropped, so neither op reaches HIR.
+    def with_assert(x: float):  # type: ignore[no-untyped-def]
+        assert abs(x) > 0.0
+        return x + 1.0
+
+    with caplog.at_level(logging.INFO, logger="holoso._frontend._lower"):
+        hir = lower(with_assert)
+    assert [o.name for o in hir.outputs] == ["out_0"]
+    assert _arith_count(hir, FloatRelational) == 0 and _arith_count(hir, FloatAbs) == 0
+    assert "has no effect in Holoso" in caplog.text
+
+
+def test_walrus_in_assert_is_ignored_not_rejected() -> None:
+    # A walrus even inside an and/or in an assert is ignored, not caught by the short-circuit-walrus pre-pass: the
+    # assert is dropped and the unused binding simply vanishes, as under -O.
+    def unused_walrus(x: float):  # type: ignore[no-untyped-def]
+        assert (ok := x > 0.0) and True
+        return x + 1.0
+
+    assert [o.name for o in lower(unused_walrus).outputs] == ["out_0"]
+
+
+def test_dropped_assert_walrus_used_later_is_unknown_name() -> None:
+    # The dropped assert never binds its walrus, yet the target stays a function local (a walrus is scoped
+    # syntactically), so a later use is a clean unknown-name error that shadows the same-named global rather than
+    # silently reading it -- mirroring Python -O, which keeps the local and raises UnboundLocalError. The injected
+    # ``y`` global is what makes this discriminating: were the target NOT kept local, the read would resolve to it.
+    def used_later(x: float):  # type: ignore[no-untyped-def]
+        assert (y := x * 2.0) > 0.0
+        return y
+
+    with pytest.raises(UnsupportedConstruct, match="unknown name"):
+        lower(_rebind_globals(used_later, y=5.0))
 
 
 def test_pow_expands_to_multiply_chain() -> None:

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -6,7 +6,9 @@ import math
 import sys
 import textwrap
 import types
+from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 import pytest
@@ -355,7 +357,7 @@ def test_nested_function_scope_does_not_shadow_global() -> None:
     # function treat that name as local, which would shadow the numpy alias (or a builtin) at an earlier use.
     def kernel(x: float) -> float:
         y = np.asarray([x])
-        return y[0]
+        return y[0]  # type: ignore[no-any-return]
 
         def helper() -> int:  # noqa -- dead nested scope; its ``np`` is not the outer's
             np = 1
@@ -821,7 +823,7 @@ def test_loop_carried_attr_written_only_in_live_folded_arm() -> None:
 
 def test_unknown_global_is_unsupported() -> None:
     def f(a: float) -> float:
-        return a + UNDEFINED_GLOBAL  # type: ignore[name-defined]  # noqa: F821
+        return a + UNDEFINED_GLOBAL  # type: ignore[name-defined, no-any-return]  # noqa: F821
 
     with pytest.raises(UnsupportedConstruct):
         lower(f)
@@ -851,7 +853,10 @@ def test_stateful_method_state_slots_and_dedup() -> None:
     assert [o.name for o in hir.outputs] == ["state_y"]
     slots = {s.name: s for s in hir.state_slots}
     assert set(slots) == {"y", "_x_prev"}
-    assert slots["y"].reset_value.value == 0.0 and slots["_x_prev"].reset_value.value == 0.0
+    assert (
+        cast(FloatConst, slots["y"].reset_value).value == 0.0
+        and cast(FloatConst, slots["_x_prev"].reset_value).value == 0.0
+    )
     assert {n.slot for n in hir.nodes.values() if isinstance(n, StateRead)} == {"y", "_x_prev"}
 
 
@@ -945,9 +950,9 @@ def test_stateful_readonly_attribute_is_folded_constant() -> None:
 def test_stateful_reset_state_is_the_instance_snapshot() -> None:
     # The reset value is whatever the instance holds at synthesis time, including post-construction mutation.
     integrator = _integrator_class()(k=2**-22)
-    integrator.y = 1.5  # type: ignore[attr-defined]
+    integrator.y = 1.5
     slots = {s.name: s for s in lower(integrator.__call__).state_slots}
-    assert slots["y"].reset_value.value == 1.5
+    assert cast(FloatConst, slots["y"].reset_value).value == 1.5
 
 
 def test_init_method_target_is_rejected() -> None:
@@ -1018,7 +1023,7 @@ def test_list_slice() -> None:
 def test_vector_scalar_broadcast() -> None:
     def f(a: float, b: float) -> list[float]:
         v = [a, b]
-        return v * 0.5
+        return v * 0.5  # type: ignore[no-any-return, operator]
 
     hir = lower(f)
     assert _arith_count(hir, FloatMul) == 2
@@ -1028,7 +1033,7 @@ def test_vector_scalar_broadcast() -> None:
 def test_flatten_collapses_nesting() -> None:
     def f(a: float, b: float) -> list[float]:
         m = [[a], [b]]
-        return m.flatten()
+        return m.flatten()  # type: ignore[no-any-return, attr-defined]
 
     assert [o.name for o in lower(f).outputs] == ["out_0", "out_1"]
 
@@ -1044,7 +1049,7 @@ def test_index_out_of_range_is_rejected() -> None:
 
 def test_indexing_a_scalar_is_rejected() -> None:
     def f(a: float) -> float:
-        return a[0]
+        return a[0]  # type: ignore[no-any-return, index]
 
     with pytest.raises(UnsupportedConstruct, match="index or slice a scalar"):
         lower(f)
@@ -1052,7 +1057,7 @@ def test_indexing_a_scalar_is_rejected() -> None:
 
 def test_star_unpacking_a_scalar_is_rejected() -> None:
     def f(a: float) -> float:
-        return [*a]
+        return [*a]  # type: ignore[misc, return-value]
 
     with pytest.raises(UnsupportedConstruct, match="unpack"):
         lower(f)
@@ -1091,8 +1096,8 @@ def test_chained_assignment_binds_every_target() -> None:
 
 def test_unpacking_a_scalar_source_is_rejected() -> None:
     def f(a: float) -> float:
-        x, y = a
-        return x + y
+        x, y = a  # type: ignore[misc]
+        return x + y  # type: ignore[no-any-return, has-type]
 
     with pytest.raises(UnsupportedConstruct, match="unpack a scalar"):
         lower(f)
@@ -1100,8 +1105,8 @@ def test_unpacking_a_scalar_source_is_rejected() -> None:
 
 def test_unpacking_arity_mismatch_is_rejected() -> None:
     def f(a: float, b: float, c: float) -> float:
-        x, y = [a, b, c]
-        return x + y
+        x, y = [a, b, c]  # type: ignore[misc]
+        return x + y  # type: ignore[no-any-return, has-type]
 
     with pytest.raises(UnsupportedConstruct, match="unpack 3 values into 2"):
         lower(f)
@@ -1128,7 +1133,7 @@ def test_unpacked_name_shadows_global_callable() -> None:
     # this exercises _collect_local_names descending into unpacking targets.
     def f(a: float) -> float:
         _addmul, b = a, a  # _addmul is now a local value (Python would raise 'float not callable' when called)
-        return _addmul(b)
+        return _addmul(b)  # type: ignore[no-any-return, operator]
 
     with pytest.raises(UnsupportedConstruct, match="not a callable"):
         lower(f)
@@ -1158,7 +1163,7 @@ def test_inlined_global_with_star_args() -> None:
 
 def test_inline_arity_mismatch_is_rejected() -> None:
     def f(a: float) -> float:
-        return _addmul(a)
+        return _addmul(a)  # type: ignore[call-arg, return-value]
 
     with pytest.raises(UnsupportedConstruct, match="positional arguments"):
         lower(f)
@@ -1179,7 +1184,7 @@ def test_user_global_function_shadows_intrinsic_name() -> None:
 def test_local_name_shadows_global_callable() -> None:
     # A parameter named like a global function refers to the parameter (a value), which is not callable.
     def f(_addmul: float, a: float) -> float:
-        return _addmul(a)
+        return _addmul(a)  # type: ignore[no-any-return, operator]
 
     with pytest.raises(UnsupportedConstruct, match="not a callable"):
         lower(f)
@@ -1187,7 +1192,7 @@ def test_local_name_shadows_global_callable() -> None:
 
 def test_flatten_on_a_scalar_is_rejected() -> None:
     def f(a: float) -> float:
-        return a.flatten()
+        return a.flatten()  # type: ignore[no-any-return, attr-defined]
 
     with pytest.raises(UnsupportedConstruct, match="aggregate"):
         lower(f)
@@ -1219,7 +1224,7 @@ def test_unary_plus_is_scalar_identity_and_rejects_aggregates() -> None:
 
     def aggregate_bad(a: float, b: float) -> list[float]:
         v = [a, b]
-        return +v
+        return +v  # type: ignore[no-any-return, operator]
 
     with pytest.raises(UnsupportedConstruct, match="scalar"):
         lower(aggregate_bad)
@@ -1229,14 +1234,15 @@ def test_method_style_abs_call_is_rejected() -> None:
     # Only a bare-name abs(...) is the builtin; a method-style a.abs(b) must not be silently treated as it (which would
     # drop the receiver) -- there is no supported scalar method, so it is an unsupported call.
     def f(a: float, b: float) -> float:
-        return a.abs(b)
+        return a.abs(b)  # type: ignore[no-any-return, attr-defined]
 
     with pytest.raises(UnsupportedConstruct, match="abs"):
         lower(f)
 
 
-def _rebind_globals(fn: types.FunctionType, **overrides: object) -> types.FunctionType:
+def _rebind_globals(fn: Callable[..., object], **overrides: object) -> Callable[..., object]:
     """A copy of ``fn`` whose module globals carry ``overrides`` (its source stays retrievable via the shared code)."""
+    assert isinstance(fn, types.FunctionType)
     copy = types.FunctionType(
         fn.__code__, {**fn.__globals__, **overrides}, fn.__name__, fn.__defaults__, fn.__closure__
     )
@@ -1251,10 +1257,10 @@ def test_noncallable_global_shadowing_builtin_is_rejected() -> None:
         return abs(a)
 
     def use_list(a: float) -> float:
-        return list((a, a))
+        return list((a, a))  # type: ignore[return-value]
 
     def use_tuple(a: float) -> float:
-        return tuple((a, a))
+        return tuple((a, a))  # type: ignore[return-value]
 
     # ``None`` shadows too -- it is present-but-non-callable, distinct from an absent global (the _ABSENT sentinel).
     shadows = ((use_abs, {"abs": 5}), (use_abs, {"abs": None}), (use_list, {"list": 5}), (use_tuple, {"tuple": 5}))
@@ -1306,7 +1312,7 @@ def test_jaxtyping_array_field_lowers_and_is_validated() -> None:
 def test_numpy_integer_array_values_coerce_to_real() -> None:
     @dataclasses.dataclass
     class Filt:
-        v: np.ndarray  # type: ignore[type-arg]
+        v: np.ndarray
 
         def step(self, a: float) -> None:
             self.v = self.v * a
@@ -1316,7 +1322,7 @@ def test_numpy_integer_array_values_coerce_to_real() -> None:
 
 def test_numpy_asarray_is_identity_on_an_aggregate() -> None:
     def f(a: float, b: float) -> list[float]:
-        return np.asarray([a, b]).flatten()  # asarray of an array-like is identity in this compile-time model
+        return np.asarray([a, b]).flatten()  # type: ignore[return-value]  # identity in this compile-time model
 
     assert [o.name for o in lower(f).outputs] == ["out_0", "out_1"]
 
@@ -1331,7 +1337,7 @@ def test_list_is_identity_on_an_aggregate() -> None:
 
 def test_list_of_a_scalar_is_rejected() -> None:
     def f(a: float) -> float:
-        return list(a)  # Python: list(scalar) is a TypeError -- a scalar is not iterable
+        return list(a)  # type: ignore[no-any-return, call-overload]  # list(scalar) is a Python TypeError
 
     with pytest.raises(UnsupportedConstruct, match="list"):
         lower(f)
@@ -1340,7 +1346,7 @@ def test_list_of_a_scalar_is_rejected() -> None:
 def test_tuple_is_identity_on_an_aggregate() -> None:
     def f(a: float, b: float, c: float) -> list[float]:
         v = [a, b, c]
-        return tuple(v[0:2])
+        return tuple(v[0:2])  # type: ignore[return-value]
 
     assert [o.name for o in lower(f).outputs] == ["out_0", "out_1"]
 
@@ -1349,7 +1355,7 @@ def test_numpy_alias_shadowed_by_a_local_is_not_numpy() -> None:
     # ``np`` is rebound to a local value, so ``np.asarray`` is a method call on that value, not the numpy function.
     def f(a: float) -> float:
         np = [a]
-        return np.asarray([a])
+        return np.asarray([a])  # type: ignore[no-any-return, attr-defined]
 
     with pytest.raises(UnsupportedConstruct, match="asarray"):
         lower(f)
@@ -1359,15 +1365,15 @@ def test_name_assigned_later_is_local_before_its_assignment() -> None:
     # A name assigned anywhere in a function is local throughout (Python's rule); using it as a global/builtin/numpy
     # before that assignment is invalid Python (UnboundLocalError), so holoso rejects it rather than seeing the global.
     def shadows_numpy(a: float) -> float:
-        y = np.asarray([a])
+        y = np.asarray([a])  # type: ignore[used-before-def]
         np = [a]  # noqa: F841  # makes np local for the whole body
-        return y
+        return y  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct):
         lower(shadows_numpy)
 
     def shadows_builtin(a: float) -> float:
-        y = abs(a)
+        y = abs(a)  # type: ignore[used-before-def]
         abs = [a]  # noqa: F841  # makes abs local for the whole body
         return y
 
@@ -1378,7 +1384,7 @@ def test_name_assigned_later_is_local_before_its_assignment() -> None:
 def test_multidimensional_array_state_is_rejected() -> None:
     @dataclasses.dataclass
     class Filt:
-        m: np.ndarray  # type: ignore[type-arg]
+        m: np.ndarray
 
         def step(self, a: float) -> None:
             self.m = self.m * a
@@ -1412,7 +1418,11 @@ def test_vector_state_decomposes_to_per_element_slots() -> None:
             self.v = [self.v[0] + a, self.v[1], self.v[2]]
 
     hir = lower(Vec().update)
-    assert {s.name: s.reset_value.value for s in hir.state_slots} == {"v_0": 1.0, "v_1": 2.0, "v_2": 3.0}
+    assert {s.name: cast(FloatConst, s.reset_value).value for s in hir.state_slots} == {
+        "v_0": 1.0,
+        "v_1": 2.0,
+        "v_2": 3.0,
+    }
     assert [o.name for o in hir.outputs] == ["state_v_0", "state_v_1", "state_v_2"]
 
 
@@ -1436,7 +1446,7 @@ def test_vector_state_nested_shape_is_rejected() -> None:
             self.v = [0.0, 0.0]
 
         def update(self, a: float, b: float) -> None:
-            self.v = [[a, b]]
+            self.v = [[a, b]]  # type: ignore[list-item]
 
     with pytest.raises(UnsupportedConstruct, match="incompatible shape"):
         lower(Vec().update)
@@ -1709,7 +1719,7 @@ def test_walrus_in_dead_or_unsupported_statement_still_scopes_the_name_local() -
     # must see the runtime local (rejected), NOT silently fold the module int 3 from the global.
     def f(x: float) -> float:
         v = x
-        for _ in range(_DEAD_WALRUS_GLOBAL):
+        for _ in range(_DEAD_WALRUS_GLOBAL):  # type: ignore[used-before-def]
             v = v + 1.0
         return v
         assert (_DEAD_WALRUS_GLOBAL := 2)  # noqa -- unreachable, but makes the name a local for the whole function
@@ -1754,7 +1764,7 @@ def test_walrus_target_shadowing_a_global_int_is_a_runtime_local() -> None:
     def f(x: float) -> float:
         v = x
         if (_WALRUS_SHADOWED_INT := x) > 0.0:
-            for _ in range(_WALRUS_SHADOWED_INT):  # the local float, not the module int 3
+            for _ in range(_WALRUS_SHADOWED_INT):  # type: ignore[call-overload]  # local float, not module int 3
                 v = v + 1.0
         return v
 
@@ -1770,7 +1780,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
             self.a = 1.0
 
         def __call__(self, x: float) -> float:
-            self = x
+            self = x  # type: ignore[assignment]
             return self.a
 
     class _Walrus:
@@ -1778,7 +1788,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
             self.a = 1.0
 
         def __call__(self, x: float) -> float:
-            y = (self := x)
+            y = (self := x)  # type: ignore[assignment]
             return self.a + y
 
     class _Augmented:
@@ -1786,7 +1796,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
             self.a = 1.0
 
         def __call__(self, x: float) -> float:
-            self += x
+            self += x  # type: ignore[operator, assignment]
             return self.a
 
     class _ForCounter:
@@ -1794,7 +1804,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
             self.a = 1.0
 
         def __call__(self, x: float) -> float:
-            for self in range(2):
+            for self in range(2):  # type: ignore[assignment]
                 pass
             return self.a
 
@@ -1803,7 +1813,7 @@ def test_reassigning_the_instance_parameter_self_is_rejected() -> None:
             self.a = 1.0
 
         def __call__(self, x: float) -> float:
-            self, y = x, x
+            self, y = x, x  # type: ignore[assignment]
             return self.a + y
 
     for ctor in (_PlainAssign, _Walrus, _Augmented, _ForCounter, _Unpack):
@@ -1926,7 +1936,7 @@ def test_bool_cast_rejects_aggregate_argument() -> None:
 
 def test_bool_cast_rejects_multiple_arguments() -> None:
     def f(x: float, y: float) -> float:
-        return 1.0 if bool(x, y) else 0.0  # type: ignore[call-arg, arg-type]
+        return 1.0 if bool(x, y) else 0.0  # type: ignore[call-arg]
 
     with pytest.raises(UnsupportedConstruct, match="single scalar"):
         lower(f)
@@ -1962,7 +1972,7 @@ def test_cross_domain_cast_chain_lowers() -> None:
 
 def test_float_cast_rejects_aggregate_argument() -> None:
     def f(x: float, y: float) -> float:
-        return float((x, y))[0]  # type: ignore[index]
+        return float((x, y))[0]  # type: ignore[no-any-return, index, arg-type]
 
     with pytest.raises(UnsupportedConstruct, match="scalar"):
         lower(f)
@@ -2220,7 +2230,7 @@ def test_read_only_scan_does_not_misfold_a_reassigned_for_counter() -> None:
 
         def __call__(self, u: float) -> float:
             for i in range(1):
-                i = u  # the loop counter is reassigned to a runtime value
+                i = u  # type: ignore[assignment]  # the loop counter is reassigned to a runtime value
                 if i > 0.0:
                     self._flag = True
             if self._flag:
@@ -2253,7 +2263,7 @@ def test_missing_return_annotation_is_rejected() -> None:
 
 def test_return_annotation_scalar_type_mismatch_is_rejected() -> None:
     def f(a: float) -> bool:
-        return a + 1.0
+        return a + 1.0  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="return type mismatch"):
         lower(f)
@@ -2269,7 +2279,7 @@ def test_return_annotation_bool_declared_float_inferred_is_rejected() -> None:
 
 def test_unsupported_return_annotation_is_rejected() -> None:
     def f(a: float) -> int:
-        return a
+        return a  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="unsupported return annotation"):
         lower(f)
@@ -2277,7 +2287,7 @@ def test_unsupported_return_annotation_is_rejected() -> None:
 
 def test_scalar_declared_but_tuple_returned_is_rejected() -> None:
     def f(a: float) -> float:
-        return a, a
+        return a, a  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="values are returned"):
         lower(f)
@@ -2285,7 +2295,7 @@ def test_scalar_declared_but_tuple_returned_is_rejected() -> None:
 
 def test_return_tuple_arity_mismatch_is_rejected() -> None:
     def f(a: float) -> tuple[float, float, float]:
-        return a, a
+        return a, a  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="arity mismatch"):
         lower(f)
@@ -2293,7 +2303,7 @@ def test_return_tuple_arity_mismatch_is_rejected() -> None:
 
 def test_return_none_declared_but_value_returned_is_rejected() -> None:
     def f(a: float) -> None:
-        return a
+        return a  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="a value is returned"):
         lower(f)
@@ -2304,7 +2314,7 @@ def test_return_value_declared_but_method_returns_nothing_is_rejected() -> None:
         def __init__(self) -> None:
             self._acc = 0.0
 
-        def update(self, x: float) -> float:
+        def update(self, x: float) -> float:  # type: ignore[return]
             self._acc = self._acc + x
 
     with pytest.raises(UnsupportedConstruct, match="returns no value"):
@@ -2345,7 +2355,7 @@ def test_none_return_annotation_accepted_for_stateful_method() -> None:
 
 def test_scalar_returned_but_tuple_declared_is_rejected() -> None:
     def f(a: float) -> tuple[float, float]:
-        return a
+        return a  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="a single value is returned"):
         lower(f)
@@ -2368,7 +2378,7 @@ def test_nested_tuple_return_annotation_accepted() -> None:
 
 def test_nested_tuple_return_shape_mismatch_is_rejected() -> None:
     def f(a: float, b: float) -> tuple[tuple[float, float], float]:
-        return a, a + b
+        return a, a + b  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="a single value is returned"):
         lower(f)

--- a/tests/test_gate_edge.py
+++ b/tests/test_gate_edge.py
@@ -33,7 +33,7 @@ _HDL_DIR = Path(__file__).resolve().parent / "hdl"
 _FMT = FloatFormat(8, 24)
 
 
-def _cycle0_kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+def _cycle0_kernel(a: float, b: float) -> float:
     # Leads with a pooled fadd (a - b) and fmul (a * b) on cycle 0, so the iv gate is exercised on a real cycle-0 issue.
     return (a - b) * 0.25 + a * b
 
@@ -44,7 +44,7 @@ class _ConstInstallState:
     def __init__(self) -> None:
         self._s = 5.0
 
-    def __call__(self, n: float):  # type: ignore[no-untyped-def]
+    def __call__(self, n: float) -> float:
         self._s = 0.0
         while self._s < n:
             self._s = self._s + 1.0

--- a/tests/test_gate_edge.py
+++ b/tests/test_gate_edge.py
@@ -33,7 +33,7 @@ _HDL_DIR = Path(__file__).resolve().parent / "hdl"
 _FMT = FloatFormat(8, 24)
 
 
-def _cycle0_kernel(a, b):  # type: ignore[no-untyped-def]
+def _cycle0_kernel(a: float, b: float):  # type: ignore[no-untyped-def]
     # Leads with a pooled fadd (a - b) and fmul (a * b) on cycle 0, so the iv gate is exercised on a real cycle-0 issue.
     return (a - b) * 0.25 + a * b
 

--- a/tests/test_install_landing.py
+++ b/tests/test_install_landing.py
@@ -16,14 +16,14 @@ from holoso import FloatFormat
 from holoso._frontend import lower as lower_frontend
 from holoso._hir import _if_convert as if_convert_pass
 from holoso._hir import optimize
-from holoso._lir import build
+from holoso._lir import Lir, build
 from holoso._mir import lower as lower_to_mir
 
-from ._examples import SPECS
+from ._examples import SPECS, ExampleSpec
 from ._modelref import assert_model_equals_interpreter, build_model_and_interpreter, default_ops
 
 
-def _build(spec):  # type: ignore[no-untyped-def]
+def _build(spec: ExampleSpec) -> Lir:
     return build(
         lower_to_mir(optimize(lower_frontend(spec.make_kernel())), default_ops(spec.formats[0])),
         spec.name,
@@ -32,7 +32,7 @@ def _build(spec):  # type: ignore[no-untyped-def]
 
 
 @pytest.mark.parametrize("spec", SPECS, ids=lambda s: s.name)
-def test_phi_arm_installs_land_within_their_block(spec) -> None:  # type: ignore[no-untyped-def]
+def test_phi_arm_installs_land_within_their_block(spec: ExampleSpec) -> None:
     lir = _build(spec)
     for block in lir.blocks:
         for install in (*block.copies, *block.bool_writes):

--- a/tests/test_install_landing.py
+++ b/tests/test_install_landing.py
@@ -12,15 +12,15 @@ of any input vector, so it holds for the data-dependent branch/loop kernels (uar
 import pytest
 
 import holoso
-from holoso import FloatFormat
+from holoso import FloatFormat, FloatValue
 from holoso._frontend import lower as lower_frontend
 from holoso._hir import _if_convert as if_convert_pass
 from holoso._hir import optimize
-from holoso._lir import Lir, build
+from holoso._lir import BoolWrite, FloatCopy, InlineScheduledOp, Lir, LirBlock, PooledScheduledOp, build
 from holoso._mir import lower as lower_to_mir
 
 from ._examples import SPECS, ExampleSpec
-from ._modelref import assert_model_equals_interpreter, build_model_and_interpreter, default_ops
+from ._modelref import Vector, assert_model_equals_interpreter, build_model_and_interpreter, default_ops
 
 
 def _build(spec: ExampleSpec) -> Lir:
@@ -31,11 +31,19 @@ def _build(spec: ExampleSpec) -> Lir:
     )
 
 
+def _phi_arm_installs(block: LirBlock) -> list[FloatCopy | BoolWrite]:
+    return [*block.copies, *block.bool_writes]
+
+
+def _block_ops(block: LirBlock) -> list[PooledScheduledOp | InlineScheduledOp]:
+    return [*block.ops, *block.inline_ops]
+
+
 @pytest.mark.parametrize("spec", SPECS, ids=lambda s: s.name)
 def test_phi_arm_installs_land_within_their_block(spec: ExampleSpec) -> None:
     lir = _build(spec)
     for block in lir.blocks:
-        for install in (*block.copies, *block.bool_writes):
+        for install in _phi_arm_installs(block):
             landing = install.landing(lir.fetch_lag)  # block-local; same fire+read-first edge the model/emitter commit
             assert landing <= block.term_offset, (
                 f"{spec.name} block {block.index}: install of {install.dst} lands at {landing}, past the terminator "
@@ -55,7 +63,7 @@ def test_targets_still_exercise_constant_installs(name: str) -> None:
     """
     spec = next(s for s in SPECS if s.name == name)
     lir = _build(spec)
-    const_installs = [x for b in lir.blocks for x in (*b.bool_writes, *b.copies) if x.is_const]
+    const_installs = [x for b in lir.blocks for x in _phi_arm_installs(b) if x.is_const]
     assert const_installs, f"{name} no longer emits constant phi-arm installs; the kernel shape changed"
 
 
@@ -69,9 +77,7 @@ def test_resident_register_source_install_is_inline_class() -> None:
     freeze (127); here we pin that the input path is what is being exercised.
     """
     lir = _build(next(s for s in SPECS if s.name == "uart_rx"))
-    resident_non_const = [
-        x for b in lir.blocks for x in (*b.bool_writes, *b.copies) if x.resident_source and not x.is_const
-    ]
+    resident_non_const = [x for b in lir.blocks for x in _phi_arm_installs(b) if x.resident_source and not x.is_const]
     assert resident_non_const, "uart_rx lost its non-const resident-source (input) install, or the predicate regressed"
 
 
@@ -89,7 +95,7 @@ def test_computed_copy_not_last_work_fits_at_work_makespan() -> None:
     bodies = [b for b in lir.blocks if any(not c.resident_source for c in b.copies)]
     assert bodies, "recip_newton no longer has a computed-source phi-arm copy; the kernel shape changed"
     for b in bodies:
-        work = max((op.commit_cycle for op in (*b.ops, *b.inline_ops)), default=0)
+        work = max((op.commit_cycle for op in _block_ops(b)), default=0)
         assert b.block_makespan == work, (
             f"recip_newton block {b.index}: a computed copy still pushes the makespan ({b.block_makespan} > work "
             f"{work}) -- the loop-carried install pin regressed to the conservative +1"
@@ -180,8 +186,8 @@ def test_cross_block_source_install_residence_stays_in_predecessor_frame() -> No
 
     fmt = FloatFormat(8, 36)
     model, interpreter = build_model_and_interpreter(kernel, ops, "live_through_arm")
-    vectors = [
-        [c, fmt.decode(fmt.encode(a)), fmt.decode(fmt.encode(b))]
+    vectors: list[Vector] = [
+        [c, FloatValue.from_float(fmt, a), FloatValue.from_float(fmt, b)]
         for c in (True, False)
         for a in (2.0, 5.0, 0.5, 9.0, 1.5)
         for b in (3.0, 1.5, 4.0, 0.25)
@@ -224,7 +230,7 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
         blk
         for blk in lir.blocks
         if any(not c.resident_source for c in blk.copies)
-        and blk.block_makespan == max((op.commit_cycle for op in (*blk.ops, *blk.inline_ops)), default=0) + 1
+        and blk.block_makespan == max((op.commit_cycle for op in _block_ops(blk)), default=0) + 1
     ]
     assert pushed, "no block takes the in-block +1 for a last-work copy source; the kernel shape changed"
     for blk in lir.blocks:
@@ -232,8 +238,8 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
 
     fmt = FloatFormat(8, 36)
     model, interpreter = build_model_and_interpreter(kernel, ops, "last_work_arm")
-    vectors = [
-        [c, fmt.decode(fmt.encode(a)), fmt.decode(fmt.encode(b))]
+    vectors: list[Vector] = [
+        [c, FloatValue.from_float(fmt, a), FloatValue.from_float(fmt, b)]
         for c in (True, False)
         for a in (2.0, 5.0, 0.5, 9.0, 1.5)
         for b in (3.0, 1.5, 4.0, 0.25)

--- a/tests/test_language_features.py
+++ b/tests/test_language_features.py
@@ -35,7 +35,7 @@ def _ops() -> OpConfig:
     )
 
 
-def _model(target: object):  # type: ignore[no-untyped-def]
+def _model(target: object) -> holoso.NumericalSimulator:
     return holoso.synthesize(target, _ops()).numerical_model.elaborate()
 
 
@@ -500,7 +500,7 @@ class _GetterOverridingProperty(property):
     so inlining ``fget`` (True) would silently diverge. Inlining is faithful only when ``__get__`` is property's own.
     """
 
-    def __get__(self, instance, owner=None):  # type: ignore[override]
+    def __get__(self, instance: object, owner: type | None = None) -> bool:  # type: ignore[override]
         return False
 
 
@@ -522,7 +522,7 @@ def test_property_subclass_overriding_get_is_rejected() -> None:
         holoso.synthesize(_PropertySubclassRead().__call__, _ops())
 
 
-def _spoofed_getter(self) -> bool:  # type: ignore[no-untyped-def]  # getter signature so a naive inline succeeds
+def _spoofed_getter(self: object) -> bool:  # getter signature so a naive inline succeeds
     return False  # the callable a hostile fget spoof hands the compiler -- the opposite of the real getter below
 
 
@@ -533,7 +533,7 @@ class _FgetSpoofingProperty(property):
     diverges from what Python runs. Defeats a ``__get__``-identity guard; only the exact type is trustworthy.
     """
 
-    def __getattribute__(self, name):  # type: ignore[no-untyped-def]
+    def __getattribute__(self, name: str) -> object:
         if name == "fget":
             return _spoofed_getter
         return super().__getattribute__(name)
@@ -562,7 +562,7 @@ class _GetterOverridingStaticmethod(staticmethod):
     overridden binding, so inlining ``__func__`` would diverge. Faithful only when ``__get__`` is staticmethod's own.
     """
 
-    def __get__(self, instance, owner=None):  # type: ignore[override]
+    def __get__(self, instance: object, owner: type | None = None) -> object:  # type: ignore[override]
         return lambda v: v * 3.0
 
 

--- a/tests/test_language_features.py
+++ b/tests/test_language_features.py
@@ -10,6 +10,8 @@ analysis -- both behavioral, not mere input validation.
 """
 
 import itertools
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import pytest
@@ -35,7 +37,7 @@ def _ops() -> OpConfig:
     )
 
 
-def _model(target: object) -> holoso.NumericalSimulator:
+def _model(target: Callable[..., object]) -> holoso.NumericalSimulator:
     return holoso.synthesize(target, _ops()).numerical_model.elaborate()
 
 
@@ -48,7 +50,7 @@ def _xor_chain(a: bool, b: bool, c: bool, d: bool) -> bool:
 
 
 def _float_xor(x: float, y: float) -> float:
-    return x ^ y
+    return x ^ y  # type: ignore[operator, no-any-return]  # deliberately ill-typed: exercises rejection of float ^
 
 
 def test_bool_xor_truth_table() -> None:
@@ -198,9 +200,9 @@ def _instance_shadow(x: float) -> float:
 
 class _ShadowedMethod:
     def __init__(self) -> None:
-        self._mix = _instance_shadow  # an instance attribute that shadows the same-named method
+        self._mix = _instance_shadow  # type: ignore[method-assign]  # shadows the same-named method below
 
-    def _mix(self, x: float) -> float:  # type: ignore[no-redef]  # shadowed at runtime by the __init__ binding
+    def _mix(self, x: float) -> float:  # shadowed at runtime by the __init__ binding
         return x * 2
 
     def __call__(self, x: float) -> float:
@@ -556,7 +558,7 @@ def test_property_subclass_spoofing_fget_is_rejected() -> None:
         holoso.synthesize(_PropertyFgetSpoof().__call__, _ops())
 
 
-class _GetterOverridingStaticmethod(staticmethod):
+class _GetterOverridingStaticmethod(staticmethod[..., Any]):
     """
     A ``staticmethod`` subclass whose ``__get__`` returns a different callable than ``__func__``: Python calls the
     overridden binding, so inlining ``__func__`` would diverge. Faithful only when ``__get__`` is staticmethod's own.
@@ -572,7 +574,7 @@ class _StaticmethodSubclassCall:
         return v * 2.0  # __func__: what reading descriptor.__func__ would inline -- but __get__ binds x*3 instead
 
     def __call__(self, x: float, /) -> float:
-        return self._scale(x)  # Python calls __get__'s binding (x*3); inlining __func__ would compute x*2
+        return self._scale(x)  # type: ignore[no-any-return, operator]  # __get__ binds x*3; __func__ would give x*2
 
 
 def test_staticmethod_subclass_overriding_get_is_rejected() -> None:
@@ -589,6 +591,8 @@ class _Meta(type):
 
 
 class _MetaclassPropertyShadow(metaclass=_Meta):
+    flag: bool  # declared only for typing; set via __dict__ below, never through this class's own namespace
+
     def __init__(self) -> None:
         self.__dict__["flag"] = True  # a LIVE instance attribute: the metaclass property does not govern instances
 

--- a/tests/test_latency_freeze.py
+++ b/tests/test_latency_freeze.py
@@ -25,7 +25,8 @@ import holoso
 from holoso import FloatFormat
 from holoso._frontend import lower as lower_frontend
 from holoso._hir import optimize
-from holoso._lir import build
+from holoso._lir import FloatStateSlot, build
+from holoso._lir._ir import BoolStateSlot
 from holoso._mir import lower as lower_to_mir
 
 from ._examples import SPECS
@@ -105,17 +106,20 @@ class _BoolShift3:
 # Chained-copy kernels and their frozen (min II, last PC). _Delay3 exercises the wide bank's tapped_by_other path,
 # _BoolShift3 the boolean bank's. _FMT is the wide e8m36 datapath the example matrix uses.
 _FMT = FloatFormat(8, 36)
-_CHAINED_COPY: list[tuple[str, object, tuple[int, int]]] = [
+_CHAINED_COPY: list[tuple[str, type[_Delay3] | type[_BoolShift3], tuple[int, int]]] = [
     ("delay3", _Delay3, (3, 3)),
     ("bool_shift3", _BoolShift3, (3, 3)),
 ]
 
 
 @pytest.mark.parametrize("name,kernel_cls,frozen", _CHAINED_COPY)
-def test_chained_copy_schedule_is_frozen(name: str, kernel_cls: object, frozen: tuple[int, int]) -> None:
+def test_chained_copy_schedule_is_frozen(
+    name: str, kernel_cls: type[_Delay3] | type[_BoolShift3], frozen: tuple[int, int]
+) -> None:
     lir = build(lower_to_mir(optimize(lower_frontend(kernel_cls().__call__)), default_ops(_FMT)), name, fetch_stages=3)
+    slots: list[FloatStateSlot | BoolStateSlot] = [*lir.float_state_slots, *lir.bool_state_slots]
     assert all(
-        slot.needs_copy for slot in (*lir.float_state_slots, *lir.bool_state_slots)
+        slot.needs_copy for slot in slots
     ), f"{name}: a chained-copy slot unexpectedly coalesced; the tapped_by_other path is no longer exercised"
     got = (lir.min_initiation_interval, lir.last_pc)
     assert got == frozen, (

--- a/tests/test_overlap_behavior.py
+++ b/tests/test_overlap_behavior.py
@@ -69,7 +69,7 @@ class _OverlapAccumulator:
     def __init__(self) -> None:
         self._acc = 0.0
 
-    def __call__(self, x, y, z):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float, y: float, z: float):  # type: ignore[no-untyped-def]
         w = (x * z + y) * z + y  # wide chain: commits late, spills past the shrunk terminator into both arms
         if x < y:
             r = w + 1.0  # then-arm reads the spilled w
@@ -170,7 +170,7 @@ def test_two_deep_shift_register_delays_by_two_and_resets() -> None:
             self._a = 0.0
             self._b = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             out = self._b
             self._b = self._a
             self._a = x
@@ -187,7 +187,7 @@ def test_two_deep_shift_register_delays_by_two_and_resets() -> None:
 
 
 def test_nested_pure_diamond_output_matches_reference() -> None:
-    def nested_pure(x, y):  # type: ignore[no-untyped-def]
+    def nested_pure(x: float, y: float):  # type: ignore[no-untyped-def]
         # A two-level pure diamond: every arm is speculatable, so it fully if-converts to selects. All four leaves and
         # the decision boundaries must be exact (additive/subtractive combinations of representable inputs).
         if x > 0.0:
@@ -204,7 +204,7 @@ def test_nested_pure_diamond_output_matches_reference() -> None:
 
 
 def test_nested_division_branch_output_matches_reference() -> None:
-    def nested_div(x, y):  # type: ignore[no-untyped-def]
+    def nested_div(x: float, y: float):  # type: ignore[no-untyped-def]
         # A nested diamond whose inner arm divides: the division is unspeculatable, so the inner diamond stays a REAL
         # branch (it cannot if-convert). The divisor ``y*y + 1`` is structurally nonzero, so the path is always valid.
         if x > 0.0:
@@ -225,7 +225,7 @@ def test_nested_division_branch_output_matches_reference() -> None:
 
 
 def test_spilled_in_branch_condition_is_read_after_it_lands() -> None:
-    def spilled_branch_condition(a, b, c, d):  # type: ignore[no-untyped-def]
+    def spilled_branch_condition(a: float, b: float, c: float, d: float):  # type: ignore[no-untyped-def]
         # A boolean comparison produced in the entry but BRANCHED ON in a single-predecessor successor. The entry
         # overlaps into that successor, and the DEEP condition (a long product, committing late) lands past the entry's
         # shrunk terminator -- so it spills into the successor frame rather than being resident there. The successor's
@@ -267,7 +267,7 @@ def test_spilled_wide_mul_operand_is_read_after_it_lands() -> None:
     # terminator and is ORPHANED (the model KeyErrors on its register; a wrong arm in general). This guards the WHOLE
     # latency-1-pooled-op spill surface, not only the single fcmp shape -- and the defect is invisible to the
     # interpreter<->model differential, so only a behavioral spill-then-read kernel catches it.
-    def spilled_wide_mul(a, b, c, d):  # type: ignore[no-untyped-def]
+    def spilled_wide_mul(a: float, b: float, c: float, d: float):  # type: ignore[no-untyped-def]
         x = a * b * c * d
         if c > 0.0:
             if d > a:
@@ -293,7 +293,7 @@ def test_spilled_wide_mul_operand_is_read_after_it_lands() -> None:
 
 
 def test_mixed_select_and_real_branch_output_matches_reference() -> None:
-    def mixed_select_and_branch(x, y):  # type: ignore[no-untyped-def]
+    def mixed_select_and_branch(x: float, y: float):  # type: ignore[no-untyped-def]
         # One kernel mixing an if-converted (select) pure diamond and a real (division-bearing) branch: the max folds
         # to a select, the division gates a real branch. Both the select polarity and the branch decision are crossed.
         m = x if x > y else y  # pure diamond -> select
@@ -312,7 +312,7 @@ def test_mixed_select_and_real_branch_output_matches_reference() -> None:
 
 
 def test_diamond_inside_loop_output_matches_reference() -> None:
-    def diamond_in_loop(x, n):  # type: ignore[no-untyped-def]
+    def diamond_in_loop(x: float, n: float):  # type: ignore[no-untyped-def]
         # A division-bearing diamond INSIDE a real back-edge while loop: a real branch nested in a loop, exercising the
         # loop-header phi merge of the accumulator across a data-dependent trip count. The divisor stays structurally
         # nonzero on the dividing arm.
@@ -337,7 +337,7 @@ def test_diamond_inside_loop_output_matches_reference() -> None:
 
 
 def test_multi_output_mixed_io_metadata_and_values() -> None:
-    def multi_io(flag: bool, x, y):  # type: ignore[no-untyped-def]
+    def multi_io(flag: bool, x: float, y: float):  # type: ignore[no-untyped-def]
         # A boolean input gating a division branch, a tuple return mixing a bool and two floats: the divisor y*y + 1 is
         # structurally nonzero, so the flag-true arm is always valid.
         inside = flag and (x > y)
@@ -438,7 +438,7 @@ def test_octave_index_resident_output_drain_only_ret_matches_reference() -> None
     # |x| >= 1 magnitudes (abs and *0.5 are exact, so the count is unambiguous) and |x| < 1 values comfortably inside
     # an octave (their reciprocal does not round across an octave boundary), so the ZKF count equals the float64 count
     # exactly. Do NOT broaden post-hoc: a value near a power-of-two boundary can flip the rounded count by one.
-    def octave_index(x):  # type: ignore[no-untyped-def]
+    def octave_index(x: float):  # type: ignore[no-untyped-def]
         # The order of magnitude of x in octaves: halvings (or doublings, for |x| < 1) to bring |x| into (0.5, 1]. The
         # division-bearing magnitude diamond stays a real branch; its merge is an empty pass-through threaded into the
         # halving loop, whose Ret is a resident-output drain (the float ``octaves`` is produced in the loop body and
@@ -474,7 +474,7 @@ def test_cross_bank_chain_edges_match_reference() -> None:
     # bools are derived from the SAME Python expression, and the operands are kept clear of those boundaries.
     import itertools  # noqa: PLC0415
 
-    def cross_bank_chain(a, b, c, d):  # type: ignore[no-untyped-def]
+    def cross_bank_chain(a: float, b: float, c: float, d: float):  # type: ignore[no-untyped-def]
         # A deep cross-bank chain on the tight same-bank edge: back-to-back inline ``band``/``bor`` over comparisons, a
         # bool->float cast, a float op consuming the cast, and a float->bool reduction folded into a select. Inline ops
         # are latency 0 and the dependency edge is the unclamped landing-vs-read spacing, so this chain is the most

--- a/tests/test_overlap_behavior.py
+++ b/tests/test_overlap_behavior.py
@@ -69,7 +69,7 @@ class _OverlapAccumulator:
     def __init__(self) -> None:
         self._acc = 0.0
 
-    def __call__(self, x: float, y: float, z: float):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float, y: float, z: float) -> float:
         w = (x * z + y) * z + y  # wide chain: commits late, spills past the shrunk terminator into both arms
         if x < y:
             r = w + 1.0  # then-arm reads the spilled w
@@ -170,7 +170,7 @@ def test_two_deep_shift_register_delays_by_two_and_resets() -> None:
             self._a = 0.0
             self._b = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             out = self._b
             self._b = self._a
             self._a = x
@@ -187,7 +187,7 @@ def test_two_deep_shift_register_delays_by_two_and_resets() -> None:
 
 
 def test_nested_pure_diamond_output_matches_reference() -> None:
-    def nested_pure(x: float, y: float):  # type: ignore[no-untyped-def]
+    def nested_pure(x: float, y: float) -> float:
         # A two-level pure diamond: every arm is speculatable, so it fully if-converts to selects. All four leaves and
         # the decision boundaries must be exact (additive/subtractive combinations of representable inputs).
         if x > 0.0:
@@ -204,7 +204,7 @@ def test_nested_pure_diamond_output_matches_reference() -> None:
 
 
 def test_nested_division_branch_output_matches_reference() -> None:
-    def nested_div(x: float, y: float):  # type: ignore[no-untyped-def]
+    def nested_div(x: float, y: float) -> float:
         # A nested diamond whose inner arm divides: the division is unspeculatable, so the inner diamond stays a REAL
         # branch (it cannot if-convert). The divisor ``y*y + 1`` is structurally nonzero, so the path is always valid.
         if x > 0.0:
@@ -225,7 +225,7 @@ def test_nested_division_branch_output_matches_reference() -> None:
 
 
 def test_spilled_in_branch_condition_is_read_after_it_lands() -> None:
-    def spilled_branch_condition(a: float, b: float, c: float, d: float):  # type: ignore[no-untyped-def]
+    def spilled_branch_condition(a: float, b: float, c: float, d: float) -> float:
         # A boolean comparison produced in the entry but BRANCHED ON in a single-predecessor successor. The entry
         # overlaps into that successor, and the DEEP condition (a long product, committing late) lands past the entry's
         # shrunk terminator -- so it spills into the successor frame rather than being resident there. The successor's
@@ -267,7 +267,7 @@ def test_spilled_wide_mul_operand_is_read_after_it_lands() -> None:
     # terminator and is ORPHANED (the model KeyErrors on its register; a wrong arm in general). This guards the WHOLE
     # latency-1-pooled-op spill surface, not only the single fcmp shape -- and the defect is invisible to the
     # interpreter<->model differential, so only a behavioral spill-then-read kernel catches it.
-    def spilled_wide_mul(a: float, b: float, c: float, d: float):  # type: ignore[no-untyped-def]
+    def spilled_wide_mul(a: float, b: float, c: float, d: float) -> float:
         x = a * b * c * d
         if c > 0.0:
             if d > a:
@@ -293,7 +293,7 @@ def test_spilled_wide_mul_operand_is_read_after_it_lands() -> None:
 
 
 def test_mixed_select_and_real_branch_output_matches_reference() -> None:
-    def mixed_select_and_branch(x: float, y: float):  # type: ignore[no-untyped-def]
+    def mixed_select_and_branch(x: float, y: float) -> float:
         # One kernel mixing an if-converted (select) pure diamond and a real (division-bearing) branch: the max folds
         # to a select, the division gates a real branch. Both the select polarity and the branch decision are crossed.
         m = x if x > y else y  # pure diamond -> select
@@ -312,7 +312,7 @@ def test_mixed_select_and_real_branch_output_matches_reference() -> None:
 
 
 def test_diamond_inside_loop_output_matches_reference() -> None:
-    def diamond_in_loop(x: float, n: float):  # type: ignore[no-untyped-def]
+    def diamond_in_loop(x: float, n: float) -> float:
         # A division-bearing diamond INSIDE a real back-edge while loop: a real branch nested in a loop, exercising the
         # loop-header phi merge of the accumulator across a data-dependent trip count. The divisor stays structurally
         # nonzero on the dividing arm.
@@ -337,7 +337,7 @@ def test_diamond_inside_loop_output_matches_reference() -> None:
 
 
 def test_multi_output_mixed_io_metadata_and_values() -> None:
-    def multi_io(flag: bool, x: float, y: float):  # type: ignore[no-untyped-def]
+    def multi_io(flag: bool, x: float, y: float) -> tuple[bool, float, float]:
         # A boolean input gating a division branch, a tuple return mixing a bool and two floats: the divisor y*y + 1 is
         # structurally nonzero, so the flag-true arm is always valid.
         inside = flag and (x > y)
@@ -396,7 +396,7 @@ def test_latching_fault_register_streams_and_resets() -> None:
             self._overvoltage = False
             self._overtemp = False
 
-        def __call__(self, overcurrent: bool, overvoltage: bool, overtemp: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, overcurrent: bool, overvoltage: bool, overtemp: bool) -> tuple[bool, bool, bool, bool]:
             self._overcurrent = self._overcurrent or overcurrent
             self._overvoltage = self._overvoltage or overvoltage
             self._overtemp = self._overtemp or overtemp
@@ -438,7 +438,7 @@ def test_octave_index_resident_output_drain_only_ret_matches_reference() -> None
     # |x| >= 1 magnitudes (abs and *0.5 are exact, so the count is unambiguous) and |x| < 1 values comfortably inside
     # an octave (their reciprocal does not round across an octave boundary), so the ZKF count equals the float64 count
     # exactly. Do NOT broaden post-hoc: a value near a power-of-two boundary can flip the rounded count by one.
-    def octave_index(x: float):  # type: ignore[no-untyped-def]
+    def octave_index(x: float) -> float:
         # The order of magnitude of x in octaves: halvings (or doublings, for |x| < 1) to bring |x| into (0.5, 1]. The
         # division-bearing magnitude diamond stays a real branch; its merge is an empty pass-through threaded into the
         # halving loop, whose Ret is a resident-output drain (the float ``octaves`` is produced in the loop body and
@@ -474,7 +474,7 @@ def test_cross_bank_chain_edges_match_reference() -> None:
     # bools are derived from the SAME Python expression, and the operands are kept clear of those boundaries.
     import itertools  # noqa: PLC0415
 
-    def cross_bank_chain(a: float, b: float, c: float, d: float):  # type: ignore[no-untyped-def]
+    def cross_bank_chain(a: float, b: float, c: float, d: float) -> tuple[float, bool, bool]:
         # A deep cross-bank chain on the tight same-bank edge: back-to-back inline ``band``/``bor`` over comparisons, a
         # bool->float cast, a float op consuming the cast, and a float->bool reduction folded into a select. Inline ops
         # are latency 0 and the dependency edge is the unclamped landing-vs-read spacing, so this chain is the most

--- a/tests/test_overlap_behavior.py
+++ b/tests/test_overlap_behavior.py
@@ -86,7 +86,9 @@ def test_overlap_kernel_persistent_state_across_many_vectors() -> None:
     reference = _OverlapAccumulator()
     rng = np.random.default_rng(0xA11CE)
     samples = [(0.5, 0.5, 1.0), (2.0, 2.0, 1.0)]  # the x == y decision boundary on both sides
-    samples += [tuple(float(rng.uniform(-3.0, 3.0)) for _ in range(3)) for _ in range(60)]
+    samples += [
+        (float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0))) for _ in range(60)
+    ]
     for x, y, z in samples:
         got = float(simulator.run(x, y, z)[0])
         want = reference(x, y, z)

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -41,7 +41,7 @@ from holoso._hir import BoolSelect, FloatDiv as HirFloatDiv, Phi, Select
 from holoso._hir import _if_convert as if_convert_pass
 from holoso._hir._const_fold import run as fold_constants
 from holoso._lir import build
-from holoso._mir import lower as lower_to_mir, Mir, MirFloatConst, MirFloatInput, MirOperation
+from holoso._mir import lower as lower_to_mir, Mir, MirFloatConst, MirFloatInput, MirFloatOutput, MirOperation
 from holoso._operators import FMulILog2Operator, FloatSignControl
 from ._importguard import forbidden_imports
 from ._modelref import build_model
@@ -228,7 +228,7 @@ def test_wide_supported_pow2_uses_ilog2_operator() -> None:
     mir = _run(f, ops)
     selected = _ops(mir)
     assert [type(o.operator) for o in selected] == [FMulILog2Operator]
-    assert selected[0].operator.k == 4
+    assert isinstance(selected[0].operator, FMulILog2Operator) and selected[0].operator.k == 4
     assert _consts(mir) == []
 
 
@@ -279,6 +279,7 @@ def test_pure_sign_output_adds_no_operation() -> None:
 
     mir = _run(f)
     assert _ops(mir) == []
+    assert isinstance(mir.outputs[0], MirFloatOutput)
     assert mir.outputs[0].sign == FloatSignControl(absolute=True).then(FloatSignControl(negate=True))
 
 
@@ -525,7 +526,7 @@ def test_bool_select_reductions_are_truth_table_correct() -> None:
             y = not f
         return y
 
-    cases = [
+    cases: list[tuple[Callable[..., bool], Callable[..., bool], int, bool]] = [
         (s_tf, lambda c: c, 1, False),
         (s_ft, lambda c: not c, 1, False),
         (s_t_dyn, lambda c, f: c or f, 2, False),

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -179,7 +179,7 @@ def test_mir_constant_only_node_carries_float_type() -> None:
 
 
 def test_mul_by_pow2_const_becomes_ilog2() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a * 0.25
 
     ops = _ops(_run(f))
@@ -188,7 +188,7 @@ def test_mul_by_pow2_const_becomes_ilog2() -> None:
 
 
 def test_left_const_mul_pow2_is_commutative() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return 2 * a
 
     ops = _ops(_run(f))
@@ -197,7 +197,7 @@ def test_left_const_mul_pow2_is_commutative() -> None:
 
 
 def test_div_by_pow2_becomes_ilog2() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a / 4.0
 
     ops = _ops(_run(f))
@@ -206,7 +206,7 @@ def test_div_by_pow2_becomes_ilog2() -> None:
 
 
 def test_div_by_nonpow2_const_becomes_reciprocal_multiply() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a / 3.0
 
     mir = _run(f)
@@ -216,7 +216,7 @@ def test_div_by_nonpow2_const_becomes_reciprocal_multiply() -> None:
 
 
 def test_wide_supported_pow2_uses_ilog2_operator() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a * 16.0
 
     fmt = FloatFormat(3, 4)
@@ -231,7 +231,7 @@ def test_wide_supported_pow2_uses_ilog2_operator() -> None:
 
 
 def test_unsupported_pow2_shift_is_rejected() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a * 64.0
 
     fmt = FloatFormat(3, 4)
@@ -247,14 +247,14 @@ def test_unsupported_pow2_shift_is_rejected() -> None:
 
 
 def test_true_division_stays_fdiv() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a / b
 
     assert [type(o.operator) for o in _ops(_run(f))] == [FDivOperator]
 
 
 def test_subtraction_folds_into_second_operand_sign() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a - b
 
     ops = _ops(_run(f))
@@ -263,7 +263,7 @@ def test_subtraction_folds_into_second_operand_sign() -> None:
 
 
 def test_operand_negation_folds_into_operator() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a * (-b)
 
     ops = _ops(_run(f))
@@ -272,7 +272,7 @@ def test_operand_negation_folds_into_operator() -> None:
 
 
 def test_pure_sign_output_adds_no_operation() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return -abs(a)
 
     mir = _run(f)
@@ -281,7 +281,7 @@ def test_pure_sign_output_adds_no_operation() -> None:
 
 
 def test_selected_mir_has_only_input_const_operation_nodes() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     mir = _run(f)
@@ -316,7 +316,7 @@ def test_unclosed_loop_phi_is_rejected() -> None:
         builder.finish()
 
 
-def _deep_cfg_kernel(p0):  # type: ignore[no-untyped-def]
+def _deep_cfg_kernel(p0: float):  # type: ignore[no-untyped-def]
     # A doubly-nested unrolled loop (each trip count well under the unroll threshold) with a per-iteration branch.
     # Unrolling chains ~2700 basic blocks, so the CFG reverse-postorder DFS recurses far deeper than Python's default
     # recursion limit. The accumulator stays >=0, so every iteration takes the add arm: the result is the input + 900.
@@ -370,7 +370,7 @@ def _hir_of(target):  # type: ignore[no-untyped-def]
 
 
 def test_if_conversion_collapses_a_pure_diamond() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         if a > b:
             y = a + b
         else:
@@ -385,7 +385,7 @@ def test_if_conversion_collapses_a_pure_diamond() -> None:
 
 def test_if_conversion_refuses_an_unspeculatable_arm() -> None:
     # Division must not be speculated: a div-by-zero on the not-taken path would assert the module error flag.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         if a > b:
             y = a + b
         else:
@@ -400,7 +400,7 @@ def test_if_conversion_refuses_an_unspeculatable_arm() -> None:
 def test_if_conversion_respects_the_arm_size_budget(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 1)
 
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         if a > b:
             y = (a + b) * a + b  # three operations: over the per-arm budget of one
         else:
@@ -414,7 +414,7 @@ def test_if_conversion_respects_the_arm_size_budget(monkeypatch: pytest.MonkeyPa
 def test_if_conversion_knob_zero_disables_the_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)
 
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         if a > b:
             y = a + b
         else:
@@ -430,7 +430,7 @@ def test_if_conversion_knob_zero_disables_the_pass(monkeypatch: pytest.MonkeyPat
 def test_if_conversion_converts_a_boolean_phi_merge() -> None:
     # Bool-phi if-conversion: a diamond merging a boolean collapses to one block, the merge becoming a bool_select
     # (a float select is the wide dual). Both arms here are dynamic comparisons, so strength reduction keeps the mux.
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         if a > b:
             flag = b > c
         else:
@@ -446,7 +446,7 @@ def test_if_conversion_converts_a_boolean_phi_merge() -> None:
 def test_if_conversion_reduces_constant_armed_boolean_select() -> None:
     # The state-machine merge shape: arms are boolean constants, so the bool_select reduces to and/or/not via strength
     # reduction (no select node survives), exactly the schmitt/pfd collapse to a single straight-line block.
-    def f(a, b, hold: bool):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, hold: bool):  # type: ignore[no-untyped-def]
         if a > b:
             flag = True
         else:
@@ -548,7 +548,7 @@ def test_bool_select_reductions_are_truth_table_correct() -> None:
 
 
 def test_if_conversion_collapses_nested_chains_to_one_block() -> None:
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         if x > 0.0:
             a = x + y
         else:
@@ -568,7 +568,7 @@ def test_if_conversion_collapses_nested_chains_to_one_block() -> None:
 def test_if_conversion_repoints_loop_header_phi_arms() -> None:
     # A diamond inside a while body: the dissolved merge block fed the loop-header phis, whose arms must repoint to
     # the spliced block (the localized pin for the repoint path; the examples exercise it only end-to-end).
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         w = x
         while w > 0.0:
             if w > 2.0:
@@ -600,7 +600,7 @@ def test_dead_diamond_frees_its_condition_cone() -> None:
     # its condition cone becomes ordinary dead code -- INCLUDING an error-bearing division feeding only the
     # condition, which then reports nothing (exactly as an unused division without a branch around it reports
     # nothing today). This pins the documented semantics of the error sideband: executed operators only.
-    def f(a, b, x):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, x: float):  # type: ignore[no-untyped-def]
         if bool(a / b):
             y = x + 1.0
         else:

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -1,6 +1,7 @@
 """Unit tests for HIR optimization and MIR selection passes."""
 
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar
@@ -27,6 +28,7 @@ from holoso._hir import (
     FloatAdd,
     FloatConst,
     FloatType as HirFloatType,
+    Hir,
     HirBuilder,
     InPort,
     Operation,
@@ -81,7 +83,7 @@ class OtherFold(Operator):
         return f"other_fold({operand})"
 
 
-def _run(target, ops: OpConfig = OPS) -> Mir:  # type: ignore[no-untyped-def]
+def _run(target: Callable[..., object], ops: OpConfig = OPS) -> Mir:
     return lower_to_mir(optimize(lower(target)), ops)
 
 
@@ -100,7 +102,7 @@ def _consts(mir: Mir) -> list[float]:
 def test_hir_nodes_carry_float_type() -> None:
     builder = HirBuilder()
     builder.block()
-    a = builder.float_input("a")
+    a = builder.input("a", HirFloatType())
     one = builder.float_const(1.0)
     y = builder.operation(FloatAdd(), [a, one])
     builder.output("out_0", y)
@@ -119,7 +121,7 @@ def test_hir_builder_rejects_wrong_semantic_operand_type() -> None:
     builder = HirBuilder()
     builder.block()
     a = builder.input("a", OtherType())
-    b = builder.float_input("b")
+    b = builder.input("b", HirFloatType())
     try:
         builder.operation(FloatAdd(), [a, b])
     except ValueError as ex:
@@ -145,7 +147,7 @@ def test_lower_rejects_non_float_hir_input_type() -> None:
 
 
 def test_hir_constant_folding_returns_float_const() -> None:
-    def f():  # type: ignore[no-untyped-def]
+    def f() -> float:
         return 1.25 + 2.0
 
     hir = optimize(lower(f))
@@ -169,7 +171,7 @@ def test_hir_constant_folding_preserves_const_subclass() -> None:
 
 
 def test_mir_constant_only_node_carries_float_type() -> None:
-    def f():  # type: ignore[no-untyped-def]
+    def f() -> float:
         return 3.5
 
     mir = _run(f)
@@ -179,7 +181,7 @@ def test_mir_constant_only_node_carries_float_type() -> None:
 
 
 def test_mul_by_pow2_const_becomes_ilog2() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a * 0.25
 
     ops = _ops(_run(f))
@@ -188,7 +190,7 @@ def test_mul_by_pow2_const_becomes_ilog2() -> None:
 
 
 def test_left_const_mul_pow2_is_commutative() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return 2 * a
 
     ops = _ops(_run(f))
@@ -197,7 +199,7 @@ def test_left_const_mul_pow2_is_commutative() -> None:
 
 
 def test_div_by_pow2_becomes_ilog2() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a / 4.0
 
     ops = _ops(_run(f))
@@ -206,7 +208,7 @@ def test_div_by_pow2_becomes_ilog2() -> None:
 
 
 def test_div_by_nonpow2_const_becomes_reciprocal_multiply() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a / 3.0
 
     mir = _run(f)
@@ -216,7 +218,7 @@ def test_div_by_nonpow2_const_becomes_reciprocal_multiply() -> None:
 
 
 def test_wide_supported_pow2_uses_ilog2_operator() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a * 16.0
 
     fmt = FloatFormat(3, 4)
@@ -231,7 +233,7 @@ def test_wide_supported_pow2_uses_ilog2_operator() -> None:
 
 
 def test_unsupported_pow2_shift_is_rejected() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a * 64.0
 
     fmt = FloatFormat(3, 4)
@@ -247,14 +249,14 @@ def test_unsupported_pow2_shift_is_rejected() -> None:
 
 
 def test_true_division_stays_fdiv() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a / b
 
     assert [type(o.operator) for o in _ops(_run(f))] == [FDivOperator]
 
 
 def test_subtraction_folds_into_second_operand_sign() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a - b
 
     ops = _ops(_run(f))
@@ -263,7 +265,7 @@ def test_subtraction_folds_into_second_operand_sign() -> None:
 
 
 def test_operand_negation_folds_into_operator() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a * (-b)
 
     ops = _ops(_run(f))
@@ -272,7 +274,7 @@ def test_operand_negation_folds_into_operator() -> None:
 
 
 def test_pure_sign_output_adds_no_operation() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return -abs(a)
 
     mir = _run(f)
@@ -281,7 +283,7 @@ def test_pure_sign_output_adds_no_operation() -> None:
 
 
 def test_selected_mir_has_only_input_const_operation_nodes() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     mir = _run(f)
@@ -306,7 +308,7 @@ def test_unclosed_loop_phi_is_rejected() -> None:
     builder = HirBuilder()
     entry = builder.block()
     header = builder.block()
-    x = builder.float_input("x")
+    x = builder.input("x", HirFloatType())
     builder.position_at(entry)
     builder.jump(header)
     builder.position_at(header)
@@ -316,7 +318,7 @@ def test_unclosed_loop_phi_is_rejected() -> None:
         builder.finish()
 
 
-def _deep_cfg_kernel(p0: float):  # type: ignore[no-untyped-def]
+def _deep_cfg_kernel(p0: float) -> float:
     # A doubly-nested unrolled loop (each trip count well under the unroll threshold) with a per-iteration branch.
     # Unrolling chains ~2700 basic blocks, so the CFG reverse-postorder DFS recurses far deeper than Python's default
     # recursion limit. The accumulator stays >=0, so every iteration takes the add arm: the result is the input + 900.
@@ -365,12 +367,12 @@ def test_const_fold_handles_absorbing_and_identity_boolean_connectives() -> None
     assert isinstance(out["and_id"], InPort) and out["and_id"].name == "x"  # x and True -> x  (identity dropped)
 
 
-def _hir_of(target):  # type: ignore[no-untyped-def]
+def _hir_of(target: object) -> Hir:
     return optimize(lower(target))
 
 
 def test_if_conversion_collapses_a_pure_diamond() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         if a > b:
             y = a + b
         else:
@@ -385,7 +387,7 @@ def test_if_conversion_collapses_a_pure_diamond() -> None:
 
 def test_if_conversion_refuses_an_unspeculatable_arm() -> None:
     # Division must not be speculated: a div-by-zero on the not-taken path would assert the module error flag.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         if a > b:
             y = a + b
         else:
@@ -400,7 +402,7 @@ def test_if_conversion_refuses_an_unspeculatable_arm() -> None:
 def test_if_conversion_respects_the_arm_size_budget(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 1)
 
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         if a > b:
             y = (a + b) * a + b  # three operations: over the per-arm budget of one
         else:
@@ -414,7 +416,7 @@ def test_if_conversion_respects_the_arm_size_budget(monkeypatch: pytest.MonkeyPa
 def test_if_conversion_knob_zero_disables_the_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)
 
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         if a > b:
             y = a + b
         else:
@@ -430,7 +432,7 @@ def test_if_conversion_knob_zero_disables_the_pass(monkeypatch: pytest.MonkeyPat
 def test_if_conversion_converts_a_boolean_phi_merge() -> None:
     # Bool-phi if-conversion: a diamond merging a boolean collapses to one block, the merge becoming a bool_select
     # (a float select is the wide dual). Both arms here are dynamic comparisons, so strength reduction keeps the mux.
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> float:
         if a > b:
             flag = b > c
         else:
@@ -446,7 +448,7 @@ def test_if_conversion_converts_a_boolean_phi_merge() -> None:
 def test_if_conversion_reduces_constant_armed_boolean_select() -> None:
     # The state-machine merge shape: arms are boolean constants, so the bool_select reduces to and/or/not via strength
     # reduction (no select node survives), exactly the schmitt/pfd collapse to a single straight-line block.
-    def f(a: float, b: float, hold: bool):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, hold: bool) -> float:
         if a > b:
             flag = True
         else:
@@ -467,56 +469,56 @@ def test_bool_select_reductions_are_truth_table_correct() -> None:
     # against its Python reference; a wrong identity -- e.g. (c,False,True) reduced to c not ~c -- mismatches here.
     import itertools
 
-    def s_tf(c: bool):  # type: ignore[no-untyped-def]   # (c, True, False) -> c
+    def s_tf(c: bool) -> bool:  # (c, True, False) -> c
         if c:
             y = True
         else:
             y = False
         return y
 
-    def s_ft(c: bool):  # type: ignore[no-untyped-def]   # (c, False, True) -> not c
+    def s_ft(c: bool) -> bool:  # (c, False, True) -> not c
         if c:
             y = False
         else:
             y = True
         return y
 
-    def s_t_dyn(c: bool, f: bool):  # type: ignore[no-untyped-def]   # (c, True, f) -> c or f
+    def s_t_dyn(c: bool, f: bool) -> bool:  # (c, True, f) -> c or f
         if c:
             y = True
         else:
             y = f
         return y
 
-    def s_f_dyn(c: bool, f: bool):  # type: ignore[no-untyped-def]   # (c, False, f) -> (not c) and f
+    def s_f_dyn(c: bool, f: bool) -> bool:  # (c, False, f) -> (not c) and f
         if c:
             y = False
         else:
             y = f
         return y
 
-    def s_dyn_t(c: bool, t: bool):  # type: ignore[no-untyped-def]   # (c, t, True) -> (not c) or t
+    def s_dyn_t(c: bool, t: bool) -> bool:  # (c, t, True) -> (not c) or t
         if c:
             y = t
         else:
             y = True
         return y
 
-    def s_dyn_f(c: bool, t: bool):  # type: ignore[no-untyped-def]   # (c, t, False) -> c and t
+    def s_dyn_f(c: bool, t: bool) -> bool:  # (c, t, False) -> c and t
         if c:
             y = t
         else:
             y = False
         return y
 
-    def s_dyn_dyn(c: bool, t: bool, f: bool):  # type: ignore[no-untyped-def]   # (c, t, f) -> bool_select kept
+    def s_dyn_dyn(c: bool, t: bool, f: bool) -> bool:  # (c, t, f) -> bool_select kept
         if c:
             y = t
         else:
             y = f
         return y
 
-    def s_dyn_not_dyn(c: bool, t: bool, f: bool):  # type: ignore[no-untyped-def]  # (c, t, ~f) -> kept, arm inverted
+    def s_dyn_not_dyn(c: bool, t: bool, f: bool) -> bool:  # (c, t, ~f) -> kept, arm inverted
         if c:
             y = t
         else:
@@ -548,7 +550,7 @@ def test_bool_select_reductions_are_truth_table_correct() -> None:
 
 
 def test_if_conversion_collapses_nested_chains_to_one_block() -> None:
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         if x > 0.0:
             a = x + y
         else:
@@ -568,7 +570,7 @@ def test_if_conversion_collapses_nested_chains_to_one_block() -> None:
 def test_if_conversion_repoints_loop_header_phi_arms() -> None:
     # A diamond inside a while body: the dissolved merge block fed the loop-header phis, whose arms must repoint to
     # the spliced block (the localized pin for the repoint path; the examples exercise it only end-to-end).
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         w = x
         while w > 0.0:
             if w > 2.0:
@@ -600,7 +602,7 @@ def test_dead_diamond_frees_its_condition_cone() -> None:
     # its condition cone becomes ordinary dead code -- INCLUDING an error-bearing division feeding only the
     # condition, which then reports nothing (exactly as an unused division without a branch around it reports
     # nothing today). This pins the documented semantics of the error sideband: executed operators only.
-    def f(a: float, b: float, x: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, x: float) -> float:
         if bool(a / b):
             y = x + 1.0
         else:

--- a/tests/test_public_api_behavior.py
+++ b/tests/test_public_api_behavior.py
@@ -28,6 +28,8 @@ These complement test_overlap_behavior.py (the M7 cross-block-overlap surface). 
     subexpression folds, and a comparison of two compile-time constants folds an arm away (still correct).
 """
 
+from collections.abc import Callable
+
 import numpy as np
 
 import holoso
@@ -54,7 +56,7 @@ def _ops() -> OpConfig:
     )
 
 
-def _sim(fn, name: str) -> holoso.NumericalSimulator:  # type: ignore[no-untyped-def]
+def _sim(fn: Callable[..., object], name: str) -> holoso.NumericalSimulator:
     return holoso.synthesize(fn, _ops(), name=name).numerical_model.elaborate()
 
 
@@ -64,12 +66,12 @@ def _close(got: float, want: float, op_count: int = 12) -> bool:
     return within(got, want, rtol, atol)
 
 
-def _abs_via_select(x: float, c: float):  # type: ignore[no-untyped-def]
+def _abs_via_select(x: float, c: float) -> float:
     # x if c>0 else -x : the negation folds into the select's operand sign conditioner -- one compare, one mux.
     return x if c > 0.0 else -x
 
 
-def _neg_abs_via_select(x: float, c: float):  # type: ignore[no-untyped-def]
+def _neg_abs_via_select(x: float, c: float) -> float:
     # The sign rides the OTHER arm, exercising the conditioner on the opposite operand. Both arms are sign chains over
     # the same input, so the whole diamond collapses to one select.
     return -x if c > 0.0 else x
@@ -86,7 +88,7 @@ def test_sign_folds_into_select_both_orientations() -> None:
             assert float(sim_b.run(x, c)[0]) == _neg_abs_via_select(x, c), f"neg_abs x={x} c={c}"
 
 
-def _cmp_select_float_chain(x: float, y: float):  # type: ignore[no-untyped-def]
+def _cmp_select_float_chain(x: float, y: float) -> float:
     # max(x, y) via a pure compare->select diamond, then a float multiply -- a cross-bank chain (boolean comparison
     # feeding a wide select feeding a wide multiply) that stays STRAIGHT-LINE (no branch). Doubling is exact in ZKF.
     return (x if x > y else y) * 2.0
@@ -102,7 +104,7 @@ def test_comparison_select_float_chain_stays_straight_line() -> None:
                 assert got == _cmp_select_float_chain(*xy), f"xy={xy}: {got}"
 
 
-def _diff_arith_select(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
+def _diff_arith_select(x: float, y: float, c: float) -> float:
     # A select whose two arms are DIFFERENT arithmetic (product vs sum), both speculatable -> if-converts to a select
     # over two distinct sub-DAGs.
     return (x * y) if c > 0.0 else (x + y)
@@ -118,7 +120,7 @@ def test_select_arms_different_arithmetic() -> None:
                 assert _close(got, want, op_count=4), f"x={x} y={y} c={c}: {got} vs {want}"
 
 
-def _nested_ternary(x: float, y: float):  # type: ignore[no-untyped-def]
+def _nested_ternary(x: float, y: float) -> float:
     # A nested ternary in expression position: the inner sign-select is one arm of the outer select. All four leaves
     # are sign chains of representable inputs, so every result is exact.
     return (x if x > 0.0 else -x) if y > 0.0 else (y if x > 0.0 else -y)
@@ -131,14 +133,14 @@ def test_nested_ternary_select() -> None:
             assert float(sim.run(x, y)[0]) == _nested_ternary(x, y), f"x={x} y={y}"
 
 
-def _ifconv_division_form(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
+def _ifconv_division_form(x: float, y: float, c: float) -> float:
     # IF-CONVERTIBLE formulation: the diamond merges two speculatable arms (add/sub), then ONE division outside it.
     # The select collapses the diamond to straight-line code; the division is not inside an arm, so nothing blocks it.
     m = (x + y) if c > 0.0 else (x - y)
     return m / (y * y + 1.0)  # structurally-nonzero, non-power-of-two divisor
 
 
-def _real_branch_division_form(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
+def _real_branch_division_form(x: float, y: float, c: float) -> float:
     # REAL-BRANCH formulation of the SAME math: each arm carries the (unspeculatable) division, so the diamond CANNOT
     # if-convert and stays a genuine branch -- yet the value computed on each path is identical to the if-converted
     # form. The two must agree (a strong cross-check: one compiles to a select + one divide, the other to a branch
@@ -172,7 +174,7 @@ def test_ifconvertible_and_real_branch_forms_agree() -> None:
 # M3: ``not`` never materializes hardware -- it folds into the consumer's sideband on the CONSUMER side.
 
 
-def _not_in_branch_condition(c: bool, x: float, y: float):  # type: ignore[no-untyped-def]
+def _not_in_branch_condition(c: bool, x: float, y: float) -> float:
     if not c:
         r = x + y
     else:
@@ -188,7 +190,7 @@ def test_not_as_branch_condition() -> None:
             assert got == _not_in_branch_condition(c, x, y), f"c={c} x={x} y={y}: {got}"
 
 
-def _not_in_boolean_logic(a: bool, b: bool):  # type: ignore[no-untyped-def]
+def _not_in_boolean_logic(a: bool, b: bool) -> bool:
     return a and not b
 
 
@@ -201,7 +203,7 @@ def test_not_in_boolean_logic_operand() -> None:
             assert got is want, f"a={a} b={b}: {got} vs {want}"
 
 
-def _not_as_output(c: bool):  # type: ignore[no-untyped-def]
+def _not_as_output(c: bool) -> bool:
     return not c
 
 
@@ -230,7 +232,7 @@ def test_not_drives_boolean_state_slot() -> None:
         assert sim.run()[0] is reference()
 
 
-def _not_in_phi_arm(c: bool, d: bool):  # type: ignore[no-untyped-def]
+def _not_in_phi_arm(c: bool, d: bool) -> bool:
     return (not d) if c else d
 
 
@@ -243,7 +245,7 @@ def test_not_in_boolean_phi_arm() -> None:
             assert got is want, f"c={c} d={d}: {got} vs {want}"
 
 
-def _double_negation(c: bool):  # type: ignore[no-untyped-def]
+def _double_negation(c: bool) -> bool:
     # ``not not c`` must fold to the identity (two consumer-side inversions cancel).
     return not not c
 
@@ -254,7 +256,7 @@ def test_double_negation_is_identity() -> None:
     assert sim.run(False)[0] is False
 
 
-def _comparison_both_polarities(x: float, y: float):  # type: ignore[no-untyped-def]
+def _comparison_both_polarities(x: float, y: float) -> tuple[bool, float]:
     # ONE comparison consumed in BOTH polarities: ``x > y`` drives a boolean output directly, and ``not (x > y)`` (the
     # complement) gates a float select. One comparator tap must serve both -- the polarities must stay consistent.
     gt = x > y
@@ -274,7 +276,7 @@ def test_comparison_in_both_polarities() -> None:
                 assert float(got[1]) == want_val, f"xy={xy}: val {float(got[1])} vs {want_val}"
 
 
-def _pure_recurrence(x: float, n: float):  # type: ignore[no-untyped-def]
+def _pure_recurrence(x: float, n: float) -> float:
     # A PURE loop-carried recurrence (no division -- the existing in-loop test is division-bearing): a Horner-like
     # multiply-accumulate over a data-dependent trip count. The header phi for ``acc`` is loop-carried; its live-in
     # overlaps its back-edge arm, so the coalescer must judge it correctly (it keeps a copy where it must, coalesces
@@ -296,7 +298,7 @@ def test_pure_loop_carried_recurrence_matches_reference() -> None:
         assert _close(got, want, op_count=2 * max(1, int(n)) + 2), f"x={x} n={n}: {got} vs {want}"
 
 
-def _soundness_corner(x: float, n: float):  # type: ignore[no-untyped-def]
+def _soundness_corner(x: float, n: float) -> float:
     # The coalescing soundness corner: a REAL diamond INSIDE a loop whose arms reuse an input (``x``) that is ALSO the
     # seed of the phi result (``acc`` is seeded from x and is the loop-carried header phi), branching ON that phi
     # result (``acc > 0.0``). The else arm divides (structurally-nonzero, non-power-of-two divisor) so the diamond
@@ -320,7 +322,7 @@ def test_coalescing_soundness_corner_matches_reference() -> None:
         assert _close(got, want, op_count=2 * max(1, int(n)) + 2), f"x={x} n={n}: {got} vs {want}"
 
 
-def _mixed_tuple_io(flag: bool, x: float, y: float):  # type: ignore[no-untyped-def]
+def _mixed_tuple_io(flag: bool, x: float, y: float) -> tuple[bool, float, float]:
     # The two float outputs are exact (sum/difference of representable inputs).
     inside = flag and (x > y)
     return inside, x + y, x - y
@@ -360,23 +362,24 @@ def test_logical_port_is_the_single_public_port_type() -> None:
     assert all(isinstance(port, holoso.LogicalPort) for port in (*sim.inputs, *sim.outputs))
 
 
-def _mixed_list_io(flag: bool, x: float):  # type: ignore[no-untyped-def]
-    # A LIST return (vs the tuple above) mixing a float and a bool: same aggregate-flattening path, different literal.
-    return [x + 1.0, not flag]
+def _mixed_list_io(flag: bool, x: float) -> list[float]:
+    # A LIST-literal return (vs the tuple above): the same aggregate-flattening path through a list, with a bool cast
+    # into a float lane.
+    return [x + 1.0, float(flag)]
 
 
 def test_mixed_list_io_metadata_and_values() -> None:
     sim = _sim(_mixed_list_io, "mixed_list")
     assert [(p.name, p.scalar_type) for p in sim.inputs] == [("flag", BoolType()), ("x", FloatType(FMT))]
-    assert [(p.name, p.scalar_type) for p in sim.outputs] == [("out_0", FloatType(FMT)), ("out_1", BoolType())]
+    assert [(p.name, p.scalar_type) for p in sim.outputs] == [("out_0", FloatType(FMT)), ("out_1", FloatType(FMT))]
     for flag in (True, False):
         for x in (-2.0, 0.0, 3.0):
             got = sim.run(flag, x)
             assert float(got[0]) == x + 1.0, f"flag={flag} x={x}: {float(got[0])}"
-            assert got[1] is (not flag), f"flag={flag} x={x}: {got[1]}"
+            assert float(got[1]) == float(flag), f"flag={flag} x={x}: {float(got[1])}"
 
 
-def _unused_bool_input(flag: bool, x: float, y: float):  # type: ignore[no-untyped-def]
+def _unused_bool_input(flag: bool, x: float, y: float) -> float:
     # An UNUSED boolean input: it is a real port but the float result must not depend on it at all.
     return x * y + 1.0
 
@@ -405,7 +408,7 @@ class _ChainedSlots:
         self._a = 0.0
         self._b = 0.0
 
-    def __call__(self, x: float):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float) -> float:
         out = self._a
         self._a = self._b
         self._b = x
@@ -431,7 +434,7 @@ class _BoolStateMachine:
     def __init__(self) -> None:
         self.armed = False
 
-    def __call__(self, x: float):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float) -> tuple[float, bool]:
         # latch ``armed`` once x crosses 1.0, and keep it latched; the float output is gated on the PREVIOUS armed.
         gated = 100.0 if self.armed else x
         if x > 1.0:
@@ -459,11 +462,11 @@ def test_boolean_state_slot_stream_and_reset() -> None:
         assert got[1] is want_armed, f"post-reset armed at x={x}: {got[1]} vs {want_armed}"
 
 
-def _lt_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
+def _lt_kernel(x: float, y: float) -> bool:
     return x < y
 
 
-def _gt_swapped_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
+def _gt_swapped_kernel(x: float, y: float) -> bool:
     return y > x
 
 
@@ -482,7 +485,7 @@ def test_commuted_comparisons_agree_bool_exact() -> None:
                 assert a is want and b is want, f"xy={xy}: lt={a} gt={b} want={want}"
 
 
-def _constant_subexpression(x: float):  # type: ignore[no-untyped-def]
+def _constant_subexpression(x: float) -> float:
     # A purely constant subexpression (``2*3 + 1`` -> 7.0) must fold at compile time; only ``x + 7.0`` survives. The
     # output is checked against the float64 reference, so a folding bug that changed the constant would be caught.
     k = 2.0 * 3.0 + 1.0
@@ -496,7 +499,7 @@ def test_constant_subexpression_folds_and_is_correct() -> None:
         assert got == _constant_subexpression(x), f"x={x}: {got}"  # x + 7.0 is exact for these x
 
 
-def _constant_condition_folds_arm(x: float):  # type: ignore[no-untyped-def]
+def _constant_condition_folds_arm(x: float) -> float:
     # A comparison of two COMPILE-TIME constants (``2.0 > 1.0``) folds the condition; only the true arm is lowered.
     # The else arm divides by a compile-time zero -- if it were ever lowered the build would record an error / produce
     # a wrong value, so a correct result on the kept arm proves the dead arm was pruned, not merely never taken.

--- a/tests/test_public_api_behavior.py
+++ b/tests/test_public_api_behavior.py
@@ -161,7 +161,9 @@ def test_ifconvertible_and_real_branch_forms_agree() -> None:
     sim_br = _sim(_real_branch_division_form, "br_div")
     rng = np.random.default_rng(0xC0FFEE)
     samples = [(2.0, 3.0, 1.0), (2.0, 3.0, -1.0), (2.0, 3.0, 0.0), (-1.0, 2.0, 0.5)]
-    samples += [tuple(float(rng.uniform(-3.0, 3.0)) for _ in range(3)) for _ in range(40)]
+    samples += [
+        (float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0))) for _ in range(40)
+    ]
     for x, y, c in samples:
         a = float(sim_ifc.run(x, y, c)[0])
         b = float(sim_br.run(x, y, c)[0])

--- a/tests/test_public_api_behavior.py
+++ b/tests/test_public_api_behavior.py
@@ -64,12 +64,12 @@ def _close(got: float, want: float, op_count: int = 12) -> bool:
     return within(got, want, rtol, atol)
 
 
-def _abs_via_select(x, c):  # type: ignore[no-untyped-def]
+def _abs_via_select(x: float, c: float):  # type: ignore[no-untyped-def]
     # x if c>0 else -x : the negation folds into the select's operand sign conditioner -- one compare, one mux.
     return x if c > 0.0 else -x
 
 
-def _neg_abs_via_select(x, c):  # type: ignore[no-untyped-def]
+def _neg_abs_via_select(x: float, c: float):  # type: ignore[no-untyped-def]
     # The sign rides the OTHER arm, exercising the conditioner on the opposite operand. Both arms are sign chains over
     # the same input, so the whole diamond collapses to one select.
     return -x if c > 0.0 else x
@@ -86,7 +86,7 @@ def test_sign_folds_into_select_both_orientations() -> None:
             assert float(sim_b.run(x, c)[0]) == _neg_abs_via_select(x, c), f"neg_abs x={x} c={c}"
 
 
-def _cmp_select_float_chain(x, y):  # type: ignore[no-untyped-def]
+def _cmp_select_float_chain(x: float, y: float):  # type: ignore[no-untyped-def]
     # max(x, y) via a pure compare->select diamond, then a float multiply -- a cross-bank chain (boolean comparison
     # feeding a wide select feeding a wide multiply) that stays STRAIGHT-LINE (no branch). Doubling is exact in ZKF.
     return (x if x > y else y) * 2.0
@@ -102,7 +102,7 @@ def test_comparison_select_float_chain_stays_straight_line() -> None:
                 assert got == _cmp_select_float_chain(*xy), f"xy={xy}: {got}"
 
 
-def _diff_arith_select(x, y, c):  # type: ignore[no-untyped-def]
+def _diff_arith_select(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
     # A select whose two arms are DIFFERENT arithmetic (product vs sum), both speculatable -> if-converts to a select
     # over two distinct sub-DAGs.
     return (x * y) if c > 0.0 else (x + y)
@@ -118,7 +118,7 @@ def test_select_arms_different_arithmetic() -> None:
                 assert _close(got, want, op_count=4), f"x={x} y={y} c={c}: {got} vs {want}"
 
 
-def _nested_ternary(x, y):  # type: ignore[no-untyped-def]
+def _nested_ternary(x: float, y: float):  # type: ignore[no-untyped-def]
     # A nested ternary in expression position: the inner sign-select is one arm of the outer select. All four leaves
     # are sign chains of representable inputs, so every result is exact.
     return (x if x > 0.0 else -x) if y > 0.0 else (y if x > 0.0 else -y)
@@ -131,14 +131,14 @@ def test_nested_ternary_select() -> None:
             assert float(sim.run(x, y)[0]) == _nested_ternary(x, y), f"x={x} y={y}"
 
 
-def _ifconv_division_form(x, y, c):  # type: ignore[no-untyped-def]
+def _ifconv_division_form(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
     # IF-CONVERTIBLE formulation: the diamond merges two speculatable arms (add/sub), then ONE division outside it.
     # The select collapses the diamond to straight-line code; the division is not inside an arm, so nothing blocks it.
     m = (x + y) if c > 0.0 else (x - y)
     return m / (y * y + 1.0)  # structurally-nonzero, non-power-of-two divisor
 
 
-def _real_branch_division_form(x, y, c):  # type: ignore[no-untyped-def]
+def _real_branch_division_form(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
     # REAL-BRANCH formulation of the SAME math: each arm carries the (unspeculatable) division, so the diamond CANNOT
     # if-convert and stays a genuine branch -- yet the value computed on each path is identical to the if-converted
     # form. The two must agree (a strong cross-check: one compiles to a select + one divide, the other to a branch
@@ -172,7 +172,7 @@ def test_ifconvertible_and_real_branch_forms_agree() -> None:
 # M3: ``not`` never materializes hardware -- it folds into the consumer's sideband on the CONSUMER side.
 
 
-def _not_in_branch_condition(c: bool, x, y):  # type: ignore[no-untyped-def]
+def _not_in_branch_condition(c: bool, x: float, y: float):  # type: ignore[no-untyped-def]
     if not c:
         r = x + y
     else:
@@ -254,7 +254,7 @@ def test_double_negation_is_identity() -> None:
     assert sim.run(False)[0] is False
 
 
-def _comparison_both_polarities(x, y):  # type: ignore[no-untyped-def]
+def _comparison_both_polarities(x: float, y: float):  # type: ignore[no-untyped-def]
     # ONE comparison consumed in BOTH polarities: ``x > y`` drives a boolean output directly, and ``not (x > y)`` (the
     # complement) gates a float select. One comparator tap must serve both -- the polarities must stay consistent.
     gt = x > y
@@ -274,7 +274,7 @@ def test_comparison_in_both_polarities() -> None:
                 assert float(got[1]) == want_val, f"xy={xy}: val {float(got[1])} vs {want_val}"
 
 
-def _pure_recurrence(x, n):  # type: ignore[no-untyped-def]
+def _pure_recurrence(x: float, n: float):  # type: ignore[no-untyped-def]
     # A PURE loop-carried recurrence (no division -- the existing in-loop test is division-bearing): a Horner-like
     # multiply-accumulate over a data-dependent trip count. The header phi for ``acc`` is loop-carried; its live-in
     # overlaps its back-edge arm, so the coalescer must judge it correctly (it keeps a copy where it must, coalesces
@@ -296,7 +296,7 @@ def test_pure_loop_carried_recurrence_matches_reference() -> None:
         assert _close(got, want, op_count=2 * max(1, int(n)) + 2), f"x={x} n={n}: {got} vs {want}"
 
 
-def _soundness_corner(x, n):  # type: ignore[no-untyped-def]
+def _soundness_corner(x: float, n: float):  # type: ignore[no-untyped-def]
     # The coalescing soundness corner: a REAL diamond INSIDE a loop whose arms reuse an input (``x``) that is ALSO the
     # seed of the phi result (``acc`` is seeded from x and is the loop-carried header phi), branching ON that phi
     # result (``acc > 0.0``). The else arm divides (structurally-nonzero, non-power-of-two divisor) so the diamond
@@ -320,7 +320,7 @@ def test_coalescing_soundness_corner_matches_reference() -> None:
         assert _close(got, want, op_count=2 * max(1, int(n)) + 2), f"x={x} n={n}: {got} vs {want}"
 
 
-def _mixed_tuple_io(flag: bool, x, y):  # type: ignore[no-untyped-def]
+def _mixed_tuple_io(flag: bool, x: float, y: float):  # type: ignore[no-untyped-def]
     # The two float outputs are exact (sum/difference of representable inputs).
     inside = flag and (x > y)
     return inside, x + y, x - y
@@ -360,7 +360,7 @@ def test_logical_port_is_the_single_public_port_type() -> None:
     assert all(isinstance(port, holoso.LogicalPort) for port in (*sim.inputs, *sim.outputs))
 
 
-def _mixed_list_io(flag: bool, x):  # type: ignore[no-untyped-def]
+def _mixed_list_io(flag: bool, x: float):  # type: ignore[no-untyped-def]
     # A LIST return (vs the tuple above) mixing a float and a bool: same aggregate-flattening path, different literal.
     return [x + 1.0, not flag]
 
@@ -376,7 +376,7 @@ def test_mixed_list_io_metadata_and_values() -> None:
             assert got[1] is (not flag), f"flag={flag} x={x}: {got[1]}"
 
 
-def _unused_bool_input(flag: bool, x, y):  # type: ignore[no-untyped-def]
+def _unused_bool_input(flag: bool, x: float, y: float):  # type: ignore[no-untyped-def]
     # An UNUSED boolean input: it is a real port but the float result must not depend on it at all.
     return x * y + 1.0
 
@@ -405,7 +405,7 @@ class _ChainedSlots:
         self._a = 0.0
         self._b = 0.0
 
-    def __call__(self, x):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float):  # type: ignore[no-untyped-def]
         out = self._a
         self._a = self._b
         self._b = x
@@ -431,7 +431,7 @@ class _BoolStateMachine:
     def __init__(self) -> None:
         self.armed = False
 
-    def __call__(self, x):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float):  # type: ignore[no-untyped-def]
         # latch ``armed`` once x crosses 1.0, and keep it latched; the float output is gated on the PREVIOUS armed.
         gated = 100.0 if self.armed else x
         if x > 1.0:
@@ -459,11 +459,11 @@ def test_boolean_state_slot_stream_and_reset() -> None:
         assert got[1] is want_armed, f"post-reset armed at x={x}: {got[1]} vs {want_armed}"
 
 
-def _lt_kernel(x, y):  # type: ignore[no-untyped-def]
+def _lt_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
     return x < y
 
 
-def _gt_swapped_kernel(x, y):  # type: ignore[no-untyped-def]
+def _gt_swapped_kernel(x: float, y: float):  # type: ignore[no-untyped-def]
     return y > x
 
 
@@ -482,7 +482,7 @@ def test_commuted_comparisons_agree_bool_exact() -> None:
                 assert a is want and b is want, f"xy={xy}: lt={a} gt={b} want={want}"
 
 
-def _constant_subexpression(x):  # type: ignore[no-untyped-def]
+def _constant_subexpression(x: float):  # type: ignore[no-untyped-def]
     # A purely constant subexpression (``2*3 + 1`` -> 7.0) must fold at compile time; only ``x + 7.0`` survives. The
     # output is checked against the float64 reference, so a folding bug that changed the constant would be caught.
     k = 2.0 * 3.0 + 1.0
@@ -496,7 +496,7 @@ def test_constant_subexpression_folds_and_is_correct() -> None:
         assert got == _constant_subexpression(x), f"x={x}: {got}"  # x + 7.0 is exact for these x
 
 
-def _constant_condition_folds_arm(x):  # type: ignore[no-untyped-def]
+def _constant_condition_folds_arm(x: float):  # type: ignore[no-untyped-def]
     # A comparison of two COMPILE-TIME constants (``2.0 > 1.0``) folds the condition; only the true arm is lowered.
     # The else arm divides by a compile-time zero -- if it were ever lowered the build would record an error / produce
     # a wrong value, so a correct result on the kept arm proves the dead arm was pruned, not merely never taken.

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -13,6 +13,7 @@ from holoso import (
     FCmpOperator,
     FDivOperator,
     FloatFormat,
+    FloatValue,
     FMulILog2OperatorFamily,
     FMulOperator,
     OpConfig,
@@ -32,6 +33,7 @@ from holoso._lir import (
     LirBlock,
     RegRef,
     Ret,
+    ScheduledOp,
     landing_cycle,
     operand_read_cycle,
 )
@@ -54,10 +56,18 @@ from holoso._mir import (
     MirFloatOutput,
     MirFloatView,
     MirInput,
+    MirNode,
     MirOperation,
     MirRet,
 )
-from holoso._operators import BoolAndOperator, BoolInversion, FMulILog2Operator, FloatSignControl, SelectOperator
+from holoso._operators import (
+    BoolAndOperator,
+    BoolInversion,
+    FMulILog2Operator,
+    FloatSignControl,
+    PooledHardwareOperator,
+    SelectOperator,
+)
 from holoso._hir import RelationalOp
 from ._modelref import build_model
 from holoso._lir import build
@@ -80,7 +90,6 @@ from ._modelref import (
     staged_ops,
 )
 from ._writetimeline import InlineProducer, build_write_timeline, latest_producer_before
-from ._examples import PhaseFrequencyDetector
 
 FMT = FloatFormat(6, 18)
 OPS = OpConfig(FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT))
@@ -114,6 +123,10 @@ def _schedule(mir: Mir) -> Schedule:
 
 def _muls(mir: Mir) -> list[int]:
     return [vid for vid, n in mir.nodes.items() if isinstance(n, MirOperation) and isinstance(n.operator, FMulOperator)]
+
+
+def _block_ops(block: LirBlock) -> list[ScheduledOp]:
+    return [*block.ops, *block.inline_ops]
 
 
 def test_schedule_respects_dependencies() -> None:
@@ -298,6 +311,7 @@ def test_resident_bound_inline_select_lands_combinationally() -> None:
     base = lir.block_base[block.index]
     landing = base + landing_cycle(op.commit_cycle, lir.fetch_lag)
     assert landing == base + op.commit_cycle + lir.fetch_lag + READ_FIRST_EDGE  # the combinational landing
+    assert isinstance(op.write.dst, RegRef), "the select's result is a wide float, not a boolean"
     assert landing in lir.reg_liveness[op.write.dst]  # the result is live on its true landing
 
 
@@ -382,8 +396,8 @@ def test_spilled_result_landings_match_the_numerical_model(config: OperatorCase)
     from holoso._backend.numerical import NumericalSimulator
 
     class _Recorder(NumericalSimulator):
-        def __init__(self, lir: object) -> None:
-            super().__init__(lir)  # type: ignore[arg-type]
+        def __init__(self, lir: Lir) -> None:
+            super().__init__(lir)
             self.writes: dict[tuple[str, int], set[int]] = {}
 
         def _write(self, dst: object, value: object) -> None:
@@ -404,7 +418,7 @@ def test_spilled_result_landings_match_the_numerical_model(config: OperatorCase)
         predicted: dict[tuple[str, int], set[int]] = {}
         multi_arm = 0
         for block in lir.blocks:
-            for op in (*block.ops, *block.inline_ops):
+            for op in _block_ops(block):
                 for write in op.writes:
                     pcs = lir.write_landing_pcs(block, op)
                     predicted.setdefault((type(write.dst).__name__, write.dst.index), set()).update(pcs)
@@ -416,8 +430,8 @@ def test_spilled_result_landings_match_the_numerical_model(config: OperatorCase)
             sim.reset()
             sim.writes = {}
             sim.run(x, y, z)
-            for key, pcs in sim.writes.items():
-                actual.setdefault(key, set()).update(pcs)
+            for key, landed in sim.writes.items():
+                actual.setdefault(key, set()).update(landed)
         assert predicted == actual, f"{name}: write_landing_pcs {predicted} != model writebacks {actual}"
 
 
@@ -435,8 +449,8 @@ def test_overlapping_loop_kernel_landings_are_real_model_writes(config: Operator
     from holoso._backend.numerical import NumericalSimulator
 
     class _Recorder(NumericalSimulator):
-        def __init__(self, lir: object) -> None:
-            super().__init__(lir)  # type: ignore[arg-type]
+        def __init__(self, lir: Lir) -> None:
+            super().__init__(lir)
             self.writes: dict[int, set[int]] = {}
 
         def _write(self, dst: object, value: object) -> None:
@@ -451,7 +465,7 @@ def test_overlapping_loop_kernel_landings_are_real_model_writes(config: Operator
     ), "recip_newton's header branch did not drain at the tight boundary: the real-kernel layout changed"
     predicted: dict[int, set[int]] = {}
     for block in lir.blocks:
-        for op in (*block.ops, *block.inline_ops):
+        for op in _block_ops(block):
             for write in op.writes:
                 if isinstance(write.dst, RegRef):
                     predicted.setdefault(write.dst.index, set()).update(lir.write_landing_pcs(block, op))
@@ -478,9 +492,7 @@ def test_bool_only_block_drains_at_the_work_boundary(monkeypatch: pytest.MonkeyP
     # its read-first lands.
 
     def is_bool_only(block: LirBlock) -> bool:  # no wide register write and no float copy at the tail
-        return not block.copies and not any(
-            isinstance(w.dst, RegRef) for op in (*block.ops, *block.inline_ops) for w in op.writes
-        )
+        return not block.copies and not any(isinstance(w.dst, RegRef) for op in _block_ops(block) for w in op.writes)
 
     # phase_frequency_detector is a single-block all-boolean kernel: its Ret does real boolean WORK (makespan > 0) and
     # installs nothing, so it drains at the work boundary (distinct from a pure-drain Ret, whose resident output needs
@@ -505,8 +517,8 @@ def test_bool_only_block_drains_at_the_work_boundary(monkeypatch: pytest.MonkeyP
     # (In-place state commit elided the former majority_voter sticky-fault installs.)
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)
 
-    def bool_install_blocks(lir: object) -> list[LirBlock]:  # bool-only blocks carrying a tail bool install
-        return [b for b in lir.blocks if b.bool_writes and is_bool_only(b)]  # type: ignore[attr-defined]
+    def bool_install_blocks(lir: Lir) -> list[LirBlock]:  # bool-only blocks carrying a tail bool install
+        return [b for b in lir.blocks if b.bool_writes and is_bool_only(b)]
 
     def computed_source_install(a: bool, b: bool, c: bool) -> tuple[bool, bool]:
         x = a and b  # COMPUTED in-block; returned so the c-false arm (= x) cannot coalesce -> a computed-source install
@@ -631,7 +643,7 @@ def test_coalesced_install_block_pays_no_spurious_install_drain() -> None:
     arms = [b for b in lir.blocks if b.ops and not b.copies and not b.bool_writes and isinstance(b.terminator, Jump)]
     assert len(arms) == 2, "the division diamond's two coalesced arm blocks are the B2 target"
     for block in arms:
-        last_commit = max(op.commit_cycle for op in (*block.ops, *block.inline_ops))
+        last_commit = max(op.commit_cycle for op in _block_ops(block))
         assert block.block_makespan == last_commit, "a coalesced-install arm block paid a spurious +1 install drain"
 
 
@@ -768,7 +780,10 @@ def test_entry_busy_gates_a_successor_firing_at_its_inherited_instance_free_cycl
     view = _view(mir)
     pool = resolve_pool(mir.nodes)
     (mul,) = _muls(mir)
-    operator = mir.nodes[mul].operator
+    mul_node = mir.nodes[mul]
+    assert isinstance(mul_node, MirOperation)
+    operator = mul_node.operator
+    assert isinstance(operator, PooledHardwareOperator)
     schedulable = set(view.operation_nodes)
 
     # With no residue the firing issues on cycle 0 (operands resident at block start) -- so any later issue is
@@ -838,8 +853,8 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
         return c, d
 
     class _Trace(NumericalSimulator):
-        def __init__(self, lir: object) -> None:
-            super().__init__(lir)  # type: ignore[arg-type]
+        def __init__(self, lir: Lir) -> None:
+            super().__init__(lir)
             self.reads: set[int] = set()
             self.writes: set[int] = set()
             self.bool_reads: set[int] = set()
@@ -853,13 +868,13 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
             self.branch_read = (self.pc, terminator.cond.index) if isinstance(terminator, Branch) else None
             super().tick(in_valid, out_ready)
 
-        def _read(self, operand: object) -> object:
+        def _read(self, operand: FloatOperand | BoolOperand) -> FloatValue | bool:
             if isinstance(operand, FloatOperand):
                 if isinstance(operand.source, RegRef):
                     self.reads.add(operand.source.index)
-            elif isinstance(operand.source, BoolRegRef):  # type: ignore[attr-defined]
-                self.bool_reads.add(operand.source.index)  # type: ignore[attr-defined]
-            return super()._read(operand)  # type: ignore[arg-type]
+            elif isinstance(operand.source, BoolRegRef):
+                self.bool_reads.add(operand.source.index)
+            return super()._read(operand)
 
         def _write(self, dst: object, value: object) -> None:
             if isinstance(dst, RegRef):
@@ -868,9 +883,7 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
                 self.bool_writes.add(dst.index)
             super()._write(dst, value)  # type: ignore[arg-type]
 
-    def model_residence(
-        lir: object, vectors: list[tuple[float, ...]]
-    ) -> tuple[dict[int, set[int]], dict[int, set[int]]]:
+    def model_residence(lir: Lir, vectors: list[tuple[float, ...]]) -> tuple[dict[int, set[int]], dict[int, set[int]]]:
         wide: dict[int, set[int]] = {}
         boolean: dict[int, set[int]] = {}
         for vec in vectors:
@@ -904,8 +917,8 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
             _ = sim.output_values  # the output taps read their registers at the boundary PC
             pc, rd, wr, brd, bwr = steps[-1]
             steps[-1] = (pc, rd | frozenset(sim.reads), wr, brd | frozenset(sim.bool_reads), bwr)
-            live: set[int] = set()
-            blive: set[int] = set()
+            live: frozenset[int] = frozenset()
+            blive: frozenset[int] = frozenset()
             # Backward per-path liveness in the model's write-then-read order (a write lands then is read at the same
             # PC), so a read on a value's landing reads THAT value, not the prior occupant: kill the carry with the
             # write AFTER folding in the read. A def cell is resident even if its value is never read (it occupies the
@@ -920,7 +933,7 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
                 blive = (breads | blive) - bwrites
         return wide, boolean
 
-    cases: list[tuple[str, object, list[tuple[float, ...]]]] = [
+    cases: list[tuple[str, Lir, list[tuple[float, ...]]]] = [
         ("join_spill", build(_run(join_spill), "join_spill", fetch_stages=3), [(0.5, 2.0, 1.5), (2.0, 0.5, 1.5)]),
         ("phi_merge", build(_run(phi_merge), "phi_merge", fetch_stages=3), [(0.5, 2.0), (2.0, 0.5)]),
         (
@@ -949,8 +962,13 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
             assert tint == model, f"{name}: residence tint {tint} != model per-path residence {model}"
         # Convention-independent invariant (catches the same-PC def+use over-tint in either bank): no register holds a
         # live value before the program's first executing step.
-        for reg, rows in {**lir.reg_liveness, **lir.bool_liveness}.items():
-            assert min(rows) >= 1, f"{name}: {reg} tinted resident at PC {min(rows)} < 1"
+        combined_liveness: dict[RegRef | BoolRegRef, set[int]] = {}
+        for reg, rows in lir.reg_liveness.items():
+            combined_liveness[reg] = rows
+        for breg, brows in lir.bool_liveness.items():
+            combined_liveness[breg] = brows
+        for any_reg, any_rows in combined_liveness.items():
+            assert min(any_rows) >= 1, f"{name}: {any_reg} tinted resident at PC {min(any_rows)} < 1"
 
 
 def test_state_slot_residence_matches_the_model_under_carry() -> None:
@@ -1019,8 +1037,8 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
             return x
 
     class _Trace(NumericalSimulator):
-        def __init__(self, lir: object) -> None:
-            super().__init__(lir)  # type: ignore[arg-type]
+        def __init__(self, lir: Lir) -> None:
+            super().__init__(lir)
             self.events: list[tuple[int, str | None, str | None, int | None]] = []  # (pc, r/w, f/b, index) in order
             self.branch: tuple[int, int] | None = None
 
@@ -1029,14 +1047,14 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
             self.branch = (self.pc, term.cond.index) if isinstance(term, Branch) else None
             super().tick(in_valid, out_ready)
 
-        def _read(self, operand: object) -> object:
-            source = operand.source  # type: ignore[attr-defined]
+        def _read(self, operand: FloatOperand | BoolOperand) -> FloatValue | bool:
+            source = operand.source
             if isinstance(operand, FloatOperand):
                 if isinstance(source, RegRef):
                     self.events.append((self.pc, "r", "f", source.index))
             elif isinstance(source, BoolRegRef):
                 self.events.append((self.pc, "r", "b", source.index))
-            return super()._read(operand)  # type: ignore[arg-type]
+            return super()._read(operand)
 
         def _write(self, dst: object, value: object) -> None:
             if isinstance(dst, RegRef):
@@ -1066,13 +1084,14 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
                     out.append((cur, frozenset(rf), frozenset(wf), frozenset(rb), frozenset(wb), read_first))
                 cur, rf, wf, rb, wb = pc, set(), set(), set(), set()
             if idx is not None:
+                assert kind is not None and bank is not None
                 {("r", "f"): rf, ("w", "f"): wf, ("r", "b"): rb, ("w", "b"): wb}[(kind, bank)].add(idx)
         if cur is not None:
             out.append((cur, frozenset(rf), frozenset(wf), frozenset(rb), frozenset(wb), read_first))
         return out
 
     def model_slot_residence(
-        lir: object, vectors: list[tuple[float, ...]]
+        lir: Lir, vectors: list[tuple[float, ...]]
     ) -> tuple[dict[int, set[int]], dict[int, set[int]]]:
         transactions = 16
         last_pc = lir.last_pc
@@ -1116,8 +1135,8 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         wide: dict[int, set[int]] = {}
         boolean: dict[int, set[int]] = {}
         resid: list[tuple[int, frozenset[int], frozenset[int]]] = []
-        live_f: set[int] = set()
-        live_b: set[int] = set()
+        live_f: frozenset[int] = frozenset()
+        live_b: frozenset[int] = frozenset()
         for pc, rf, wf, rb, wb, read_first in reversed(flat):
             resid.append((pc, rf | live_f | wf, rb | live_b | wb))
             if read_first:  # read-then-write bundle: a read outlives a same-register write (the live-in survives)
@@ -1140,7 +1159,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
                         boolean.setdefault(reg, set()).add(pc)
         return wide, boolean
 
-    cases: list[tuple[str, object, list[tuple[float, ...]]]] = [
+    cases: list[tuple[str, Lir, list[tuple[float, ...]]]] = [
         ("Delay", build(_run(Delay().__call__), "Delay", fetch_stages=3), [(0.5,), (-0.5,), (1.5,), (2.0,)]),
         (
             "MBWide",
@@ -1168,11 +1187,11 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
                 model = {pc for pc in model_wide.get(slot.reg.index, set()) if 1 <= pc <= last}
                 assert tint == model, f"{name}: wide slot {slot.reg} tint {sorted(tint)} != model {sorted(model)}"
                 compared += 1
-        for slot in [*lir.bool_state_slots]:
-            if slot.needs_copy:
-                tint = {pc for pc in lir.bool_liveness[slot.reg] if pc <= last}
-                model = {pc for pc in model_bool.get(slot.reg.index, set()) if 1 <= pc <= last}
-                assert tint == model, f"{name}: bool slot {slot.reg} tint {sorted(tint)} != model {sorted(model)}"
+        for bslot in [*lir.bool_state_slots]:
+            if bslot.needs_copy:
+                tint = {pc for pc in lir.bool_liveness[bslot.reg] if pc <= last}
+                model = {pc for pc in model_bool.get(bslot.reg.index, set()) if 1 <= pc <= last}
+                assert tint == model, f"{name}: bool slot {bslot.reg} tint {sorted(tint)} != model {sorted(model)}"
                 compared += 1
     # Guard against the kernels silently losing their non-coalesced slots (e.g. a future coalescing change) -- without
     # this the loop above would vacuously pass and re-open the read-first coverage gap this test exists to close.
@@ -1320,7 +1339,12 @@ def test_fmul_ilog2_different_k_never_shares() -> None:
     assert len(il) == 2
     sched = _schedule(mir)
     assert sched.inst_of[il[0]] != sched.inst_of[il[1]]
-    assert {sched.inst_of[v].operator.k for v in il} == {2, 3}
+    ks: set[int] = set()
+    for v in il:
+        op = sched.inst_of[v].operator
+        assert isinstance(op, FMulILog2Operator)
+        ks.add(op.k)
+    assert ks == {2, 3}
     assert {sched.inst_of[v].index for v in il} == {0}  # indices are local to each concrete operator value
 
 
@@ -1563,7 +1587,7 @@ def test_interfering_loop_carried_phi_keeps_its_copy() -> None:
     assert back_edge_op_copies, "the interfering loop-carried Newton update must keep its back-edge install copy"
 
 
-def _check_float_kernel(fn: Callable[..., object], name: str, samples: list[tuple[float, ...]]) -> None:
+def _check_float_kernel(fn: Callable[..., tuple[float, ...]], name: str, samples: list[tuple[float, ...]]) -> None:
     lir = build(
         _run(fn), name, fetch_stages=3
     )  # crash-before: the install-free oracle admitted an unsound merge -> backstop assert
@@ -1655,7 +1679,10 @@ def test_bool_phi_coalescing_residual_install_conflict_is_resolved() -> None:
     )  # crash-before: the bool oracle admitted the unsound merge -> backstop assert
     model = build_model(lir)
     for p, q, r in itertools.product([False, True], repeat=3):
-        got = [bool(int(v)) for v in model.run(p, q, r)]
+        got: list[bool] = []
+        for v in model.run(p, q, r):
+            assert isinstance(v, bool)
+            got.append(bool(int(v)))
         ref = list(k(p, q, r))
         assert got == ref, f"coal_bool({p},{q},{r}): {got} vs {ref}"
 
@@ -1891,9 +1918,9 @@ def test_mir_builder_rejects_mixed_float_operand_formats() -> None:
 
 def test_mir_operation_validates_invariants() -> None:
     with pytest.raises(TypeError, match="scalar_type"):
-        MirFloatInput("a", OtherScalarType())
+        MirFloatInput("a", OtherScalarType())  # type: ignore[arg-type]  # deliberately wrong scalar type
     with pytest.raises(TypeError, match="scalar_type"):
-        MirFloatConst(OtherScalarType(), 1.0)
+        MirFloatConst(OtherScalarType(), 1.0)  # type: ignore[arg-type]  # deliberately wrong scalar type
     with pytest.raises(ValueError, match="operand"):
         MirOperation(FAddOperator(FMT), [0], [FloatSignControl(), FloatSignControl()], 0, FloatSignControl(), ())
     with pytest.raises(ValueError, match="conditioner"):
@@ -1914,7 +1941,7 @@ def test_mir_operation_validates_invariants() -> None:
     with pytest.raises(ValueError, match="does not exist"):
         MirOperation(FAddOperator(FMT), [0, 0], [FloatSignControl(), FloatSignControl()], 1, FloatSignControl(), ())
     with pytest.raises(TypeError, match="sign"):
-        MirFloatOutput("out_0", 0, object())
+        MirFloatOutput("out_0", 0, object())  # type: ignore[arg-type]  # deliberately wrong sign control type
 
 
 def test_float_view_rejects_non_float_mir_before_scheduling() -> None:
@@ -2022,13 +2049,20 @@ def test_optional_stages_raise_latency_without_changing_numerics() -> None:
     lirs = {name: build(_run(kernel, ops), f"stages_{name}", fetch_stages=3) for name, ops in configs.items()}
     assert lirs["default"].initiation_interval < lirs["staged"].initiation_interval
 
+    def bits(outputs: list[FloatValue | bool]) -> list[int]:  # the kernel is all-float, so every output is a FloatValue
+        result = []
+        for v in outputs:
+            assert isinstance(v, FloatValue)
+            result.append(v.bits)
+        return result
+
     # Optional stages only insert pipeline registers, so the numerical result is bit-identical across every config.
     models = {name: build_model(lir) for name, lir in lirs.items()}
     vectors = [(1.5, -0.5, 2.0), (3.25, 1.0, -4.0), (0.0, 2.5, 0.125), (-1.0, -1.0, 1e3)]
     for values in vectors:
-        want = [v.bits for v in models["default"].run(*values)]
+        want = bits(models["default"].run(*values))
         for name, model in models.items():
-            assert [v.bits for v in model.run(*values)] == want, f"{name} diverged from default at {values}"
+            assert bits(model.run(*values)) == want, f"{name} diverged from default at {values}"
 
 
 def test_reach_floor_seed_skips_annealing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2037,8 +2071,13 @@ def test_reach_floor_seed_skips_annealing(monkeypatch: pytest.MonkeyPatch) -> No
     import holoso._lir._regalloc as regalloc
 
     calls: list[int] = []
-    real = regalloc.dual_annealing
-    monkeypatch.setattr(regalloc, "dual_annealing", lambda *a, **k: (calls.append(1), real(*a, **k))[1])
+    real = regalloc.dual_annealing  # type: ignore[attr-defined]  # scipy's dual_annealing, not reexported by _regalloc
+
+    def tracking_dual_annealing(*args: object, **kwargs: object) -> object:
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(regalloc, "dual_annealing", tracking_dual_annealing)
 
     def floor_kernel(a: float, b: float) -> float:
         return a + b  # no register sharing -> greedy seed is at the reach floor
@@ -2086,12 +2125,14 @@ def test_bool_to_float_cast_result_is_live_on_its_landing_cycle() -> None:
         # Landing it one cycle later would return base + commit + 4 here -- this is the discriminating guard, since
         # reg_liveness alone is a union over the register's reuse and stays satisfied even with the late landing.
         assert lir.write_landing_pcs(block, op) == [landing]
+        assert isinstance(op.write.dst, RegRef)
         assert landing in lir.reg_liveness[op.write.dst]
     cast_regs = {op.write.dst for _, op in casts}
     for fop in lir.ops:  # the consuming multiply must read the cast result within its residence (no late-def gap)
         for operand in fop.operands:
             if operand.source in cast_regs:
                 read = operand_read_cycle(fop.inst.operator, fop.issue_cycle, lir.fetch_lag)
+                assert isinstance(operand.source, RegRef)
                 assert read in lir.reg_liveness[operand.source]
 
 
@@ -2180,7 +2221,7 @@ def test_progress_cap_accommodates_long_initiation_intervals() -> None:
     # II with this many firings). Same-port duplicates do not fuse, so the
     # hand-built identical operations below are forty separate firings serialized on one instance.
     slow = _HeavilyThrottledAdd(FMT)
-    nodes = {0: MirFloatInput("a", FloatType(FMT)), 1: MirFloatInput("b", FloatType(FMT))}
+    nodes: dict[int, MirNode] = {0: MirFloatInput("a", FloatType(FMT)), 1: MirFloatInput("b", FloatType(FMT))}
     count = 40
     for i in range(count):
         nodes[2 + i] = MirOperation(slow, [0, 1], [FloatSignControl(), FloatSignControl()], 0, FloatSignControl(), ())
@@ -2536,6 +2577,9 @@ def test_aliased_state_slots_merge_onto_one_register() -> None:
     # Regression (user): two state slots that always hold the same value share one register, so neither needs an
     # install copy. PFD's up/_ref_pending and down/_fb_pending collapse 7 bool registers to 5 with no copies; the
     # float path (a public attribute and its write-only alias) is exercised too.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
+    from phase_frequency_detector import PhaseFrequencyDetector  # noqa: PLC0415
+
     pfd = build(_run(PhaseFrequencyDetector().__call__), "pfd_merge", fetch_stages=3)
     assert pfd.bool_regfile.nreg == 5
     assert pfd.regfile.nreg == 0  # purely boolean: the wide bank is unused

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -115,7 +115,7 @@ def _muls(mir: Mir) -> list[int]:
 
 
 def test_schedule_respects_dependencies() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     mir = _run(f)
@@ -134,7 +134,7 @@ def test_schedule_respects_dependencies() -> None:
 
 def test_pipelined_issue_overlaps_a_slow_op() -> None:
     # A fast chain advances while an unrelated slow divide is still in flight -- the barrier model could not do this.
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return a / b + (a + b + c)
 
     mir = _run(f)
@@ -157,7 +157,7 @@ def test_two_comparisons_in_a_block_serialize_on_the_shared_comparator(config: O
     # two must issue on distinct cycles. Before the contention rule the scheduler let both issue on the same cycle
     # -> they collided on the single comparator (one read the other's operands), corrupting the result in the RTL
     # while the model still passed.
-    def f(x, lo, hi):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         return 0.0 if lo < x < hi else x
 
     lir = build(_run(f, config.make_ops(FMT)), f"deadband_{config.label}", fetch_stages=3)
@@ -218,7 +218,7 @@ def test_entry_branch_on_resident_condition_skips_the_drained_boundary() -> None
         def __init__(self) -> None:
             self._armed = False
 
-        def step(self, a, b):  # type: ignore[no-untyped-def]
+        def step(self, a: float, b: float):  # type: ignore[no-untyped-def]
             if self._armed:
                 r = a / b  # a non-speculatable arm keeps this a real branch, not an if-converted select
             else:
@@ -246,7 +246,7 @@ def test_non_entry_branch_on_resident_condition_redirects_at_its_base() -> None:
         def __init__(self) -> None:
             self._armed = False
 
-        def step(self, p: bool, q: bool, a, b):  # type: ignore[no-untyped-def]
+        def step(self, p: bool, q: bool, a: float, b: float):  # type: ignore[no-untyped-def]
             if self._armed:  # entry branch on the resident boolean state
                 if q:  # non-entry branch on the resident input q; division arms keep it a real branch, not a select
                     r = a / b
@@ -281,7 +281,7 @@ def test_resident_bound_inline_select_lands_combinationally() -> None:
         def __init__(self) -> None:
             self._armed = False
 
-        def step(self, c, d):  # type: ignore[no-untyped-def]
+        def step(self, c: float, d: float):  # type: ignore[no-untyped-def]
             r = c if self._armed else d  # condition (state) and both arms are resident -> the select binds nothing
             self._armed = c > d
             return r
@@ -675,7 +675,7 @@ def test_merge_threading_refuses_a_back_edge_carried_merge_phi() -> None:
     # BACK-EDGE arm is a successor-phi arm too, yet from a different predecessor, so composition would not rewrite it;
     # deleting the merge phi would dangle. The guard must refuse such a merge (the deferred self-latch case).
     # Crash-before: optimize() raised KeyError after threading deleted the still-referenced merge phi.
-    def loop_invariant_merge(a, den, c):  # type: ignore[no-untyped-def]
+    def loop_invariant_merge(a: float, den: float, c: float):  # type: ignore[no-untyped-def]
         if a > 0.0:
             x = a / den  # a real (non-speculatable) division branch -> a separate merge block holding phi x
         else:
@@ -759,7 +759,7 @@ def test_entry_busy_gates_a_successor_firing_at_its_inherited_instance_free_cycl
     # for every current kernel -- a residue survives only when an operator's initiation interval exceeds its latest
     # write word, which no II=1 operator does -- so no end-to-end build exercises it. Pin its consumption directly:
     # ``schedule_ops`` must hold a pooled firing off its instance until that instance frees in the successor frame.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a * b  # one pooled firing; both operands are inputs (block-start ready), so nothing else can delay it
 
     mir = _run(f)
@@ -807,7 +807,7 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from recip_newton import NewtonReciprocal  # noqa: PLC0415 (example kernels live under examples/)
 
-    def join_spill(x, y, z):  # w spills from the entry into BOTH arms and is read after the merge
+    def join_spill(x: float, y: float, z: float):  # w spills from the entry into BOTH arms and is read after the merge
         w = (x * z + y) * z + y
         if x < y:
             a = z + 1.0
@@ -815,14 +815,16 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
             a = z / (y + 1.0)  # the division keeps this a real branch (not if-converted)
         return w + a
 
-    def phi_merge(x, y):  # the merged value is produced in each arm (no entry spill), read after the merge
+    # the merged value is produced in each arm (no entry spill), read after the merge
+    def phi_merge(x: float, y: float):
         if x < y:
             a = x + 1.0
         else:
             a = x / (y + 1.0)
         return a * 2.0
 
-    def bool_write_merge(x, y):  # a boolean phi whose else arm reads the value inverted -> a non-coalesced bool_write
+    # a boolean phi whose else arm reads the value inverted -> a non-coalesced bool_write
+    def bool_write_merge(x: float, y: float):
         p = x < y
         if x < 1.0:
             c = p
@@ -967,7 +969,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._d = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             prev = self._d
             self._d = x
             return prev
@@ -976,7 +978,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._s = 0.0
 
-        def __call__(self, x, y):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float, y: float):  # type: ignore[no-untyped-def]
             out = self._s
             if x > 0.0:
                 self._s = x + y
@@ -988,7 +990,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._f = False
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             out = self._f
             if x > 0.0:
                 self._f = True
@@ -1000,7 +1002,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._b = False
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             old = self._b
             self._b = not self._b
             return x if old else -x
@@ -1009,7 +1011,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:  # the destination): the carry survives only if the boundary bundle is read-first
             self._b = False
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self._b = not self._b
             return x
 
@@ -1280,7 +1282,7 @@ def _ilog2(mir: Mir) -> list[int]:
 
 def test_fmul_ilog2_same_k_shares_one_instance() -> None:
     # Two K=2 scalings that never run on the same cycle (the second waits on a multiply) pool onto one instance.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a * b) * 4.0, b * 4.0
 
     mir = _run(f)
@@ -1294,7 +1296,7 @@ def test_fmul_ilog2_same_k_shares_one_instance() -> None:
 
 def test_fmul_ilog2_same_k_serializes_by_default_parallelizes_with_budget() -> None:
     # Two independent K=2 scalings are both ready at cycle 1; the per-kind budget governs them like any other kind.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a * 4.0, b * 4.0
 
     mir = _run(f)
@@ -1307,7 +1309,7 @@ def test_fmul_ilog2_same_k_serializes_by_default_parallelizes_with_budget() -> N
 
 
 def test_fmul_ilog2_different_k_never_shares() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a * 4.0 + b * 8.0  # K=2 and K=3 -- distinct hardware modules
 
     mir = _run(f)
@@ -1320,7 +1322,7 @@ def test_fmul_ilog2_different_k_never_shares() -> None:
 
 
 def test_build_lir_small_kernel() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     lir = build(_run(f), "kernel", fetch_stages=3)
@@ -1355,7 +1357,7 @@ def test_state_writeback_installs_early_and_is_first_class() -> None:
         def __init__(self) -> None:
             self._p = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             out = self._p + x  # reads the old _p; the fadd result is the only output
             self._p = x  # a non-coalesced writeback whose source (the input x) is an ordinary register
             return out
@@ -1395,7 +1397,7 @@ def test_cfg_phi_merge_register_shows_residence(monkeypatch: pytest.MonkeyPatch)
     # register is written ONLY by the per-arm phi copies and read at the boundary, never by an operator. Before
     # phi-copy residence was added to reg_liveness, such a register had a use but no def and so collapsed to an empty
     # (untinted) live set -- the CFG-report liveness gap.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         if x > 0.0:
             z = 1.0
         else:
@@ -1419,7 +1421,7 @@ def test_cfg_write_only_state_slot_is_reserved() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if x > 0.0:
                 t = x * 2.0
             else:
@@ -1443,7 +1445,7 @@ def test_cfg_state_slot_coalesces_onto_its_register() -> None:
         def __init__(self) -> None:
             self.state = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.state = self.state * 0.9 + x
             return float(x > 0.0) * self.state
 
@@ -1464,7 +1466,7 @@ def test_cfg_branch_conditions_reuse_boolean_registers(monkeypatch: pytest.Monke
 
     # Sequential data-dependent branches: each condition is computed, tested at its boundary, and dead before the next,
     # so the boolean bank reuses one register across them instead of allocating one per branch.
-    def f(x, y, z):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
         a = x
         if x > 0.0:
             a = a + 1.0
@@ -1500,7 +1502,7 @@ def test_diamond_op_result_arms_coalesce(monkeypatch: pytest.MonkeyPatch) -> Non
     # correct on both arms -- bit-exact value preservation against the RTL is the cosim's job; here we pin the win.
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)  # keep the diamond a real phi merge, not a select
 
-    def f(x, y):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float):  # type: ignore[no-untyped-def]
         if x > 0.0:
             z = x + y
         else:
@@ -1521,7 +1523,7 @@ def test_loop_carried_phi_coalesces_when_non_interfering() -> None:
     # A directed loop whose carried value is read once (read-first) before its update lands: the header phi and its
     # back-edge arm (an op result) do not interfere, so they coalesce -- the loop body installs no register-source copy.
     # Only the entry constants (acc=0, i=0) keep their copies.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         acc = 0.0
         i = 0.0
         while i < 3.0:
@@ -1577,7 +1579,7 @@ def test_phi_coalescing_residual_install_conflict_is_resolved() -> None:
     # (sign-folded) else-arm install writes that shared register. The final, install-aware interference then flags the
     # class against itself and the coloring backstop aborted the build. The fixpoint must de-coalesce ``a`` and build.
     # The division keeps the diamond a real branch (un-if-converted), which is what creates the phi merge.
-    def k(x, b, cc):  # type: ignore[no-untyped-def]
+    def k(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
         if b < cc:
             a = x
             z = 1.0
@@ -1596,7 +1598,7 @@ def test_phi_coalescing_conflict_resolved_under_reversed_declaration_order() -> 
     # order the union-find follows -- change, so a DIFFERENT phi wins the merge onto ``x``. The fixpoint must converge
     # regardless of which phi coalesced first; this pins the resolution as order-independent, not an artifact of one id
     # assignment.
-    def k(x, b, cc):  # type: ignore[no-untyped-def]
+    def k(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
         if b < cc:
             d = b
             z = 1.0
@@ -1613,7 +1615,7 @@ def test_phi_coalescing_conflict_resolved_under_reversed_declaration_order() -> 
 def test_phi_coalescing_conflict_resolved_with_swapped_branch_arms() -> None:
     # The mirror: the coalescing identity arm sits in the else block and the sign-folded residual arm in the then block,
     # so the conflict is exercised from the opposite branch polarity. Confirms the de-coalescing is arm-order agnostic.
-    def k(x, b, cc):  # type: ignore[no-untyped-def]
+    def k(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
         if b < cc:
             a = -(x + 1.0)
             z = x
@@ -1662,7 +1664,7 @@ def test_state_war_backstop_allows_noop_writeback() -> None:
         def __init__(self) -> None:
             self.s = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             out = self.s + x
             self.s = self.s
             return out
@@ -1678,7 +1680,7 @@ def test_copy_slot_residence_unbroken_when_tapped_at_boundary() -> None:
         def __init__(self) -> None:
             self._d = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             prev = self._d
             self._d = x
             return prev
@@ -1734,7 +1736,7 @@ def test_build_lir_ekf1_stateless() -> None:
 
 def test_sign_paired_constants_collapse_to_one_magnitude() -> None:
     # +c and -c share a single nonnegative pool entry; the sign rides the (free) per-operand sign control.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a * 1000.0 + a * (-1000.0)
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -1745,7 +1747,7 @@ def test_sign_paired_constants_collapse_to_one_magnitude() -> None:
 
 
 def test_negative_constant_operand_is_stored_as_magnitude_with_negate() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a + (-1000.0)
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -1774,7 +1776,7 @@ def test_constant_pool_is_canonically_nonnegative() -> None:
 def test_underflowing_negative_constant_is_not_sign_folded() -> None:
     # A negative value that rounds to +0 in ZKF (which has no -0) must NOT carry a folded negate: the magnitude already
     # encodes to the canonical +0, so a negate over it would emit an illegal -0 rather than the +0 the value encodes to.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a + (-1e-12)  # -1e-12 underflows to +0 in FloatFormat(6, 18)
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -1784,7 +1786,7 @@ def test_underflowing_negative_constant_is_not_sign_folded() -> None:
 
 
 def test_underflowing_negative_constant_output_stays_canonical_zero() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a + a, -1e-12  # the -1e-12 output underflows to +0; it must stay canonical, not fold to illegal -0
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -2009,7 +2011,7 @@ def test_commutative_port_assignment_never_increases_read_mux_fan_in(  # type: i
 
 def test_optional_stages_raise_latency_without_changing_numerics() -> None:
     # A kernel touching every operator family: fadd, fmul, fdiv, and the 2^-2 strength-reduced fmul_ilog2.
-    def kernel(a, b, c):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return (a - b) / c + a * b * 0.25
 
     fmt = FloatFormat(8, 36)
@@ -2035,10 +2037,10 @@ def test_reach_floor_seed_skips_annealing(monkeypatch) -> None:  # type: ignore[
     real = regalloc.dual_annealing
     monkeypatch.setattr(regalloc, "dual_annealing", lambda *a, **k: (calls.append(1), real(*a, **k))[1])
 
-    def floor_kernel(a, b):  # type: ignore[no-untyped-def]
+    def floor_kernel(a: float, b: float):  # type: ignore[no-untyped-def]
         return a + b  # no register sharing -> greedy seed is at the reach floor
 
-    def sharing_kernel(a, b, c):  # type: ignore[no-untyped-def]
+    def sharing_kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return a * b + c  # the product and the sum reuse registers, lifting the objective above the floor
 
     build(_run(floor_kernel), "floor", fetch_stages=3)
@@ -2053,7 +2055,7 @@ def test_zero_regalloc_effort_bypasses_annealing(monkeypatch) -> None:  # type: 
     monkeypatch.setattr(regalloc, "_REFINE_MAXITER", 0)
     monkeypatch.setattr(regalloc, "dual_annealing", lambda *args, **kwargs: pytest.fail("annealing was not bypassed"))
 
-    def sharing_kernel(a, b, c):  # type: ignore[no-untyped-def]
+    def sharing_kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         return a * b + c
 
     build(_run(sharing_kernel), "sharing", fetch_stages=3)
@@ -2065,7 +2067,7 @@ def test_bool_to_float_cast_result_is_live_on_its_landing_cycle() -> None:
     # later marks it past its true landing (and, for a boundary cast, past the initiation interval, so its report cell
     # falls off the grid) and leaves a consumer's read cycle outside its residence. Here a multiply consumes the cast
     # result.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return float(x > 0.0) * x
 
     lir = build(_run(f), "cast_mul", fetch_stages=3)
@@ -2094,7 +2096,7 @@ def test_two_relations_over_one_operand_pair_fuse_into_one_firing() -> None:
     # Two DIFFERENT relations over the same operand pair tap two distinct output ports of one comparator activation,
     # so they fuse into a single firing: one instance issue, one operand read, two boolean writes -- the multi-output
     # machinery exercised end to end on the boolean side. The model must still produce both values correctly.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         below = a < b
         same = a == b
         return [float(below), float(same)]
@@ -2115,7 +2117,7 @@ def test_two_relations_over_one_operand_pair_fuse_into_one_firing() -> None:
 def test_same_port_taps_with_different_inversions_do_not_fuse() -> None:
     # ``a < b`` taps the lt flag plainly and ``a >= b`` taps the SAME flag inverted: one output-port lane writes once
     # per firing, so these must stay two firings, spaced by instance contention. Both values must still be correct.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         below = a < b
         not_below = a >= b
         return [float(below), float(not_below)]
@@ -2212,7 +2214,7 @@ def test_write_timeline_resolves_inline_wide_producers() -> None:
     # Regression (review): the write timeline recorded only pooled firings' wide writes, so a register written by an
     # inline bool->float cast and read by a float operator resolved to NO producer at all -- latest_producer_before
     # raised KeyError on the cast-fed multiply below.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         return float(x > 0.0) * x
 
     lir = build(_run(f), "cast_timeline", fetch_stages=3)
@@ -2236,7 +2238,7 @@ def test_commutative_comparator_swap_permutes_output_taps(config: OperatorCase) 
     # otherwise read (a,b) and (b,a) -- two registers per read port; the port assignment orients one of them swapped,
     # shrinking each port's read-set to a single register, and the swapped firing's lt tap moves to gt. Bit-exact
     # because the ZKF ordering is total and compare is antisymmetric.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         below = a < b
         above = b < a
         return [float(below), float(above)]
@@ -2276,7 +2278,7 @@ def test_chained_slot_live_in_blocks_early_install(config: OperatorCase) -> None
 def test_select_folds_arm_signs_into_operand_conditioners() -> None:
     # ``x if c else -x`` costs exactly one comparison and one select: the arm negation rides the select's operand
     # conditioner (the inline dual of the pooled operators' sign sidebands), never a separate float operation.
-    def f(x, c):  # type: ignore[no-untyped-def]
+    def f(x: float, c: float):  # type: ignore[no-untyped-def]
         y = x if c > 0.0 else -x
         return y
 
@@ -2324,7 +2326,7 @@ def test_not_folds_into_every_sink_position() -> None:
     # A semantic NOT never materializes hardware: it becomes a free inversion conditioner at each consumer. The
     # kernel routes one comparison's negation into a logic operand, a bool output, and a bool->float cast; the LIR
     # must contain NO inline op beyond the band and the cast, and the inversions must ride the operand sidebands.
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         flag = not (a > b)
         out_logic = flag and (c > 0.0)
         return [float(flag), float(out_logic)]
@@ -2345,7 +2347,7 @@ def test_not_folds_into_every_sink_position() -> None:
 def test_not_on_a_branch_condition_swaps_the_targets() -> None:
     # ``if not cond`` costs nothing: the branch takes the complementary target instead of inverting the register.
     # The division arms keep the diamond a real branch (if-conversion refuses them).
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         if not (a > b):
             y = a / (b * b + 1.0)
         else:
@@ -2362,7 +2364,7 @@ def test_not_on_a_branch_condition_swaps_the_targets() -> None:
 
 
 def test_double_negation_cancels() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         flag = not (not (a > b))
         return float(flag)
 
@@ -2377,7 +2379,7 @@ def test_double_negation_cancels() -> None:
 
 def test_value_consumed_in_both_polarities_shares_one_producer() -> None:
     # ``x`` and ``not x`` share one comparator tap and one boolean register: the polarity lives on each consumer.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         flag = a > b
         return [float(flag), float(not flag)]
 
@@ -2393,7 +2395,7 @@ class _InvertedState:
     def __init__(self) -> None:
         self._flip = False
 
-    def step(self, x):  # type: ignore[no-untyped-def]
+    def step(self, x: float):  # type: ignore[no-untyped-def]
         old = self._flip
         self._flip = not self._flip
         return x if old else -x
@@ -2417,7 +2419,7 @@ def test_inverted_bool_phi_arm_installs_with_opposite_polarities(config: Operato
     # opposite inversions (one arm rewrites the flag as its own negation). The two install copies must carry
     # opposite-polarity sources, and the model must take the correct value on both paths. The division keeps the
     # diamond a real branch (bool-phi diamonds are refused by if-conversion anyway; the div makes it doubly so).
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         flag = a > b
         if c > 0.0:
             flag = not flag
@@ -2445,7 +2447,7 @@ def test_boolean_registers_are_reused_within_a_block() -> None:
     # Exact per-consumer read steps free a condition's register once its last reader fires, so a chain of sequential
     # selects whose conditions die mid-block shares a few boolean registers instead of one per condition. The chain
     # is data-dependent (each select feeds the next comparison), so the conditions' lifetimes are disjoint.
-    def f(x):  # type: ignore[no-untyped-def]
+    def f(x: float):  # type: ignore[no-untyped-def]
         for _ in range(6):
             x = (x - 1.0) if x > 1.0 else (x + 1.0)
         return x
@@ -2468,7 +2470,7 @@ def test_boolean_logic_chain_reuses_registers_on_the_tight_same_bank_edge() -> N
     # reduction over many comparisons produces intermediate flags that die as the next gate consumes them, on the
     # tightest read-first edge (an inline gate reads its operand on exactly the step the next result's write-enable
     # fires; landing = fire + 1 keeps R(a) < W(b)). The chain must collapse onto a handful of registers.
-    def f(a, b, c, d, e, g):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float, d: float, e: float, g: float):  # type: ignore[no-untyped-def]
         return 1.0 if (a > b and c > d and e > g and a > d and b > e) else 0.0
 
     lir = build(_run(f), "bool_chain", fetch_stages=3)
@@ -2521,7 +2523,7 @@ class _AliasedFloatState:
         self.pub = 0.0
         self._alias = 0.0
 
-    def step(self, a, b):  # type: ignore[no-untyped-def]
+    def step(self, a: float, b: float):  # type: ignore[no-untyped-def]
         self.pub = a + b
         self._alias = a + b
         return self.pub

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -2,6 +2,7 @@
 
 import math
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,6 +28,7 @@ from holoso._lir import (
     FloatConstRef,
     FloatOperand,
     Jump,
+    Lir,
     LirBlock,
     RegRef,
     Ret,
@@ -59,7 +61,7 @@ from holoso._operators import BoolAndOperator, BoolInversion, FMulILog2Operator,
 from holoso._hir import RelationalOp
 from ._modelref import build_model
 from holoso._lir import build
-from holoso._lir._schedule import resolve_pool, schedule_ops
+from holoso._lir._schedule import resolve_pool, schedule_ops, Schedule
 from holoso._type import BoolType, FloatType, ScalarType
 
 from ._modelref import (
@@ -97,7 +99,7 @@ class OtherMirInput(MirInput):
     pass
 
 
-def _run(target, ops: OpConfig = OPS) -> Mir:  # type: ignore[no-untyped-def]
+def _run(target: Callable[..., object], ops: OpConfig = OPS) -> Mir:
     return lower_to_mir(optimize(lower(target)), ops)
 
 
@@ -105,7 +107,7 @@ def _view(mir: Mir) -> MirFloatView:
     return MirFloatView.from_mir(mir)
 
 
-def _schedule(mir: Mir):
+def _schedule(mir: Mir) -> Schedule:
     view = _view(mir)
     return schedule_ops(mir.nodes, resolve_pool(mir.nodes), set(view.operation_nodes), _FETCH_LAG)
 
@@ -115,7 +117,7 @@ def _muls(mir: Mir) -> list[int]:
 
 
 def test_schedule_respects_dependencies() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     mir = _run(f)
@@ -134,7 +136,7 @@ def test_schedule_respects_dependencies() -> None:
 
 def test_pipelined_issue_overlaps_a_slow_op() -> None:
     # A fast chain advances while an unrelated slow divide is still in flight -- the barrier model could not do this.
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> float:
         return a / b + (a + b + c)
 
     mir = _run(f)
@@ -157,7 +159,7 @@ def test_two_comparisons_in_a_block_serialize_on_the_shared_comparator(config: O
     # two must issue on distinct cycles. Before the contention rule the scheduler let both issue on the same cycle
     # -> they collided on the single comparator (one read the other's operands), corrupting the result in the RTL
     # while the model still passed.
-    def f(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def f(x: float, lo: float, hi: float) -> float:
         return 0.0 if lo < x < hi else x
 
     lir = build(_run(f, config.make_ops(FMT)), f"deadband_{config.label}", fetch_stages=3)
@@ -218,7 +220,7 @@ def test_entry_branch_on_resident_condition_skips_the_drained_boundary() -> None
         def __init__(self) -> None:
             self._armed = False
 
-        def step(self, a: float, b: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float, b: float) -> float:
             if self._armed:
                 r = a / b  # a non-speculatable arm keeps this a real branch, not an if-converted select
             else:
@@ -246,7 +248,7 @@ def test_non_entry_branch_on_resident_condition_redirects_at_its_base() -> None:
         def __init__(self) -> None:
             self._armed = False
 
-        def step(self, p: bool, q: bool, a: float, b: float):  # type: ignore[no-untyped-def]
+        def step(self, p: bool, q: bool, a: float, b: float) -> float:
             if self._armed:  # entry branch on the resident boolean state
                 if q:  # non-entry branch on the resident input q; division arms keep it a real branch, not a select
                     r = a / b
@@ -281,7 +283,7 @@ def test_resident_bound_inline_select_lands_combinationally() -> None:
         def __init__(self) -> None:
             self._armed = False
 
-        def step(self, c: float, d: float):  # type: ignore[no-untyped-def]
+        def step(self, c: float, d: float) -> float:
             r = c if self._armed else d  # condition (state) and both arms are resident -> the select binds nothing
             self._armed = c > d
             return r
@@ -506,7 +508,7 @@ def test_bool_only_block_drains_at_the_work_boundary(monkeypatch: pytest.MonkeyP
     def bool_install_blocks(lir: object) -> list[LirBlock]:  # bool-only blocks carrying a tail bool install
         return [b for b in lir.blocks if b.bool_writes and is_bool_only(b)]  # type: ignore[attr-defined]
 
-    def computed_source_install(a: bool, b: bool, c: bool):  # type: ignore[no-untyped-def]
+    def computed_source_install(a: bool, b: bool, c: bool) -> tuple[bool, bool]:
         x = a and b  # COMPUTED in-block; returned so the c-false arm (= x) cannot coalesce -> a computed-source install
         r = x
         if c:
@@ -522,7 +524,7 @@ def test_bool_only_block_drains_at_the_work_boundary(monkeypatch: pytest.MonkeyP
             block.block_makespan, _FETCH_LAG
         ), "a computed-source bool install reads-first past the work makespan, draining where its block_makespan lands"
 
-    def resident_source_install(a: bool, b: bool, c: bool):  # type: ignore[no-untyped-def]
+    def resident_source_install(a: bool, b: bool, c: bool) -> tuple[bool, bool]:
         r = a  # the c-false arm is the INPUT a (resident at block entry), returned so it cannot coalesce
         if c:
             r = a and b
@@ -564,12 +566,12 @@ def test_entry_state_liveout_producer_reclaims_cycle_0() -> None:
         def __init__(self) -> None:
             self._s = False
 
-        def __call__(self, a: bool, b: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, a: bool, b: bool) -> bool:
             prev = self._s
             self._s = a and b  # the new state is a combinational inline op in the entry block
             return prev
 
-    def _stateless(a: bool, b: bool):  # type: ignore[no-untyped-def]
+    def _stateless(a: bool, b: bool) -> bool:
         return a and b
 
     stateful = build(_run(_Stateful().__call__), "dwell_stateful", fetch_stages=3)
@@ -675,7 +677,7 @@ def test_merge_threading_refuses_a_back_edge_carried_merge_phi() -> None:
     # BACK-EDGE arm is a successor-phi arm too, yet from a different predecessor, so composition would not rewrite it;
     # deleting the merge phi would dangle. The guard must refuse such a merge (the deferred self-latch case).
     # Crash-before: optimize() raised KeyError after threading deleted the still-referenced merge phi.
-    def loop_invariant_merge(a: float, den: float, c: float):  # type: ignore[no-untyped-def]
+    def loop_invariant_merge(a: float, den: float, c: float) -> float:
         if a > 0.0:
             x = a / den  # a real (non-speculatable) division branch -> a separate merge block holding phi x
         else:
@@ -759,7 +761,7 @@ def test_entry_busy_gates_a_successor_firing_at_its_inherited_instance_free_cycl
     # for every current kernel -- a residue survives only when an operator's initiation interval exceeds its latest
     # write word, which no II=1 operator does -- so no end-to-end build exercises it. Pin its consumption directly:
     # ``schedule_ops`` must hold a pooled firing off its instance until that instance frees in the successor frame.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a * b  # one pooled firing; both operands are inputs (block-start ready), so nothing else can delay it
 
     mir = _run(f)
@@ -807,7 +809,8 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from recip_newton import NewtonReciprocal  # noqa: PLC0415 (example kernels live under examples/)
 
-    def join_spill(x: float, y: float, z: float):  # w spills from the entry into BOTH arms and is read after the merge
+    # w spills from the entry into BOTH arms and is read after the merge
+    def join_spill(x: float, y: float, z: float) -> float:
         w = (x * z + y) * z + y
         if x < y:
             a = z + 1.0
@@ -816,7 +819,7 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
         return w + a
 
     # the merged value is produced in each arm (no entry spill), read after the merge
-    def phi_merge(x: float, y: float):
+    def phi_merge(x: float, y: float) -> float:
         if x < y:
             a = x + 1.0
         else:
@@ -824,7 +827,7 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
         return a * 2.0
 
     # a boolean phi whose else arm reads the value inverted -> a non-coalesced bool_write
-    def bool_write_merge(x: float, y: float):
+    def bool_write_merge(x: float, y: float) -> tuple[bool, float]:
         p = x < y
         if x < 1.0:
             c = p
@@ -969,7 +972,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._d = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             prev = self._d
             self._d = x
             return prev
@@ -978,7 +981,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._s = 0.0
 
-        def __call__(self, x: float, y: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float, y: float) -> float:
             out = self._s
             if x > 0.0:
                 self._s = x + y
@@ -990,7 +993,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._f = False
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> tuple[bool, float]:
             out = self._f
             if x > 0.0:
                 self._f = True
@@ -1002,7 +1005,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:
             self._b = False
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             old = self._b
             self._b = not self._b
             return x if old else -x
@@ -1011,7 +1014,7 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         def __init__(self) -> None:  # the destination): the carry survives only if the boundary bundle is read-first
             self._b = False
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self._b = not self._b
             return x
 
@@ -1282,7 +1285,7 @@ def _ilog2(mir: Mir) -> list[int]:
 
 def test_fmul_ilog2_same_k_shares_one_instance() -> None:
     # Two K=2 scalings that never run on the same cycle (the second waits on a multiply) pool onto one instance.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> tuple[float, float]:
         return (a * b) * 4.0, b * 4.0
 
     mir = _run(f)
@@ -1296,7 +1299,7 @@ def test_fmul_ilog2_same_k_shares_one_instance() -> None:
 
 def test_fmul_ilog2_same_k_serializes_by_default_parallelizes_with_budget() -> None:
     # Two independent K=2 scalings are both ready at cycle 1; the per-kind budget governs them like any other kind.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> tuple[float, float]:
         return a * 4.0, b * 4.0
 
     mir = _run(f)
@@ -1309,7 +1312,7 @@ def test_fmul_ilog2_same_k_serializes_by_default_parallelizes_with_budget() -> N
 
 
 def test_fmul_ilog2_different_k_never_shares() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a * 4.0 + b * 8.0  # K=2 and K=3 -- distinct hardware modules
 
     mir = _run(f)
@@ -1322,7 +1325,7 @@ def test_fmul_ilog2_different_k_never_shares() -> None:
 
 
 def test_build_lir_small_kernel() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     lir = build(_run(f), "kernel", fetch_stages=3)
@@ -1357,7 +1360,7 @@ def test_state_writeback_installs_early_and_is_first_class() -> None:
         def __init__(self) -> None:
             self._p = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             out = self._p + x  # reads the old _p; the fadd result is the only output
             self._p = x  # a non-coalesced writeback whose source (the input x) is an ordinary register
             return out
@@ -1397,7 +1400,7 @@ def test_cfg_phi_merge_register_shows_residence(monkeypatch: pytest.MonkeyPatch)
     # register is written ONLY by the per-arm phi copies and read at the boundary, never by an operator. Before
     # phi-copy residence was added to reg_liveness, such a register had a use but no def and so collapsed to an empty
     # (untinted) live set -- the CFG-report liveness gap.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         if x > 0.0:
             z = 1.0
         else:
@@ -1421,7 +1424,7 @@ def test_cfg_write_only_state_slot_is_reserved() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if x > 0.0:
                 t = x * 2.0
             else:
@@ -1445,7 +1448,7 @@ def test_cfg_state_slot_coalesces_onto_its_register() -> None:
         def __init__(self) -> None:
             self.state = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self.state = self.state * 0.9 + x
             return float(x > 0.0) * self.state
 
@@ -1466,7 +1469,7 @@ def test_cfg_branch_conditions_reuse_boolean_registers(monkeypatch: pytest.Monke
 
     # Sequential data-dependent branches: each condition is computed, tested at its boundary, and dead before the next,
     # so the boolean bank reuses one register across them instead of allocating one per branch.
-    def f(x: float, y: float, z: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float, z: float) -> float:
         a = x
         if x > 0.0:
             a = a + 1.0
@@ -1484,7 +1487,7 @@ def test_cfg_branch_conditions_reuse_boolean_registers(monkeypatch: pytest.Monke
     assert abs(float(model.run(1.0, -1.0, 1.0)[0]) - 6.0) < 1e-3  # a=1; +1 (x>0); skip (y<=0); +4 (z>0) = 6
 
 
-def _coalescing_self_copies(lir) -> int:  # type: ignore[no-untyped-def]
+def _coalescing_self_copies(lir: Lir) -> int:
     """Count no-op identity copies (``r <= r`` with identity sign): a coalescable arm the pass should have merged."""
     return sum(
         1
@@ -1502,7 +1505,7 @@ def test_diamond_op_result_arms_coalesce(monkeypatch: pytest.MonkeyPatch) -> Non
     # correct on both arms -- bit-exact value preservation against the RTL is the cosim's job; here we pin the win.
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)  # keep the diamond a real phi merge, not a select
 
-    def f(x: float, y: float):  # type: ignore[no-untyped-def]
+    def f(x: float, y: float) -> float:
         if x > 0.0:
             z = x + y
         else:
@@ -1523,7 +1526,7 @@ def test_loop_carried_phi_coalesces_when_non_interfering() -> None:
     # A directed loop whose carried value is read once (read-first) before its update lands: the header phi and its
     # back-edge arm (an op result) do not interfere, so they coalesce -- the loop body installs no register-source copy.
     # Only the entry constants (acc=0, i=0) keep their copies.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         acc = 0.0
         i = 0.0
         while i < 3.0:
@@ -1560,7 +1563,7 @@ def test_interfering_loop_carried_phi_keeps_its_copy() -> None:
     assert back_edge_op_copies, "the interfering loop-carried Newton update must keep its back-edge install copy"
 
 
-def _check_float_kernel(fn, name, samples):  # type: ignore[no-untyped-def]
+def _check_float_kernel(fn: Callable[..., object], name: str, samples: list[tuple[float, ...]]) -> None:
     lir = build(
         _run(fn), name, fetch_stages=3
     )  # crash-before: the install-free oracle admitted an unsound merge -> backstop assert
@@ -1579,7 +1582,7 @@ def test_phi_coalescing_residual_install_conflict_is_resolved() -> None:
     # (sign-folded) else-arm install writes that shared register. The final, install-aware interference then flags the
     # class against itself and the coloring backstop aborted the build. The fixpoint must de-coalesce ``a`` and build.
     # The division keeps the diamond a real branch (un-if-converted), which is what creates the phi merge.
-    def k(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
+    def k(x: float, b: float, cc: float) -> tuple[float, float, float]:
         if b < cc:
             a = x
             z = 1.0
@@ -1598,7 +1601,7 @@ def test_phi_coalescing_conflict_resolved_under_reversed_declaration_order() -> 
     # order the union-find follows -- change, so a DIFFERENT phi wins the merge onto ``x``. The fixpoint must converge
     # regardless of which phi coalesced first; this pins the resolution as order-independent, not an artifact of one id
     # assignment.
-    def k(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
+    def k(x: float, b: float, cc: float) -> tuple[float, float, float]:
         if b < cc:
             d = b
             z = 1.0
@@ -1615,7 +1618,7 @@ def test_phi_coalescing_conflict_resolved_under_reversed_declaration_order() -> 
 def test_phi_coalescing_conflict_resolved_with_swapped_branch_arms() -> None:
     # The mirror: the coalescing identity arm sits in the else block and the sign-folded residual arm in the then block,
     # so the conflict is exercised from the opposite branch polarity. Confirms the de-coalescing is arm-order agnostic.
-    def k(x: float, b: float, cc: float):  # type: ignore[no-untyped-def]
+    def k(x: float, b: float, cc: float) -> tuple[float, float, float]:
         if b < cc:
             a = -(x + 1.0)
             z = x
@@ -1636,7 +1639,7 @@ def test_bool_phi_coalescing_residual_install_conflict_is_resolved() -> None:
     # if-converted). The fixpoint must de-coalesce and build; checked bit-exact across all eight boolean input vectors.
     import itertools  # noqa: PLC0415
 
-    def k(p: bool, q: bool, r: bool):  # type: ignore[no-untyped-def]
+    def k(p: bool, q: bool, r: bool) -> tuple[bool, bool, bool]:
         if p:
             a = q
             z = True
@@ -1664,7 +1667,7 @@ def test_state_war_backstop_allows_noop_writeback() -> None:
         def __init__(self) -> None:
             self.s = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             out = self.s + x
             self.s = self.s
             return out
@@ -1680,7 +1683,7 @@ def test_copy_slot_residence_unbroken_when_tapped_at_boundary() -> None:
         def __init__(self) -> None:
             self._d = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             prev = self._d
             self._d = x
             return prev
@@ -1736,7 +1739,7 @@ def test_build_lir_ekf1_stateless() -> None:
 
 def test_sign_paired_constants_collapse_to_one_magnitude() -> None:
     # +c and -c share a single nonnegative pool entry; the sign rides the (free) per-operand sign control.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a * 1000.0 + a * (-1000.0)
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -1747,7 +1750,7 @@ def test_sign_paired_constants_collapse_to_one_magnitude() -> None:
 
 
 def test_negative_constant_operand_is_stored_as_magnitude_with_negate() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a + (-1000.0)
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -1776,7 +1779,7 @@ def test_constant_pool_is_canonically_nonnegative() -> None:
 def test_underflowing_negative_constant_is_not_sign_folded() -> None:
     # A negative value that rounds to +0 in ZKF (which has no -0) must NOT carry a folded negate: the magnitude already
     # encodes to the canonical +0, so a negate over it would emit an illegal -0 rather than the +0 the value encodes to.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a + (-1e-12)  # -1e-12 underflows to +0 in FloatFormat(6, 18)
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -1786,7 +1789,7 @@ def test_underflowing_negative_constant_is_not_sign_folded() -> None:
 
 
 def test_underflowing_negative_constant_output_stays_canonical_zero() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> tuple[float, float]:
         return a + a, -1e-12  # the -1e-12 output underflows to +0; it must stay canonical, not fold to illegal -0
 
     lir = build(_run(f), "f", fetch_stages=3)
@@ -1963,7 +1966,7 @@ def test_fmul_ilog2_operator_rejects_out_of_range_k() -> None:
         FMulILog2Operator(FMT, k=-limit - 1)
 
 
-def _read_mux_fan_in(lir) -> int:  # type: ignore[no-untyped-def]
+def _read_mux_fan_in(lir: Lir) -> int:
     return sum(max(0, len(regs) - 1) for regs in lir.read_set_per_port.values())
 
 
@@ -1985,8 +1988,8 @@ def test_marked_commutative_operators_are_bit_exact_commutative() -> None:
             assert evaluate(a, b).bits == evaluate(b, a).bits
 
 
-def test_commutative_port_assignment_never_increases_read_mux_fan_in(  # type: ignore[no-untyped-def]
-    monkeypatch,
+def test_commutative_port_assignment_never_increases_read_mux_fan_in(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import holoso._lir._build as build_module
 
@@ -2011,7 +2014,7 @@ def test_commutative_port_assignment_never_increases_read_mux_fan_in(  # type: i
 
 def test_optional_stages_raise_latency_without_changing_numerics() -> None:
     # A kernel touching every operator family: fadd, fmul, fdiv, and the 2^-2 strength-reduced fmul_ilog2.
-    def kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float, b: float, c: float) -> float:
         return (a - b) / c + a * b * 0.25
 
     fmt = FloatFormat(8, 36)
@@ -2028,7 +2031,7 @@ def test_optional_stages_raise_latency_without_changing_numerics() -> None:
             assert [v.bits for v in model.run(*values)] == want, f"{name} diverged from default at {values}"
 
 
-def test_reach_floor_seed_skips_annealing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_reach_floor_seed_skips_annealing(monkeypatch: pytest.MonkeyPatch) -> None:
     # The mux-fan-in objective bottoms out at 0 (every read port reaches one register, every register one producer). A
     # greedy seed already there is globally optimal, so refinement must short-circuit rather than burn the budget.
     import holoso._lir._regalloc as regalloc
@@ -2037,10 +2040,10 @@ def test_reach_floor_seed_skips_annealing(monkeypatch) -> None:  # type: ignore[
     real = regalloc.dual_annealing
     monkeypatch.setattr(regalloc, "dual_annealing", lambda *a, **k: (calls.append(1), real(*a, **k))[1])
 
-    def floor_kernel(a: float, b: float):  # type: ignore[no-untyped-def]
+    def floor_kernel(a: float, b: float) -> float:
         return a + b  # no register sharing -> greedy seed is at the reach floor
 
-    def sharing_kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def sharing_kernel(a: float, b: float, c: float) -> float:
         return a * b + c  # the product and the sum reuse registers, lifting the objective above the floor
 
     build(_run(floor_kernel), "floor", fetch_stages=3)
@@ -2049,13 +2052,13 @@ def test_reach_floor_seed_skips_annealing(monkeypatch) -> None:  # type: ignore[
     assert calls
 
 
-def test_zero_regalloc_effort_bypasses_annealing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_zero_regalloc_effort_bypasses_annealing(monkeypatch: pytest.MonkeyPatch) -> None:
     import holoso._lir._regalloc as regalloc
 
     monkeypatch.setattr(regalloc, "_REFINE_MAXITER", 0)
     monkeypatch.setattr(regalloc, "dual_annealing", lambda *args, **kwargs: pytest.fail("annealing was not bypassed"))
 
-    def sharing_kernel(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def sharing_kernel(a: float, b: float, c: float) -> float:
         return a * b + c
 
     build(_run(sharing_kernel), "sharing", fetch_stages=3)
@@ -2067,7 +2070,7 @@ def test_bool_to_float_cast_result_is_live_on_its_landing_cycle() -> None:
     # later marks it past its true landing (and, for a boundary cast, past the initiation interval, so its report cell
     # falls off the grid) and leaves a consumer's read cycle outside its residence. Here a multiply consumes the cast
     # result.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return float(x > 0.0) * x
 
     lir = build(_run(f), "cast_mul", fetch_stages=3)
@@ -2096,7 +2099,7 @@ def test_two_relations_over_one_operand_pair_fuse_into_one_firing() -> None:
     # Two DIFFERENT relations over the same operand pair tap two distinct output ports of one comparator activation,
     # so they fuse into a single firing: one instance issue, one operand read, two boolean writes -- the multi-output
     # machinery exercised end to end on the boolean side. The model must still produce both values correctly.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         below = a < b
         same = a == b
         return [float(below), float(same)]
@@ -2117,7 +2120,7 @@ def test_two_relations_over_one_operand_pair_fuse_into_one_firing() -> None:
 def test_same_port_taps_with_different_inversions_do_not_fuse() -> None:
     # ``a < b`` taps the lt flag plainly and ``a >= b`` taps the SAME flag inverted: one output-port lane writes once
     # per firing, so these must stay two firings, spaced by instance contention. Both values must still be correct.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         below = a < b
         not_below = a >= b
         return [float(below), float(not_below)]
@@ -2214,7 +2217,7 @@ def test_write_timeline_resolves_inline_wide_producers() -> None:
     # Regression (review): the write timeline recorded only pooled firings' wide writes, so a register written by an
     # inline bool->float cast and read by a float operator resolved to NO producer at all -- latest_producer_before
     # raised KeyError on the cast-fed multiply below.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         return float(x > 0.0) * x
 
     lir = build(_run(f), "cast_timeline", fetch_stages=3)
@@ -2238,7 +2241,7 @@ def test_commutative_comparator_swap_permutes_output_taps(config: OperatorCase) 
     # otherwise read (a,b) and (b,a) -- two registers per read port; the port assignment orients one of them swapped,
     # shrinking each port's read-set to a single register, and the swapped firing's lt tap moves to gt. Bit-exact
     # because the ZKF ordering is total and compare is antisymmetric.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         below = a < b
         above = b < a
         return [float(below), float(above)]
@@ -2278,7 +2281,7 @@ def test_chained_slot_live_in_blocks_early_install(config: OperatorCase) -> None
 def test_select_folds_arm_signs_into_operand_conditioners() -> None:
     # ``x if c else -x`` costs exactly one comparison and one select: the arm negation rides the select's operand
     # conditioner (the inline dual of the pooled operators' sign sidebands), never a separate float operation.
-    def f(x: float, c: float):  # type: ignore[no-untyped-def]
+    def f(x: float, c: float) -> float:
         y = x if c > 0.0 else -x
         return y
 
@@ -2326,7 +2329,7 @@ def test_not_folds_into_every_sink_position() -> None:
     # A semantic NOT never materializes hardware: it becomes a free inversion conditioner at each consumer. The
     # kernel routes one comparison's negation into a logic operand, a bool output, and a bool->float cast; the LIR
     # must contain NO inline op beyond the band and the cast, and the inversions must ride the operand sidebands.
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> list[float]:
         flag = not (a > b)
         out_logic = flag and (c > 0.0)
         return [float(flag), float(out_logic)]
@@ -2347,7 +2350,7 @@ def test_not_folds_into_every_sink_position() -> None:
 def test_not_on_a_branch_condition_swaps_the_targets() -> None:
     # ``if not cond`` costs nothing: the branch takes the complementary target instead of inverting the register.
     # The division arms keep the diamond a real branch (if-conversion refuses them).
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         if not (a > b):
             y = a / (b * b + 1.0)
         else:
@@ -2364,7 +2367,7 @@ def test_not_on_a_branch_condition_swaps_the_targets() -> None:
 
 
 def test_double_negation_cancels() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         flag = not (not (a > b))
         return float(flag)
 
@@ -2379,7 +2382,7 @@ def test_double_negation_cancels() -> None:
 
 def test_value_consumed_in_both_polarities_shares_one_producer() -> None:
     # ``x`` and ``not x`` share one comparator tap and one boolean register: the polarity lives on each consumer.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         flag = a > b
         return [float(flag), float(not flag)]
 
@@ -2395,7 +2398,7 @@ class _InvertedState:
     def __init__(self) -> None:
         self._flip = False
 
-    def step(self, x: float):  # type: ignore[no-untyped-def]
+    def step(self, x: float) -> float:
         old = self._flip
         self._flip = not self._flip
         return x if old else -x
@@ -2419,7 +2422,7 @@ def test_inverted_bool_phi_arm_installs_with_opposite_polarities(config: Operato
     # opposite inversions (one arm rewrites the flag as its own negation). The two install copies must carry
     # opposite-polarity sources, and the model must take the correct value on both paths. The division keeps the
     # diamond a real branch (bool-phi diamonds are refused by if-conversion anyway; the div makes it doubly so).
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> list[float]:
         flag = a > b
         if c > 0.0:
             flag = not flag
@@ -2447,7 +2450,7 @@ def test_boolean_registers_are_reused_within_a_block() -> None:
     # Exact per-consumer read steps free a condition's register once its last reader fires, so a chain of sequential
     # selects whose conditions die mid-block shares a few boolean registers instead of one per condition. The chain
     # is data-dependent (each select feeds the next comparison), so the conditions' lifetimes are disjoint.
-    def f(x: float):  # type: ignore[no-untyped-def]
+    def f(x: float) -> float:
         for _ in range(6):
             x = (x - 1.0) if x > 1.0 else (x + 1.0)
         return x
@@ -2470,7 +2473,7 @@ def test_boolean_logic_chain_reuses_registers_on_the_tight_same_bank_edge() -> N
     # reduction over many comparisons produces intermediate flags that die as the next gate consumes them, on the
     # tightest read-first edge (an inline gate reads its operand on exactly the step the next result's write-enable
     # fires; landing = fire + 1 keeps R(a) < W(b)). The chain must collapse onto a handful of registers.
-    def f(a: float, b: float, c: float, d: float, e: float, g: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float, d: float, e: float, g: float) -> float:
         return 1.0 if (a > b and c > d and e > g and a > d and b > e) else 0.0
 
     lir = build(_run(f), "bool_chain", fetch_stages=3)
@@ -2523,7 +2526,7 @@ class _AliasedFloatState:
         self.pub = 0.0
         self._alias = 0.0
 
-    def step(self, a: float, b: float):  # type: ignore[no-untyped-def]
+    def step(self, a: float, b: float) -> float:
         self.pub = a + b
         self._alias = a + b
         return self.pub

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -19,7 +19,7 @@ from holoso import (
 )
 
 
-def _kernel(a: float, b: float):  # type: ignore[no-untyped-def]  # module-level so inspect.getsource works
+def _kernel(a: float, b: float) -> float:  # module-level so inspect.getsource works
     return (a - b) * 0.25 + a * b
 
 
@@ -53,7 +53,7 @@ def test_op_config_rejects_mixed_float_formats() -> None:
 
 
 def test_constant_only_module_keeps_operator_configured_format() -> None:
-    def const_only():  # type: ignore[no-untyped-def]
+    def const_only() -> float:
         return 3.5
 
     fmt = FloatFormat(6, 18)
@@ -85,10 +85,10 @@ def test_synthesize_threads_pipeline_stages() -> None:
 
 
 def test_rejects_non_finite_constants() -> None:
-    def overflow(a: float):  # type: ignore[no-untyped-def]
+    def overflow(a: float) -> float:
         return a + 1e400  # overflows to +inf, not representable in the ZKF format
 
-    def folds_to_nan(a: float):  # type: ignore[no-untyped-def]
+    def folds_to_nan(a: float) -> float:
         return a + (1e400 - 1e400)  # inf - inf const-folds to NaN
 
     for fn in (overflow, folds_to_nan):
@@ -148,7 +148,7 @@ def test_synthesize_ekf1_stateless() -> None:
 
 def test_class_target_is_unsupported() -> None:
     class Stateful:
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             return x
 
     with pytest.raises(holoso.UnsupportedConstruct):

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -19,7 +19,7 @@ from holoso import (
 )
 
 
-def _kernel(a, b):  # type: ignore[no-untyped-def]  # module-level so inspect.getsource works
+def _kernel(a: float, b: float):  # type: ignore[no-untyped-def]  # module-level so inspect.getsource works
     return (a - b) * 0.25 + a * b
 
 
@@ -85,10 +85,10 @@ def test_synthesize_threads_pipeline_stages() -> None:
 
 
 def test_rejects_non_finite_constants() -> None:
-    def overflow(a):  # type: ignore[no-untyped-def]
+    def overflow(a: float):  # type: ignore[no-untyped-def]
         return a + 1e400  # overflows to +inf, not representable in the ZKF format
 
-    def folds_to_nan(a):  # type: ignore[no-untyped-def]
+    def folds_to_nan(a: float):  # type: ignore[no-untyped-def]
         return a + (1e400 - 1e400)  # inf - inf const-folds to NaN
 
     for fn in (overflow, folds_to_nan):
@@ -148,7 +148,7 @@ def test_synthesize_ekf1_stateless() -> None:
 
 def test_class_target_is_unsupported() -> None:
     class Stateful:
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             return x
 
     with pytest.raises(holoso.UnsupportedConstruct):

--- a/tests/test_timing_equivalence_behavior.py
+++ b/tests/test_timing_equivalence_behavior.py
@@ -27,6 +27,8 @@ handshake (out stays frozen, no new input accepted, state advances exactly once 
 invariant. A divergence under back-pressure would indicate the longer pipeline mis-drains an in-flight transaction.
 """
 
+from collections.abc import Callable
+
 import numpy as np
 
 import holoso
@@ -37,15 +39,13 @@ from ._modelref import default_ops, overlap_spill_kernel, staged_ops
 FMT = FloatFormat(6, 18)
 
 
-def _pair(fn, name: str):  # type: ignore[no-untyped-def]
+def _pair(fn: Callable[..., object], name: str) -> tuple[holoso.NumericalSimulator, holoso.NumericalSimulator]:
     short = holoso.synthesize(fn, default_ops(FMT), name=f"{name}_short").numerical_model.elaborate()
     long = holoso.synthesize(fn, staged_ops(FMT), name=f"{name}_long").numerical_model.elaborate()
     return short, long
 
 
-def _assert_bits_equal(  # type: ignore[no-untyped-def]
-    short: holoso.NumericalSimulator, long: holoso.NumericalSimulator, *inputs
-) -> int:
+def _assert_bits_equal(short: holoso.NumericalSimulator, long: holoso.NumericalSimulator, *inputs: float) -> int:
     out_short = short.run(*inputs)
     out_long = long.run(*inputs)
     assert len(out_short) == len(out_long), f"output arity differs: {len(out_short)} vs {len(out_long)}"
@@ -68,7 +68,7 @@ def _assert_bits_equal(  # type: ignore[no-untyped-def]
 # --------------------------------------------------------------------------------------------------------------------
 
 
-def _branchy_diamond(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
+def _branchy_diamond(x: float, y: float, c: float) -> float:
     t = (x * y + c) * y  # a multiply-add-multiply chain that commits late
     if t > c:
         r = t + x
@@ -94,7 +94,7 @@ def test_branchy_diamond_timing_invariant() -> None:
 # --------------------------------------------------------------------------------------------------------------------
 
 
-def _newton_reciprocal(a: float, n: float):  # type: ignore[no-untyped-def]
+def _newton_reciprocal(a: float, n: float) -> float:
     # y_{k+1} = y_k * (2 - a*y_k) converges to 1/a; the loop carries y across a data-dependent number of iterations.
     y = 0.5
     i = n
@@ -112,7 +112,7 @@ def test_back_edge_loop_timing_invariant() -> None:
             _assert_bits_equal(short, long, a, n)
 
 
-def _cycles_to_out_valid(simulator: holoso.NumericalSimulator, *inputs) -> int:  # type: ignore[no-untyped-def]
+def _cycles_to_out_valid(simulator: holoso.NumericalSimulator, *inputs: float) -> int:
     simulator.set_inputs(*inputs)
     count = 1
     simulator.tick(in_valid=True, out_ready=False)
@@ -146,7 +146,7 @@ class _LeakyAccumulator:
     def __init__(self) -> None:
         self._acc = 0.0
 
-    def __call__(self, x: float, y: float):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float, y: float) -> float:
         d = x * y + x
         if x > y:
             r = d + 1.0
@@ -170,7 +170,9 @@ def test_stateful_stream_timing_invariant_with_reset() -> None:
         _assert_bits_equal(short, long, x, y)
 
 
-def _drain_to_output(simulator: holoso.NumericalSimulator, inputs, stall: int):  # type: ignore[no-untyped-def]
+def _drain_to_output(
+    simulator: holoso.NumericalSimulator, inputs: tuple[float, ...], stall: int
+) -> holoso.FloatValue | bool:
     simulator.set_inputs(*inputs)
     while not simulator.in_ready:
         simulator.tick(in_valid=False, out_ready=True)

--- a/tests/test_timing_equivalence_behavior.py
+++ b/tests/test_timing_equivalence_behavior.py
@@ -68,7 +68,7 @@ def _assert_bits_equal(  # type: ignore[no-untyped-def]
 # --------------------------------------------------------------------------------------------------------------------
 
 
-def _branchy_diamond(x, y, c):  # type: ignore[no-untyped-def]
+def _branchy_diamond(x: float, y: float, c: float):  # type: ignore[no-untyped-def]
     t = (x * y + c) * y  # a multiply-add-multiply chain that commits late
     if t > c:
         r = t + x
@@ -94,7 +94,7 @@ def test_branchy_diamond_timing_invariant() -> None:
 # --------------------------------------------------------------------------------------------------------------------
 
 
-def _newton_reciprocal(a, n):  # type: ignore[no-untyped-def]
+def _newton_reciprocal(a: float, n: float):  # type: ignore[no-untyped-def]
     # y_{k+1} = y_k * (2 - a*y_k) converges to 1/a; the loop carries y across a data-dependent number of iterations.
     y = 0.5
     i = n
@@ -146,7 +146,7 @@ class _LeakyAccumulator:
     def __init__(self) -> None:
         self._acc = 0.0
 
-    def __call__(self, x, y):  # type: ignore[no-untyped-def]
+    def __call__(self, x: float, y: float):  # type: ignore[no-untyped-def]
         d = x * y + x
         if x > y:
             r = d + 1.0

--- a/tests/test_timing_equivalence_behavior.py
+++ b/tests/test_timing_equivalence_behavior.py
@@ -32,7 +32,7 @@ from collections.abc import Callable
 import numpy as np
 
 import holoso
-from holoso import FloatFormat
+from holoso import FloatFormat, FloatValue
 
 from ._modelref import default_ops, overlap_spill_kernel, staged_ops
 
@@ -82,7 +82,9 @@ def test_branchy_diamond_timing_invariant() -> None:
     rng = np.random.default_rng(0xB47C)
     # Both branch polarities and the exact decision boundary (t == c) on hand-picked vectors plus a random sweep.
     samples = [(1.0, 2.0, 0.0), (0.5, 0.5, 1.0), (-1.0, 3.0, -2.0), (2.0, 1.0, 5.0), (0.0, 4.0, 0.0)]
-    samples += [tuple(float(rng.uniform(-3.0, 3.0)) for _ in range(3)) for _ in range(60)]
+    samples += [
+        (float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0))) for _ in range(60)
+    ]
     for x, y, c in samples:
         _assert_bits_equal(short, long, x, y, c)
 
@@ -160,7 +162,7 @@ def test_stateful_stream_timing_invariant_with_reset() -> None:
     short, long = _pair(_LeakyAccumulator().__call__, "leaky_acc")
     rng = np.random.default_rng(0x5EED)
     sequence = [(1.0, 2.0), (2.0, 1.0), (0.5, 0.5)]  # both polarities and the x == y boundary
-    sequence += [tuple(float(rng.uniform(-3.0, 3.0)) for _ in range(2)) for _ in range(40)]
+    sequence += [(float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0))) for _ in range(40)]
     for x, y in sequence:
         _assert_bits_equal(short, long, x, y)
     # A reset partway must restore both pipelines to the same snapshot; they must continue bit-identical afterwards.
@@ -195,6 +197,7 @@ def test_stateful_backpressure_timing_invariant() -> None:
     for index, vector in enumerate([(1.0, 2.0), (3.0, 1.0), (0.5, 4.0), (2.0, 2.0), (-1.0, 0.5)]):
         held_short = _drain_to_output(short, vector, stall=2 * index)
         held_long = _drain_to_output(long, vector, stall=2 * index)
+        assert isinstance(held_short, FloatValue) and isinstance(held_long, FloatValue)
         assert held_short.bits == held_long.bits, (
             f"vector={vector} stall={2 * index}: short=0x{held_short.bits:x} ({float(held_short)}) "
             f"long=0x{held_long.bits:x} ({float(held_long)})"
@@ -213,6 +216,8 @@ def test_overlap_spill_timing_invariant() -> None:
     short, long = _pair(overlap_spill_kernel, "overlap_spill")
     rng = np.random.default_rng(0x09E2)
     samples = [(1.0, 2.0, 0.5), (2.0, 1.0, 0.5), (0.5, 0.5, 1.0), (-1.0, 3.0, 2.0), (3.0, -1.0, -2.0)]
-    samples += [tuple(float(rng.uniform(-3.0, 3.0)) for _ in range(3)) for _ in range(60)]
+    samples += [
+        (float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0)), float(rng.uniform(-3.0, 3.0))) for _ in range(60)
+    ]
     for x, y, z in samples:
         _assert_bits_equal(short, long, x, y, z)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -63,7 +63,7 @@ def test_model_exact_integer_comparison_is_not_folded_via_float() -> None:
     def exact_int_comparison(a: float) -> float:
         # Regression (user): two compile-time integers must be compared exactly, not via a lossy float64 fold. As
         # float64 both operands round to 9007199254740992.0 and the `==` would misfold true; as integers they differ.
-        if 9007199254740993 == 9007199254740992:
+        if 9007199254740993 == 9007199254740992:  # type: ignore[comparison-overlap]  # deliberately-distinct literals
             r = a
         else:
             r = a + 1.0
@@ -189,7 +189,7 @@ def test_for_counter_reassigned_to_runtime_clears_static_binding() -> None:
     # ``1.0 >= 0`` (the counter), silently taking the wrong arm and miscompiling the output for any ``i`` above 1.
     def f(a: float) -> float:
         for i in range(1):
-            i = a  # reassign the loop variable to a runtime value inside the (single-trip) body
+            i = a  # type: ignore[assignment]  # reassign the loop variable to a runtime value (single-trip body)
         if 1.0 >= i:
             r = 100.0
         else:
@@ -209,7 +209,7 @@ def test_for_counter_reassigned_after_loop_clears_static_binding() -> None:
         acc = 0.0
         for i in range(3):
             acc = acc + 1.0
-        i = a
+        i = a  # type: ignore[assignment]
         if 1.0 >= i:
             acc = acc + 50.0
         return acc
@@ -227,7 +227,7 @@ def test_runtime_reassigned_for_counter_is_not_a_static_index() -> None:
     def f(a: float, b: float, c: float) -> float:
         vec = [a, b, c]
         for i in range(1):
-            i = a  # i is now a runtime value, not a compile-time index
+            i = a  # type: ignore[assignment]  # i is now a runtime value, not a compile-time index
         return vec[i]
 
     with pytest.raises(UnsupportedConstruct):
@@ -247,7 +247,7 @@ def test_for_counter_reassign_keeps_scan_and_lowering_in_lockstep() -> None:
 
         def step(self, a: float) -> float:
             for t in range(1):
-                t = a  # reassign the counter to a runtime value -> the following branch is dynamic
+                t = a  # type: ignore[assignment]  # reassign the counter to a runtime value -> a dynamic branch
             # Both sides are otherwise compile-time (the counter and a literal), so if the scan failed to demote the
             # reassigned counter it would fold ``0 < 1.0`` to True and never scan the else arm. With the counter
             # correctly demoted, this is a real runtime branch and the else arm's ``self.s`` write is reachable.
@@ -283,7 +283,7 @@ def test_walrus_counter_demotion_keeps_scan_and_lowering_in_lockstep() -> None:
         def step(self, a: float) -> float:
             for t in range(1):  # leaks t == 0 (a compile-time integer) into the enclosing scope
                 pass
-            if (t := a) < 1.0:  # the walrus rebinds t to a runtime value -> a real branch, not a stale 0<1.0 fold
+            if (t := a) < 1.0:  # type: ignore[assignment]  # the walrus rebinds t to a runtime value, not a fold
                 pass
             else:
                 c = 2.0
@@ -312,7 +312,7 @@ def test_for_counter_reassigned_inside_while_is_demoted_after_the_loop() -> None
             pass
         w = 0.0
         while w < 1.0:
-            i = a  # demote the counter to a runtime value INSIDE the while body
+            i = a  # type: ignore[assignment]  # demote the counter to a runtime value INSIDE the while body
             w = w + 1.0
         r = 0.0
         if i < 0.0:  # must be a real runtime branch on the reassigned value, not a fold on the stale counter (0)
@@ -336,7 +336,8 @@ def test_for_counter_reassigned_inside_while_rejects_later_static_use() -> None:
             pass
         w = 0.0
         while w < 1.0:
-            i = a  # runtime reassignment inside the loop -> i is no longer a compile-time integer afterwards
+            # runtime reassignment inside the loop -> i is no longer a compile-time integer afterwards
+            i = a  # type: ignore[assignment]
             w = w + 1.0
         return a * 2.0**i  # a runtime exponent must be rejected, never folded against the stale counter
 
@@ -394,6 +395,7 @@ def test_model_is_bit_exact_for_wide_zkf_multiply_regression() -> None:
         FloatValue.from_bits(fmt, 0x42BF30E6505),
         FloatValue.from_bits(fmt, 0xBD734F60F3A),
     )
+    assert isinstance(got[0], FloatValue)
     assert got[0].bits == 0xC0B5B6B31D9
 
 
@@ -1216,7 +1218,7 @@ def test_model_attr_written_under_counter_gated_branch_in_while() -> None:
                     self.s1 = a
                 else:
                     self._s2 = a
-                i = a
+                i = a  # type: ignore[assignment]
                 w = w - 1.0
             return self._s2
 
@@ -1278,7 +1280,8 @@ def test_model_statically_dead_attribute_write_is_not_state() -> None:
                 self.y = x
             return self.y
 
-    for kernel, constant in [(DeadLoopWrite, 1.25), (DeadIfWrite, 2.5)]:
+    kernels: list[tuple[type[DeadLoopWrite] | type[DeadIfWrite], float]] = [(DeadLoopWrite, 1.25), (DeadIfWrite, 2.5)]
+    for kernel, constant in kernels:
         lir = build(_run(kernel().__call__), "dead", fetch_stages=3)
         assert [slot.name for slot in lir.float_state_slots] == []  # no state slot; no crash building it
         model = build_model(lir)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -58,7 +58,7 @@ def _run(target):  # type: ignore[no-untyped-def]
 
 
 def test_model_exact_integer_comparison_is_not_folded_via_float() -> None:
-    def exact_int_comparison(a):  # type: ignore[no-untyped-def]
+    def exact_int_comparison(a: float):  # type: ignore[no-untyped-def]
         # Regression (user): two compile-time integers must be compared exactly, not via a lossy float64 fold. As
         # float64 both operands round to 9007199254740992.0 and the `==` would misfold true; as integers they differ.
         if 9007199254740993 == 9007199254740992:
@@ -125,14 +125,14 @@ def test_is_legal_rejects_subnormal_and_negative_zero() -> None:
 
 
 def test_reference_evaluates_and_flattens() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return [a + b, a * b]
 
     assert evaluate_reference(f, {"a": 2.0, "b": 3.0}) == [5.0, 6.0]
 
 
 def test_model_matches_reference_small_kernels() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     inputs = {"a": 1.25, "b": -3.5}
@@ -149,7 +149,7 @@ def test_model_matches_reference_dense_boolean_chain() -> None:
     # after its producer's commit, and the wide-result cast one later, so this pins the model's read/landing
     # frames against the exact Python reference at exactly that spacing. All values are chosen exactly representable,
     # so every comparison, cast, and product is exact and the outputs must match the reference bit-for-bit.
-    def f(a, b, c, d, k):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float, d: float, k: float):  # type: ignore[no-untyped-def]
         inside = a < b and not (c < d)
         gated = float(inside) * k
         live = bool(gated + a)
@@ -168,7 +168,7 @@ def test_model_matches_reference_dense_boolean_chain() -> None:
 def test_tuple_unpacking_matches_python_reference() -> None:
     # The reference runs the kernel as ordinary Python (which unpacks natively), so a bit-faithful hardware model must
     # route the swapped operands identically before the arithmetic.
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         x, y = b, a
         return [x - y, x * y]
 
@@ -185,7 +185,7 @@ def test_for_counter_reassigned_to_runtime_clears_static_binding() -> None:
     # binding, so a subsequent branch on that name is a real runtime branch -- not folded with the stale counter value.
     # With the defect, the loop-counter's static-int binding survived the reassignment and ``1.0 >= i`` was folded as
     # ``1.0 >= 0`` (the counter), silently taking the wrong arm and miscompiling the output for any ``i`` above 1.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         for i in range(1):
             i = a  # reassign the loop variable to a runtime value inside the (single-trip) body
         if 1.0 >= i:
@@ -203,7 +203,7 @@ def test_for_counter_reassigned_after_loop_clears_static_binding() -> None:
     # The same hazard when the counter (leaked after the loop) is reassigned to a runtime value past the loop: the
     # stale static-int binding must not fold a later branch. Without the fix, ``1.0 >= i`` folds with the counter's
     # final value (2) and the conditional state update is dropped on every call.
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         acc = 0.0
         for i in range(3):
             acc = acc + 1.0
@@ -222,7 +222,7 @@ def test_runtime_reassigned_for_counter_is_not_a_static_index() -> None:
     # array index must be REJECTED (it is out-of-subset -- plain Python raises ``TypeError`` indexing with a float).
     # With the defect, the stale static-int binding let the index silently resolve to the counter value, miscompiling
     # an invalid kernel into a constant element selection.
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         vec = [a, b, c]
         for i in range(1):
             i = a  # i is now a runtime value, not a compile-time index
@@ -243,7 +243,7 @@ def test_for_counter_reassign_keeps_scan_and_lowering_in_lockstep() -> None:
         def __init__(self) -> None:
             self.s = 4.0
 
-        def step(self, a):  # type: ignore[no-untyped-def]
+        def step(self, a: float):  # type: ignore[no-untyped-def]
             for t in range(1):
                 t = a  # reassign the counter to a runtime value -> the following branch is dynamic
             # Both sides are otherwise compile-time (the counter and a literal), so if the scan failed to demote the
@@ -278,7 +278,7 @@ def test_walrus_counter_demotion_keeps_scan_and_lowering_in_lockstep() -> None:
         def __init__(self) -> None:
             self.s = 4.0
 
-        def step(self, a):  # type: ignore[no-untyped-def]
+        def step(self, a: float):  # type: ignore[no-untyped-def]
             for t in range(1):  # leaks t == 0 (a compile-time integer) into the enclosing scope
                 pass
             if (t := a) < 1.0:  # the walrus rebinds t to a runtime value -> a real branch, not a stale 0<1.0 fold
@@ -305,7 +305,7 @@ def test_for_counter_reassigned_inside_while_is_demoted_after_the_loop() -> None
     # resurrected the stale compile-time counter value (the body's ``_invalidate_static_int`` was undone). A later
     # comparison ``if i < 0.0`` was then folded against the stale counter (0) instead of the runtime value -- a SILENT
     # miscompile that took the wrong arm. The post-loop fold must follow the runtime value, matching plain Python.
-    def kernel(a):  # type: ignore[no-untyped-def]
+    def kernel(a: float):  # type: ignore[no-untyped-def]
         for i in range(1):  # leaks i == 0 (a compile-time integer) into the enclosing scope
             pass
         w = 0.0
@@ -329,7 +329,7 @@ def test_for_counter_reassigned_inside_while_is_demoted_after_the_loop() -> None
 def test_for_counter_reassigned_inside_while_rejects_later_static_use() -> None:
     # Companion to the above: once the counter is demoted by a while-body reassignment, a later static-only use of it
     # (a shift exponent) must be REJECTED as runtime, not silently folded to the stale compile-time counter value.
-    def kernel(a):  # type: ignore[no-untyped-def]
+    def kernel(a: float):  # type: ignore[no-untyped-def]
         for i in range(2):
             pass
         w = 0.0
@@ -343,7 +343,7 @@ def test_for_counter_reassigned_inside_while_rejects_later_static_use() -> None:
 
 
 def test_model_uses_exact_ilog2_for_wide_supported_shift() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a * 16.0
 
     fmt = FloatFormat(3, 4)
@@ -355,7 +355,7 @@ def test_model_uses_exact_ilog2_for_wide_supported_shift() -> None:
 
 
 def test_model_handles_unused_input_ports() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return b
 
     model = build_model(build(_run(f), "f", fetch_stages=3))
@@ -366,7 +366,7 @@ def test_model_handles_unused_input_ports() -> None:
 
 
 def test_model_rejects_ambiguous_int_and_mismatched_float_value_format() -> None:
-    def f(a):  # type: ignore[no-untyped-def]
+    def f(a: float):  # type: ignore[no-untyped-def]
         return a
 
     model = build_model(build(_run(f), "f", fetch_stages=3))
@@ -379,7 +379,7 @@ def test_model_rejects_ambiguous_int_and_mismatched_float_value_format() -> None
 
 
 def test_model_is_bit_exact_for_wide_zkf_multiply_regression() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return a * b
 
     fmt = FloatFormat(8, 36)
@@ -426,7 +426,7 @@ def test_model_matches_reference_ekf1_stateless() -> None:
 
 
 def test_model_matches_reference_aggregates() -> None:
-    def f(a, b, c):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
         v = [a, b, c]
         head = v[0:2]
         return [v[2], *head]  # index, slice, and unpack -> [c, a, b]
@@ -466,7 +466,7 @@ def test_model_matches_reference_ekf1_stateful() -> None:
 
 
 def test_model_pickles_and_round_trips() -> None:
-    def f(a, b):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float):  # type: ignore[no-untyped-def]
         return (a - b) * 0.25 + a * b
 
     model = build_model(build(_run(f), "f", fetch_stages=3))
@@ -546,7 +546,7 @@ def test_model_pid_controller_all_arms_anti_windup_and_first_update() -> None:
 
 
 def test_model_walrus_binds_once_and_stays_visible_after_the_test() -> None:
-    def walrus(x):  # type: ignore[no-untyped-def]
+    def walrus(x: float):  # type: ignore[no-untyped-def]
         # ``(t := x*2)`` evaluates the subexpression once, binds ``t``, and yields it to the comparison; ``t`` then
         # stays visible to both arms (it is bound in the test, before the branch), as in Python.
         if (t := x * 2.0) > 4.0:
@@ -561,7 +561,7 @@ def test_model_walrus_binds_once_and_stays_visible_after_the_test() -> None:
 
 
 def test_model_walrus_reassigned_loop_variable_is_loop_carried() -> None:
-    def walrus_loop(x):  # type: ignore[no-untyped-def]
+    def walrus_loop(x: float):  # type: ignore[no-untyped-def]
         # A walrus reassigning a pre-defined accumulator inside a loop body must be loop-carried (a header phi), so the
         # accumulation persists across iterations rather than resetting to the preheader value each trip.
         acc = 0.0
@@ -604,7 +604,7 @@ def test_model_schmitt_trigger_hysteresis() -> None:
             self.low = -1.0
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if x > self.high:
                 self.y = 1.0
             elif x < self.low:
@@ -645,7 +645,7 @@ def test_model_boolean_only_state_output() -> None:
 
 
 def test_model_boolean_input_and_mixed_outputs() -> None:
-    def gate(flag: bool, x):  # type: ignore[no-untyped-def]
+    def gate(flag: bool, x: float):  # type: ignore[no-untyped-def]
         if flag:
             y = x
         else:
@@ -667,7 +667,7 @@ def test_model_boolean_input_and_mixed_outputs() -> None:
 def test_model_ports_carry_scalar_types() -> None:
     # The model describes its I/O by typed ports (logical name + ScalarType), not parallel name/is-bool lists, so a
     # driver decides a port's encoding from its type. The handle exposes the same metadata as the elaborated simulator.
-    def gate(flag: bool, x):  # type: ignore[no-untyped-def]
+    def gate(flag: bool, x: float):  # type: ignore[no-untyped-def]
         if flag:
             y = x
         else:
@@ -689,7 +689,7 @@ def test_model_unused_boolean_input_keeps_cfg_state_timing() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, flag: bool, x):  # type: ignore[no-untyped-def]
+        def __call__(self, flag: bool, x: float):  # type: ignore[no-untyped-def]
             self.y = self.y + x + 1.0
             return self.y
 
@@ -708,7 +708,7 @@ def test_run_drains_in_flight_transaction_before_presenting_new_inputs() -> None
         def __init__(self) -> None:
             self.total = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.total = self.total + x
             return self.total
 
@@ -748,7 +748,7 @@ def test_compare_float_values_exact_for_wide_formats() -> None:
 def test_model_unrolled_for_loop_newton_reciprocal() -> None:
     import math
 
-    def reciprocal(x):  # type: ignore[no-untyped-def]
+    def reciprocal(x: float):  # type: ignore[no-untyped-def]
         y = 1.5 - 0.5 * x
         for _ in range(4):
             y = y * (2.0 - x * y)
@@ -777,7 +777,7 @@ def test_model_attribute_written_only_in_loop_is_persistent_state() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for _ in range(3):
                 self.acc = self.acc + x
             return self.acc
@@ -796,7 +796,7 @@ def test_model_state_liveout_does_not_clobber_live_in_branch() -> None:
         def __init__(self) -> None:
             self.y = 2.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if self.y > 0.0:  # reads the live-in y
                 z = self.y
             else:
@@ -817,7 +817,7 @@ def test_model_state_phi_does_not_clobber_returned_live_in() -> None:
         def __init__(self) -> None:
             self.y = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             old = self.y
             if x > 0.0:
                 self.y = x
@@ -837,7 +837,7 @@ def test_model_signed_state_liveout_persists_with_sign() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if x > 0.0:
                 t = x + 1.0
             else:
@@ -854,7 +854,7 @@ def test_model_signed_state_liveout_persists_with_sign() -> None:
 def test_model_sign_conditioned_phi_arm() -> None:
     # Regression (#16): the merge resolution carries a per-arm folded sign, so a sign-conditioned phi arm lowers and
     # evaluates correctly (it was previously rejected with "a sign-conditioned value merged by a phi").
-    def neg_abs_phi(x):  # type: ignore[no-untyped-def]
+    def neg_abs_phi(x: float):  # type: ignore[no-untyped-def]
         if x > 0.0:
             y = -x
         else:
@@ -1006,7 +1006,7 @@ def test_chained_float_slots_do_not_coalesce() -> None:
             self.a = 0.0
             self.b = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             self.a = self.b
             self.b = self.b + x
             return self.a
@@ -1027,7 +1027,7 @@ def test_inplace_multiarm_float_phi() -> None:
         def __init__(self) -> None:
             self._s = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if x > 0.0:
                 if x > 10.0:
                     self._s = x
@@ -1106,7 +1106,7 @@ def test_state_livein_feeding_unrelated_phi_does_not_coalesce(monkeypatch: pytes
 
 def test_model_while_loop_accumulates() -> None:
     # Regression (#14): a variable-count while loop follows the back-edge in the model and converges to x * n.
-    def while_sum(x, n):  # type: ignore[no-untyped-def]
+    def while_sum(x: float, n: float):  # type: ignore[no-untyped-def]
         acc = 0.0
         i = n
         while i > 0.0:
@@ -1126,7 +1126,7 @@ def test_model_while_loop_carries_persistent_state() -> None:
         def __init__(self) -> None:
             self._total = 0.0
 
-        def __call__(self, x, n):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float, n: float):  # type: ignore[no-untyped-def]
             i = n
             while i > 0.0:
                 self._total = self._total + x
@@ -1140,7 +1140,7 @@ def test_model_while_loop_carries_persistent_state() -> None:
 
 
 def test_model_for_counter_inside_while_is_loop_carried() -> None:
-    def for_counter_inside_while(x):  # type: ignore[no-untyped-def]
+    def for_counter_inside_while(x: float):  # type: ignore[no-untyped-def]
         # Regression (Codex iter5): a `for` counter bound inside a `while` body is a loop-carried local; its value at
         # the body's end must flow through the while-header phi, not be dropped when the preheader env is restored.
         j = 0.0
@@ -1157,7 +1157,7 @@ def test_model_for_counter_inside_while_is_loop_carried() -> None:
 
 
 def test_model_counter_assigned_only_on_dead_path_stays_static() -> None:
-    def counter_dead_arm_in_while(x):  # type: ignore[no-untyped-def]
+    def counter_dead_arm_in_while(x: float):  # type: ignore[no-untyped-def]
         # Regression (Codex iter7): a leaked `for` counter assigned only on a statically-dead path (`if False:`) inside
         # a `while` is NOT actually reassigned, so it stays a compile-time int -- a later static index must still
         # resolve, not be rejected (the demotion is fold-aware: only a counter reassigned on a reachable path is
@@ -1178,7 +1178,7 @@ def test_model_counter_assigned_only_on_dead_path_stays_static() -> None:
 
 
 def test_model_zero_trip_inner_for_keeps_outer_counter_static() -> None:
-    def zero_trip_inner_for(x):  # type: ignore[no-untyped-def]
+    def zero_trip_inner_for(x: float):  # type: ignore[no-untyped-def]
         # Regression (Codex iter8): `for i in range(0)` runs zero times and never binds `i` (Python semantics), so it
         # must not be recorded as a loop-carried reassignment of the outer leaked counter -- the later static index
         # still uses the outer for's leaked value.
@@ -1205,7 +1205,7 @@ def test_model_attr_written_under_counter_gated_branch_in_while() -> None:
             self.s1 = -1.0
             self._s2 = 2.0
 
-        def step(self, a):  # type: ignore[no-untyped-def]
+        def step(self, a: float):  # type: ignore[no-untyped-def]
             for i in range(3):
                 pass
             w = 2.0
@@ -1235,7 +1235,7 @@ def test_model_shared_constant_branch_condition() -> None:
         def __init__(self) -> None:
             self.flag = True
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if x > 0.0:
                 if self.flag:
                     y = 1.0
@@ -1262,7 +1262,7 @@ def test_model_statically_dead_attribute_write_is_not_state() -> None:
         def __init__(self) -> None:
             self.y = 1.25
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for _ in range(0):  # statically empty: the body never lowers
                 self.y = x
             return self.y
@@ -1271,7 +1271,7 @@ def test_model_statically_dead_attribute_write_is_not_state() -> None:
         def __init__(self) -> None:
             self.y = 2.5
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if False:  # statically never taken
                 self.y = x
             return self.y
@@ -1292,7 +1292,7 @@ def test_model_counter_dependent_empty_inner_loop_is_not_state() -> None:
         def __init__(self) -> None:
             self.y = 1.25
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for i in range(1):  # the only outer trip has i == 0
                 for _ in range(i):  # range(0) on that trip: the body never lowers
                     self.y = x
@@ -1302,7 +1302,7 @@ def test_model_counter_dependent_empty_inner_loop_is_not_state() -> None:
         def __init__(self) -> None:
             self.s = 0.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for i in range(3):  # inner runs 0 + 1 + 2 = 3 times per call
                 for _ in range(i):
                     self.s = self.s + x
@@ -1327,7 +1327,7 @@ def test_model_return_in_literal_if_arm_ends_the_scan() -> None:
         def __init__(self) -> None:
             self.y = 2.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             if True:
                 return x + self.y  # the only live path; reads y as a constant
             self.y = x  # unreachable: lowering stops at the return above
@@ -1346,7 +1346,7 @@ def test_model_loop_counter_does_not_leak_across_branch_arms_in_scan() -> None:
         def __init__(self) -> None:
             self.y = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             for i in range(1):  # leaves i == 0 before the branch
                 pass
             if x > 0.0:
@@ -1371,7 +1371,7 @@ def test_model_chained_state_copy_delay_line() -> None:
             self._prev = 0.0
             self.c = 1.0
 
-        def __call__(self, x):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float):  # type: ignore[no-untyped-def]
             out = self._prev
             self._prev = self.c  # chained copy of c's live-in; c also self-accumulates below
             self.c = self.c + x
@@ -1392,14 +1392,14 @@ def test_synthesis_result_reports_latency_metric() -> None:
         FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT)
     )
 
-    def straight_line(a, b):  # type: ignore[no-untyped-def]
+    def straight_line(a: float, b: float):  # type: ignore[no-untyped-def]
         return a * b + a
 
     flat = holoso.synthesize(straight_line, ops)
     flat_min, flat_max = flat.initiation_interval
     assert flat_min > 0 and flat_max == flat_min  # exact: min == max
 
-    def looping(x):  # type: ignore[no-untyped-def]
+    def looping(x: float):  # type: ignore[no-untyped-def]
         w = x
         while w > 1.0:
             w = w - 1.0
@@ -1423,7 +1423,7 @@ def test_model_handle_round_trips_through_pickle() -> None:
 
 
 def test_model_boolean_connectives_and_chained_and_ternary_are_exact() -> None:
-    def kernel(x, lo, hi):  # type: ignore[no-untyped-def]
+    def kernel(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
         deadband = 0.0 if lo < x < hi else x  # chained comparison + ternary
         gate = 1.0 if (x > lo and x < hi) else 0.0  # and-connective in a condition
         outside = 1.0 if (x < lo or x > hi) else 0.0  # or-connective
@@ -1441,7 +1441,7 @@ def test_model_boolean_connectives_and_chained_and_ternary_are_exact() -> None:
 def test_model_bool_cast_matches_float_nonzero() -> None:
     # bool(x) is the ZKF exponent-nonzero test: true iff the value is nonzero *after* encoding into the format (a
     # magnitude too small to represent rounds to zero, like any ZKF value), including for +0.0 and -0.0.
-    def kernel(x, y):  # type: ignore[no-untyped-def]
+    def kernel(x: float, y: float):  # type: ignore[no-untyped-def]
         return y if bool(x) else 0.0
 
     model = build_model(build(_run(kernel), "bool_cast", fetch_stages=3))
@@ -1454,7 +1454,7 @@ def test_model_bool_cast_matches_float_nonzero() -> None:
 def test_model_cross_domain_cast_chain_is_exact() -> None:
     # Regression: a branch-free float->bool->float->float chain (float(x>0)*k) builds via the CFG path even with a
     # single block (it has combinational ops, no branch); the model must take the same path and be bit-exact.
-    def kernel(x, k):  # type: ignore[no-untyped-def]
+    def kernel(x: float, k: float):  # type: ignore[no-untyped-def]
         gate = float(x > 0.0) * k  # cross-domain chain
         cast = float(x < 0.0)  # branch-free bool->float
         return (gate, cast)
@@ -1472,7 +1472,7 @@ def test_model_bool_cast_of_underflowing_constant_is_false() -> None:
     # cast is False -- the HIR const-folder must not fold it to True.
     assert FMT.encode(2.0**-200) == 0  # the constant underflows to ZKF zero in this format
 
-    def kernel(a):  # type: ignore[no-untyped-def]
+    def kernel(a: float):  # type: ignore[no-untyped-def]
         return a if bool(2.0**-200) else -a  # the gate is False -> the model returns -a
 
     model = build_model(build(_run(kernel), "tiny_bool", fetch_stages=3))
@@ -1490,7 +1490,7 @@ def test_connective_branch_does_not_create_a_phantom_state_slot() -> None:
             self.x = 0.0
             self.y = 0.0
 
-        def __call__(self, u):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float):  # type: ignore[no-untyped-def]
             if u > 0.0 or True:
                 self.x = self.x + u
             else:
@@ -1513,7 +1513,7 @@ def test_connective_branch_in_a_loop_body_does_not_carry_a_phantom_attribute() -
             self.acc = 0.0
             self.dead = 0.0
 
-        def __call__(self, u):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float):  # type: ignore[no-untyped-def]
             n = 0.0
             while n < 3.0:
                 if u > 0.0 or True:
@@ -1580,7 +1580,7 @@ def test_aliased_slot_with_phi_live_in_builds(monkeypatch: pytest.MonkeyPatch) -
             self.x = 0.0
             self._alias = 0.0
 
-        def __call__(self, cond: bool, a, b):  # type: ignore[no-untyped-def]
+        def __call__(self, cond: bool, a: float, b: float):  # type: ignore[no-untyped-def]
             old = self.x if cond else 0.0
             self.x = a if cond else b
             self._alias = self.x

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,6 +1,7 @@
 """Unit tests for the pure-Python verification core."""
 
 import pickle
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -22,8 +23,9 @@ from ._modelref import build_model, generate
 from holoso._frontend import lower
 from holoso._hir import optimize
 from holoso._hir import _if_convert as if_convert_pass
-from holoso._lir import build
-from holoso._mir import lower as lower_to_mir
+from holoso._lir import FloatStateSlot, Lir, build
+from holoso._lir._ir import BoolStateSlot
+from holoso._mir import Mir, lower as lower_to_mir
 from ._modelref import (
     assert_model_equals_interpreter,
     bounded,
@@ -53,12 +55,12 @@ FMT = FloatFormat(6, 18)
 OPS = OpConfig(FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT))
 
 
-def _run(target):  # type: ignore[no-untyped-def]
+def _run(target: Callable[..., object]) -> Mir:
     return lower_to_mir(optimize(lower(target)), OPS)
 
 
 def test_model_exact_integer_comparison_is_not_folded_via_float() -> None:
-    def exact_int_comparison(a: float):  # type: ignore[no-untyped-def]
+    def exact_int_comparison(a: float) -> float:
         # Regression (user): two compile-time integers must be compared exactly, not via a lossy float64 fold. As
         # float64 both operands round to 9007199254740992.0 and the `==` would misfold true; as integers they differ.
         if 9007199254740993 == 9007199254740992:
@@ -125,14 +127,14 @@ def test_is_legal_rejects_subnormal_and_negative_zero() -> None:
 
 
 def test_reference_evaluates_and_flattens() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         return [a + b, a * b]
 
     assert evaluate_reference(f, {"a": 2.0, "b": 3.0}) == [5.0, 6.0]
 
 
 def test_model_matches_reference_small_kernels() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     inputs = {"a": 1.25, "b": -3.5}
@@ -149,11 +151,11 @@ def test_model_matches_reference_dense_boolean_chain() -> None:
     # after its producer's commit, and the wide-result cast one later, so this pins the model's read/landing
     # frames against the exact Python reference at exactly that spacing. All values are chosen exactly representable,
     # so every comparison, cast, and product is exact and the outputs must match the reference bit-for-bit.
-    def f(a: float, b: float, c: float, d: float, k: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float, d: float, k: float) -> tuple[float, bool]:
         inside = a < b and not (c < d)
         gated = float(inside) * k
         live = bool(gated + a)
-        return [gated, live]
+        return (gated, live)
 
     model = build_model(build(_run(f), "dense_bool", fetch_stages=3))
     values = (-1.5, -0.25, 0.0, 0.25, 1.5)
@@ -168,7 +170,7 @@ def test_model_matches_reference_dense_boolean_chain() -> None:
 def test_tuple_unpacking_matches_python_reference() -> None:
     # The reference runs the kernel as ordinary Python (which unpacks natively), so a bit-faithful hardware model must
     # route the swapped operands identically before the arithmetic.
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> list[float]:
         x, y = b, a
         return [x - y, x * y]
 
@@ -185,7 +187,7 @@ def test_for_counter_reassigned_to_runtime_clears_static_binding() -> None:
     # binding, so a subsequent branch on that name is a real runtime branch -- not folded with the stale counter value.
     # With the defect, the loop-counter's static-int binding survived the reassignment and ``1.0 >= i`` was folded as
     # ``1.0 >= 0`` (the counter), silently taking the wrong arm and miscompiling the output for any ``i`` above 1.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         for i in range(1):
             i = a  # reassign the loop variable to a runtime value inside the (single-trip) body
         if 1.0 >= i:
@@ -203,7 +205,7 @@ def test_for_counter_reassigned_after_loop_clears_static_binding() -> None:
     # The same hazard when the counter (leaked after the loop) is reassigned to a runtime value past the loop: the
     # stale static-int binding must not fold a later branch. Without the fix, ``1.0 >= i`` folds with the counter's
     # final value (2) and the conditional state update is dropped on every call.
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         acc = 0.0
         for i in range(3):
             acc = acc + 1.0
@@ -222,7 +224,7 @@ def test_runtime_reassigned_for_counter_is_not_a_static_index() -> None:
     # array index must be REJECTED (it is out-of-subset -- plain Python raises ``TypeError`` indexing with a float).
     # With the defect, the stale static-int binding let the index silently resolve to the counter value, miscompiling
     # an invalid kernel into a constant element selection.
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> float:
         vec = [a, b, c]
         for i in range(1):
             i = a  # i is now a runtime value, not a compile-time index
@@ -243,7 +245,7 @@ def test_for_counter_reassign_keeps_scan_and_lowering_in_lockstep() -> None:
         def __init__(self) -> None:
             self.s = 4.0
 
-        def step(self, a: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float) -> float:
             for t in range(1):
                 t = a  # reassign the counter to a runtime value -> the following branch is dynamic
             # Both sides are otherwise compile-time (the counter and a literal), so if the scan failed to demote the
@@ -278,7 +280,7 @@ def test_walrus_counter_demotion_keeps_scan_and_lowering_in_lockstep() -> None:
         def __init__(self) -> None:
             self.s = 4.0
 
-        def step(self, a: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float) -> float:
             for t in range(1):  # leaks t == 0 (a compile-time integer) into the enclosing scope
                 pass
             if (t := a) < 1.0:  # the walrus rebinds t to a runtime value -> a real branch, not a stale 0<1.0 fold
@@ -305,7 +307,7 @@ def test_for_counter_reassigned_inside_while_is_demoted_after_the_loop() -> None
     # resurrected the stale compile-time counter value (the body's ``_invalidate_static_int`` was undone). A later
     # comparison ``if i < 0.0`` was then folded against the stale counter (0) instead of the runtime value -- a SILENT
     # miscompile that took the wrong arm. The post-loop fold must follow the runtime value, matching plain Python.
-    def kernel(a: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float) -> float:
         for i in range(1):  # leaks i == 0 (a compile-time integer) into the enclosing scope
             pass
         w = 0.0
@@ -329,7 +331,7 @@ def test_for_counter_reassigned_inside_while_is_demoted_after_the_loop() -> None
 def test_for_counter_reassigned_inside_while_rejects_later_static_use() -> None:
     # Companion to the above: once the counter is demoted by a while-body reassignment, a later static-only use of it
     # (a shift exponent) must be REJECTED as runtime, not silently folded to the stale compile-time counter value.
-    def kernel(a: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float) -> float:
         for i in range(2):
             pass
         w = 0.0
@@ -343,7 +345,7 @@ def test_for_counter_reassigned_inside_while_rejects_later_static_use() -> None:
 
 
 def test_model_uses_exact_ilog2_for_wide_supported_shift() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a * 16.0
 
     fmt = FloatFormat(3, 4)
@@ -355,7 +357,7 @@ def test_model_uses_exact_ilog2_for_wide_supported_shift() -> None:
 
 
 def test_model_handles_unused_input_ports() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return b
 
     model = build_model(build(_run(f), "f", fetch_stages=3))
@@ -366,7 +368,7 @@ def test_model_handles_unused_input_ports() -> None:
 
 
 def test_model_rejects_ambiguous_int_and_mismatched_float_value_format() -> None:
-    def f(a: float):  # type: ignore[no-untyped-def]
+    def f(a: float) -> float:
         return a
 
     model = build_model(build(_run(f), "f", fetch_stages=3))
@@ -379,7 +381,7 @@ def test_model_rejects_ambiguous_int_and_mismatched_float_value_format() -> None
 
 
 def test_model_is_bit_exact_for_wide_zkf_multiply_regression() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return a * b
 
     fmt = FloatFormat(8, 36)
@@ -426,7 +428,7 @@ def test_model_matches_reference_ekf1_stateless() -> None:
 
 
 def test_model_matches_reference_aggregates() -> None:
-    def f(a: float, b: float, c: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float, c: float) -> list[float]:
         v = [a, b, c]
         head = v[0:2]
         return [v[2], *head]  # index, slice, and unpack -> [c, a, b]
@@ -449,7 +451,7 @@ def test_model_matches_reference_ekf1_stateful() -> None:
     dt = bounded(rng, 1e-3, 1e-2)
     step_inputs = {"dt": dt, "u_shunt": bounded(rng, -1.0, 1.0), "di_dt": bounded(rng, -1.0, 1.0)}
 
-    def fresh():  # type: ignore[no-untyped-def]
+    def fresh() -> ekf1_stateful.Ekf1:
         return ekf1_stateful.Ekf1(x=list(x), P_urt=list(p_urt), R_diag=list(r_diag), Q_diag=np.array(q_diag))
 
     model = build_model(build(_run(fresh().update), "ekf1_stateful", fetch_stages=3))
@@ -466,7 +468,7 @@ def test_model_matches_reference_ekf1_stateful() -> None:
 
 
 def test_model_pickles_and_round_trips() -> None:
-    def f(a: float, b: float):  # type: ignore[no-untyped-def]
+    def f(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
     model = build_model(build(_run(f), "f", fetch_stages=3))
@@ -546,7 +548,7 @@ def test_model_pid_controller_all_arms_anti_windup_and_first_update() -> None:
 
 
 def test_model_walrus_binds_once_and_stays_visible_after_the_test() -> None:
-    def walrus(x: float):  # type: ignore[no-untyped-def]
+    def walrus(x: float) -> float:
         # ``(t := x*2)`` evaluates the subexpression once, binds ``t``, and yields it to the comparison; ``t`` then
         # stays visible to both arms (it is bound in the test, before the branch), as in Python.
         if (t := x * 2.0) > 4.0:
@@ -561,7 +563,7 @@ def test_model_walrus_binds_once_and_stays_visible_after_the_test() -> None:
 
 
 def test_model_walrus_reassigned_loop_variable_is_loop_carried() -> None:
-    def walrus_loop(x: float):  # type: ignore[no-untyped-def]
+    def walrus_loop(x: float) -> float:
         # A walrus reassigning a pre-defined accumulator inside a loop body must be loop-carried (a header phi), so the
         # accumulation persists across iterations rather than resetting to the preheader value each trip.
         acc = 0.0
@@ -604,7 +606,7 @@ def test_model_schmitt_trigger_hysteresis() -> None:
             self.low = -1.0
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if x > self.high:
                 self.y = 1.0
             elif x < self.low:
@@ -645,7 +647,7 @@ def test_model_boolean_only_state_output() -> None:
 
 
 def test_model_boolean_input_and_mixed_outputs() -> None:
-    def gate(flag: bool, x: float):  # type: ignore[no-untyped-def]
+    def gate(flag: bool, x: float) -> tuple[bool, float]:
         if flag:
             y = x
         else:
@@ -667,7 +669,7 @@ def test_model_boolean_input_and_mixed_outputs() -> None:
 def test_model_ports_carry_scalar_types() -> None:
     # The model describes its I/O by typed ports (logical name + ScalarType), not parallel name/is-bool lists, so a
     # driver decides a port's encoding from its type. The handle exposes the same metadata as the elaborated simulator.
-    def gate(flag: bool, x: float):  # type: ignore[no-untyped-def]
+    def gate(flag: bool, x: float) -> tuple[bool, float]:
         if flag:
             y = x
         else:
@@ -689,7 +691,7 @@ def test_model_unused_boolean_input_keeps_cfg_state_timing() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, flag: bool, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, flag: bool, x: float) -> float:
             self.y = self.y + x + 1.0
             return self.y
 
@@ -708,7 +710,7 @@ def test_run_drains_in_flight_transaction_before_presenting_new_inputs() -> None
         def __init__(self) -> None:
             self.total = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self.total = self.total + x
             return self.total
 
@@ -748,7 +750,7 @@ def test_compare_float_values_exact_for_wide_formats() -> None:
 def test_model_unrolled_for_loop_newton_reciprocal() -> None:
     import math
 
-    def reciprocal(x: float):  # type: ignore[no-untyped-def]
+    def reciprocal(x: float) -> float:
         y = 1.5 - 0.5 * x
         for _ in range(4):
             y = y * (2.0 - x * y)
@@ -777,7 +779,7 @@ def test_model_attribute_written_only_in_loop_is_persistent_state() -> None:
         def __init__(self) -> None:
             self.acc = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for _ in range(3):
                 self.acc = self.acc + x
             return self.acc
@@ -796,7 +798,7 @@ def test_model_state_liveout_does_not_clobber_live_in_branch() -> None:
         def __init__(self) -> None:
             self.y = 2.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if self.y > 0.0:  # reads the live-in y
                 z = self.y
             else:
@@ -817,7 +819,7 @@ def test_model_state_phi_does_not_clobber_returned_live_in() -> None:
         def __init__(self) -> None:
             self.y = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             old = self.y
             if x > 0.0:
                 self.y = x
@@ -837,7 +839,7 @@ def test_model_signed_state_liveout_persists_with_sign() -> None:
         def __init__(self) -> None:
             self.y = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if x > 0.0:
                 t = x + 1.0
             else:
@@ -854,7 +856,7 @@ def test_model_signed_state_liveout_persists_with_sign() -> None:
 def test_model_sign_conditioned_phi_arm() -> None:
     # Regression (#16): the merge resolution carries a per-arm folded sign, so a sign-conditioned phi arm lowers and
     # evaluates correctly (it was previously rejected with "a sign-conditioned value merged by a phi").
-    def neg_abs_phi(x: float):  # type: ignore[no-untyped-def]
+    def neg_abs_phi(x: float) -> float:
         if x > 0.0:
             y = -x
         else:
@@ -872,11 +874,11 @@ def test_model_sign_conditioned_phi_arm() -> None:
 # elided (``not needs_copy``) -- a correctness and a tightness guard, so a regression back to the copy-back fails here.
 
 
-def _bool_slot(lir, name):  # type: ignore[no-untyped-def]
+def _bool_slot(lir: Lir, name: str) -> BoolStateSlot:
     return next(s for s in lir.bool_state_slots if s.name == name)
 
 
-def _float_slot(lir, name):  # type: ignore[no-untyped-def]
+def _float_slot(lir: Lir, name: str) -> FloatStateSlot:
     return next(s for s in lir.float_state_slots if s.name == name)
 
 
@@ -887,7 +889,7 @@ def test_inplace_bool_conditional_sticky_latch() -> None:
         def __init__(self) -> None:
             self._f = False
 
-        def __call__(self, en: bool, x: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, en: bool, x: bool) -> bool:
             if en:
                 self._f = self._f or x
             return self._f
@@ -910,7 +912,7 @@ def test_inplace_bool_unconditional_self_update() -> None:
         def __init__(self) -> None:
             self._f = False
 
-        def __call__(self, x: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, x: bool) -> bool:
             self._f = self._f or x
             return self._f
 
@@ -932,7 +934,7 @@ def test_inplace_loop_preheader_arm_is_dwell_safe() -> None:
         def __init__(self) -> None:
             self._s = False
 
-        def __call__(self, a: bool, n: float):  # type: ignore[no-untyped-def]
+        def __call__(self, a: bool, n: float) -> bool:
             self._s = self._s or a
             i = n
             while i > 0.0:
@@ -959,7 +961,7 @@ def test_inplace_write_only_slot_gap_tenant_is_dwell_safe() -> None:
             self._x = False
             self._w = False
 
-        def __call__(self, cond: bool, y: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, cond: bool, y: bool) -> tuple[bool, bool]:
             if cond:
                 self._x = y or self._x
                 self._w = y
@@ -984,7 +986,7 @@ def test_inplace_float_conditional_accumulator() -> None:
         def __init__(self) -> None:
             self._acc = 0.0
 
-        def __call__(self, x: float, en: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float, en: bool) -> float:
             if en:
                 self._acc = self._acc + x
             return self._acc
@@ -1006,7 +1008,7 @@ def test_chained_float_slots_do_not_coalesce() -> None:
             self.a = 0.0
             self.b = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             self.a = self.b
             self.b = self.b + x
             return self.a
@@ -1027,7 +1029,7 @@ def test_inplace_multiarm_float_phi() -> None:
         def __init__(self) -> None:
             self._s = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if x > 0.0:
                 if x > 10.0:
                     self._s = x
@@ -1055,7 +1057,7 @@ def test_state_livein_feeding_another_slot_phi_does_not_coalesce(monkeypatch: py
             self.x = 0.0
             self.w = 0.0
 
-        def __call__(self, cond: bool, y: float):  # type: ignore[no-untyped-def]
+        def __call__(self, cond: bool, y: float) -> tuple[float, float]:
             old_x = self.x  # the live-in of slot x
             if cond:
                 self.x = y + 1.0
@@ -1086,7 +1088,7 @@ def test_state_livein_feeding_unrelated_phi_does_not_coalesce(monkeypatch: pytes
         def __init__(self) -> None:
             self.x = 0.0
 
-        def __call__(self, cond: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, cond: bool) -> tuple[float, float]:
             new_y = self.x if cond else 0.0  # an unrelated phi taking x's live-in as an arm
             self.x = 1.0 if cond else 2.0
             return new_y, self.x
@@ -1106,7 +1108,7 @@ def test_state_livein_feeding_unrelated_phi_does_not_coalesce(monkeypatch: pytes
 
 def test_model_while_loop_accumulates() -> None:
     # Regression (#14): a variable-count while loop follows the back-edge in the model and converges to x * n.
-    def while_sum(x: float, n: float):  # type: ignore[no-untyped-def]
+    def while_sum(x: float, n: float) -> float:
         acc = 0.0
         i = n
         while i > 0.0:
@@ -1126,7 +1128,7 @@ def test_model_while_loop_carries_persistent_state() -> None:
         def __init__(self) -> None:
             self._total = 0.0
 
-        def __call__(self, x: float, n: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float, n: float) -> float:
             i = n
             while i > 0.0:
                 self._total = self._total + x
@@ -1140,7 +1142,7 @@ def test_model_while_loop_carries_persistent_state() -> None:
 
 
 def test_model_for_counter_inside_while_is_loop_carried() -> None:
-    def for_counter_inside_while(x: float):  # type: ignore[no-untyped-def]
+    def for_counter_inside_while(x: float) -> float:
         # Regression (Codex iter5): a `for` counter bound inside a `while` body is a loop-carried local; its value at
         # the body's end must flow through the while-header phi, not be dropped when the preheader env is restored.
         j = 0.0
@@ -1157,7 +1159,7 @@ def test_model_for_counter_inside_while_is_loop_carried() -> None:
 
 
 def test_model_counter_assigned_only_on_dead_path_stays_static() -> None:
-    def counter_dead_arm_in_while(x: float):  # type: ignore[no-untyped-def]
+    def counter_dead_arm_in_while(x: float) -> float:
         # Regression (Codex iter7): a leaked `for` counter assigned only on a statically-dead path (`if False:`) inside
         # a `while` is NOT actually reassigned, so it stays a compile-time int -- a later static index must still
         # resolve, not be rejected (the demotion is fold-aware: only a counter reassigned on a reachable path is
@@ -1178,7 +1180,7 @@ def test_model_counter_assigned_only_on_dead_path_stays_static() -> None:
 
 
 def test_model_zero_trip_inner_for_keeps_outer_counter_static() -> None:
-    def zero_trip_inner_for(x: float):  # type: ignore[no-untyped-def]
+    def zero_trip_inner_for(x: float) -> float:
         # Regression (Codex iter8): `for i in range(0)` runs zero times and never binds `i` (Python semantics), so it
         # must not be recorded as a loop-carried reassignment of the outer leaked counter -- the later static index
         # still uses the outer for's leaked value.
@@ -1205,7 +1207,7 @@ def test_model_attr_written_under_counter_gated_branch_in_while() -> None:
             self.s1 = -1.0
             self._s2 = 2.0
 
-        def step(self, a: float):  # type: ignore[no-untyped-def]
+        def step(self, a: float) -> float:
             for i in range(3):
                 pass
             w = 2.0
@@ -1235,7 +1237,7 @@ def test_model_shared_constant_branch_condition() -> None:
         def __init__(self) -> None:
             self.flag = True
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if x > 0.0:
                 if self.flag:
                     y = 1.0
@@ -1262,7 +1264,7 @@ def test_model_statically_dead_attribute_write_is_not_state() -> None:
         def __init__(self) -> None:
             self.y = 1.25
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for _ in range(0):  # statically empty: the body never lowers
                 self.y = x
             return self.y
@@ -1271,7 +1273,7 @@ def test_model_statically_dead_attribute_write_is_not_state() -> None:
         def __init__(self) -> None:
             self.y = 2.5
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if False:  # statically never taken
                 self.y = x
             return self.y
@@ -1292,7 +1294,7 @@ def test_model_counter_dependent_empty_inner_loop_is_not_state() -> None:
         def __init__(self) -> None:
             self.y = 1.25
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for i in range(1):  # the only outer trip has i == 0
                 for _ in range(i):  # range(0) on that trip: the body never lowers
                     self.y = x
@@ -1302,7 +1304,7 @@ def test_model_counter_dependent_empty_inner_loop_is_not_state() -> None:
         def __init__(self) -> None:
             self.s = 0.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for i in range(3):  # inner runs 0 + 1 + 2 = 3 times per call
                 for _ in range(i):
                     self.s = self.s + x
@@ -1327,7 +1329,7 @@ def test_model_return_in_literal_if_arm_ends_the_scan() -> None:
         def __init__(self) -> None:
             self.y = 2.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             if True:
                 return x + self.y  # the only live path; reads y as a constant
             self.y = x  # unreachable: lowering stops at the return above
@@ -1346,7 +1348,7 @@ def test_model_loop_counter_does_not_leak_across_branch_arms_in_scan() -> None:
         def __init__(self) -> None:
             self.y = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             for i in range(1):  # leaves i == 0 before the branch
                 pass
             if x > 0.0:
@@ -1371,7 +1373,7 @@ def test_model_chained_state_copy_delay_line() -> None:
             self._prev = 0.0
             self.c = 1.0
 
-        def __call__(self, x: float):  # type: ignore[no-untyped-def]
+        def __call__(self, x: float) -> float:
             out = self._prev
             self._prev = self.c  # chained copy of c's live-in; c also self-accumulates below
             self.c = self.c + x
@@ -1392,14 +1394,14 @@ def test_synthesis_result_reports_latency_metric() -> None:
         FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT)
     )
 
-    def straight_line(a: float, b: float):  # type: ignore[no-untyped-def]
+    def straight_line(a: float, b: float) -> float:
         return a * b + a
 
     flat = holoso.synthesize(straight_line, ops)
     flat_min, flat_max = flat.initiation_interval
     assert flat_min > 0 and flat_max == flat_min  # exact: min == max
 
-    def looping(x: float):  # type: ignore[no-untyped-def]
+    def looping(x: float) -> float:
         w = x
         while w > 1.0:
             w = w - 1.0
@@ -1423,7 +1425,7 @@ def test_model_handle_round_trips_through_pickle() -> None:
 
 
 def test_model_boolean_connectives_and_chained_and_ternary_are_exact() -> None:
-    def kernel(x: float, lo: float, hi: float):  # type: ignore[no-untyped-def]
+    def kernel(x: float, lo: float, hi: float) -> tuple[float, float, float, float, float]:
         deadband = 0.0 if lo < x < hi else x  # chained comparison + ternary
         gate = 1.0 if (x > lo and x < hi) else 0.0  # and-connective in a condition
         outside = 1.0 if (x < lo or x > hi) else 0.0  # or-connective
@@ -1441,7 +1443,7 @@ def test_model_boolean_connectives_and_chained_and_ternary_are_exact() -> None:
 def test_model_bool_cast_matches_float_nonzero() -> None:
     # bool(x) is the ZKF exponent-nonzero test: true iff the value is nonzero *after* encoding into the format (a
     # magnitude too small to represent rounds to zero, like any ZKF value), including for +0.0 and -0.0.
-    def kernel(x: float, y: float):  # type: ignore[no-untyped-def]
+    def kernel(x: float, y: float) -> float:
         return y if bool(x) else 0.0
 
     model = build_model(build(_run(kernel), "bool_cast", fetch_stages=3))
@@ -1454,7 +1456,7 @@ def test_model_bool_cast_matches_float_nonzero() -> None:
 def test_model_cross_domain_cast_chain_is_exact() -> None:
     # Regression: a branch-free float->bool->float->float chain (float(x>0)*k) builds via the CFG path even with a
     # single block (it has combinational ops, no branch); the model must take the same path and be bit-exact.
-    def kernel(x: float, k: float):  # type: ignore[no-untyped-def]
+    def kernel(x: float, k: float) -> tuple[float, float]:
         gate = float(x > 0.0) * k  # cross-domain chain
         cast = float(x < 0.0)  # branch-free bool->float
         return (gate, cast)
@@ -1472,7 +1474,7 @@ def test_model_bool_cast_of_underflowing_constant_is_false() -> None:
     # cast is False -- the HIR const-folder must not fold it to True.
     assert FMT.encode(2.0**-200) == 0  # the constant underflows to ZKF zero in this format
 
-    def kernel(a: float):  # type: ignore[no-untyped-def]
+    def kernel(a: float) -> float:
         return a if bool(2.0**-200) else -a  # the gate is False -> the model returns -a
 
     model = build_model(build(_run(kernel), "tiny_bool", fetch_stages=3))
@@ -1486,11 +1488,11 @@ def test_connective_branch_does_not_create_a_phantom_state_slot() -> None:
     # descended both arms (strict ``_static_bool`` does not fold ``X or True``) while lowering folded one, so the dead
     # else-arm's ``self.y`` became a state slot with no value and ``_register_state_slots`` crashed with KeyError.
     class K:
-        def __init__(self):
+        def __init__(self) -> None:
             self.x = 0.0
             self.y = 0.0
 
-        def __call__(self, u: float):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float) -> float:
             if u > 0.0 or True:
                 self.x = self.x + u
             else:
@@ -1509,11 +1511,11 @@ def test_connective_branch_in_a_loop_body_does_not_carry_a_phantom_attribute() -
     # Same desync hazard via the loop-carried scan (``_loop_assigned``): a folded connective ``if`` inside a loop body
     # must not open a loop-header phi for an attribute the body never actually writes.
     class K:
-        def __init__(self):
+        def __init__(self) -> None:
             self.acc = 0.0
             self.dead = 0.0
 
-        def __call__(self, u: float):  # type: ignore[no-untyped-def]
+        def __call__(self, u: float) -> float:
             n = 0.0
             while n < 3.0:
                 if u > 0.0 or True:
@@ -1558,7 +1560,7 @@ def test_aliased_slot_with_phi_live_in_builds(monkeypatch: pytest.MonkeyPatch) -
             self.x = 0.0
             self._alias = 0.0
 
-        def __call__(self, cond: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, cond: bool) -> tuple[float, float]:
             y = self.x if cond else 0.0
             self.x = 1.0 if cond else 2.0
             self._alias = self.x
@@ -1569,7 +1571,7 @@ def test_aliased_slot_with_phi_live_in_builds(monkeypatch: pytest.MonkeyPatch) -
             self._alias = 0.0
             self.x = 0.0
 
-        def __call__(self, cond: bool):  # type: ignore[no-untyped-def]
+        def __call__(self, cond: bool) -> tuple[float, float]:
             y = self.x if cond else 0.0
             self.x = 1.0 if cond else 2.0
             self._alias = self.x
@@ -1580,7 +1582,7 @@ def test_aliased_slot_with_phi_live_in_builds(monkeypatch: pytest.MonkeyPatch) -
             self.x = 0.0
             self._alias = 0.0
 
-        def __call__(self, cond: bool, a: float, b: float):  # type: ignore[no-untyped-def]
+        def __call__(self, cond: bool, a: float, b: float) -> tuple[float, float]:
             old = self.x if cond else 0.0
             self.x = a if cond else b
             self._alias = self.x

--- a/tools/synth_compare.py
+++ b/tools/synth_compare.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any, cast
 
 REPO = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO))
@@ -50,7 +51,7 @@ def capture(out_path: str) -> None:
     dirty = bool(subprocess.run(["git", "status", "--porcelain"], cwd=REPO, capture_output=True, text=True).stdout)
     rows = []
     for target in TARGETS:
-        row = {
+        row: dict[str, Any] = {
             "label": target.label,
             "name": target.name,
             "example": target.example,
@@ -86,7 +87,9 @@ def capture(out_path: str) -> None:
     print(f"\nWrote {out_path}: {len(rows)} targets @ {commit}{'+dirty' if dirty else ''}")
 
 
-def _delta_cell(before, after, *, lower_is_better: bool, unit: str = "", fmt: str = "{:.2f}") -> str:
+def _delta_cell(
+    before: float | int | None, after: float | int | None, *, lower_is_better: bool, unit: str = "", fmt: str = "{:.2f}"
+) -> str:
     if before is None or after is None:
         b = fmt.format(before) if before is not None else "—"
         a = fmt.format(after) if after is not None else "—"
@@ -101,10 +104,10 @@ def _delta_cell(before, after, *, lower_is_better: bool, unit: str = "", fmt: st
     )
 
 
-def _resource_total(row, key):
+def _resource_total(row: dict[str, Any], key: str) -> int | None:
     res = row.get("resources") or {}
     item = res.get(key)
-    return item["used"] if item else None
+    return cast(int, item["used"]) if item else None
 
 
 def _critical_path(directory: Path, flow: str) -> str | None:
@@ -129,12 +132,12 @@ def _critical_path(directory: Path, flow: str) -> str | None:
             lines = log.read_text(errors="ignore").splitlines()
             for i, ln in enumerate(lines):
                 if "Critical path report" in ln:
-                    out: list[str] = []
+                    out2: list[str] = []
                     for sub in lines[i:]:
-                        out.append(sub.replace("Info: ", "").rstrip())
+                        out2.append(sub.replace("Info: ", "").rstrip())
                         if "ns logic" in sub and "ns rout" in sub:  # the path's terminating summary line
-                            return "\n".join(out)
-                    return "\n".join(out[:80])
+                            return "\n".join(out2)
+                    return "\n".join(out2[:80])
         elif "vivado" in flow:
             rpt = directory / "worst_path.rpt"
             if not rpt.exists():


### PR DESCRIPTION
Makes kernel type annotations mandatory and validated in the Holoso frontend. The return is checked against the inferred outputs.

`assert` statements are now ignored (no hardware effect).