### PR TITLE
Frontend: matrix product `@` and statically-shaped numpy matrix/vector support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,6 @@ References:
 ### Python
 
 Follow PEP8 with one exception: the maximum line length is 120 columns. This is already configured in Black.
-Comment block lines should utilize the 120 column limit well, avoiding overly short lines.
 
 Use strongly typed primitives. Instead of int constants, prefer enums; instead of dicts, prefer dataclasses;
 instead of existence/vaidity flags, prefer optional type or unions, etc.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -181,10 +181,7 @@ returning all work on it. A numpy array -- a shaped parameter, an ndarray module
 The numpy-only operations (elementwise arithmetic, the matrix product, transpose, `.flatten()`, and multi-axis
 indexing) apply to arrays and are rejected on a list/tuple: on a Python sequence they mean something else or nothing
 (list `+`/`*` are concatenation/repetition, list `-`/`@`/`.T` are undefined), none of which is the array operation
-intended. A bare list is never coerced -- `matrix - [row0, row1]` is rejected; the user writes
-`matrix - np.array([row0, row1])`. `np.array([...])` is the list-accepting factory that converts a sequence into an
-array (numpy rejects a ragged literal, so a non-rectangular argument is rejected too), the idiomatic fix when a kernel
-needs array arithmetic over a value built as a list.
+intended.
 
 Array arithmetic. The elementwise arithmetic operators `+ - * /` apply leafwise to same-shape arrays, and a scalar
 operand broadcasts over the other side's leaves; this is deliberately narrower than numpy broadcasting -- a mixed-rank
@@ -207,9 +204,8 @@ Parameters. Positional and keyword-only parameters become input ports and requir
 `float`-annotated scalars are floating-point ports, `bool`-annotated ones are 1-bit boolean ports, and a jaxtyping
 array annotation with fixed 1-D/2-D dimensions and a floating dtype (e.g. `Float64[np.ndarray, "3 3"]`) decomposes
 row-major into one float port per element (a vector's are `name_0, name_1, ...`, a matrix's `name_0_0, name_0_1, ...`).
-The jaxtyping types are detected structurally, so jaxtyping stays a dependency of the user's code only. Symbolic or
-broadcastable dimensions are rejected -- shapes must be fully static. An unannotated parameter is rejected. An
-aggregate attribute's shape is read from its reset value, optionally validated against an explicit jaxtyping
+The jaxtyping types are detected structurally, so jaxtyping stays a dependency of the user's code only.
+An aggregate attribute's shape is read from its reset value, optionally validated against an explicit jaxtyping
 annotation; interior shapes are inferred.
 
 Return type. The return annotation is likewise mandatory and validated against the inferred output leaves: `float`,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,7 +148,11 @@ Abstract interpretation over the Python AST/CFG with a binding-time lattice (sta
 `__init__`-derived constants, compile-time tables) are evaluated concretely -- real Python/NumPy runs at synthesis time.
 Dynamic values (input ports, persistent state) become SSA handles that accumulate HIR. A `for` over a static `range` is
 unrolled (unless the count exceeds the unroll threshold); a `while` lowers to a real back-edge loop; an `if` on a static
-test takes one branch, on a dynamic test emits a real branch.
+test takes one branch, on a dynamic test emits a real branch. Static evaluation (used for branch/loop reachability and
+compile-time indices) resolves only the operands that both the reachability scan and lowering reconstruct identically:
+numeric literals, module-level numeric/array constants, read-only instance attributes, and loop counters -- including
+numpy navigation (indexing, slicing, transpose, `.flatten()`) of a module-level array constant or read-only array
+attribute.
 
 Persistent state. A synthesized method's `self` is not a port: each instance attribute the method writes becomes a
 persistent register (a loop-carried value, the back-edge of the initiation loop), and each attribute it only reads is a
@@ -156,14 +160,42 @@ frozen constant folded from the `__init__` snapshot. Within the method `self.att
 and writes interleave freely. Public attributes additionally drive a `state_<attr>` output port, so a method need not
 return anything (and a returned value that is by dataflow a public attribute is deduped onto that state port);
 underscore-prefixed attributes stay internal. A vector-valued attribute (list, tuple, or 1-D numpy array) decomposes
-into one scalar register per element (`attr_0`, `attr_1`, ...); a scalar keeps its bare name. Whether an attribute is
-state follows reachability. Reassigning `self` itself is rejected: attributes resolve against the fixed original
-instance, so a rebinding would silently miscompile.
+into one scalar register per element (`attr_0`, `attr_1`, ...), a matrix-valued one (2-D numpy array) row-major into
+`attr_0_0`, `attr_0_1`, ...; a scalar keeps its bare name. Whether an attribute is state follows reachability.
+Reassigning `self` itself is rejected: attributes resolve against the fixed original instance, so a rebinding would
+silently miscompile.
 
 Matrices/vectors are statically shaped and unrolled to scalar operations; arrays never exist as hardware aggregates,
 only as compile-time bookkeeping over scalar registers. That bookkeeping is a front-end value -- either a scalar wire or
-an ordered aggregate -- supporting list/tuple literals, indexing and constant slicing, unpacking, elementwise broadcast,
-and the identity sequence wrappers; only scalar leaves reach HIR, so the supported source is executable numpy.
+an ordered aggregate -- supporting list/tuple literals, numpy-style indexing and constant slicing (`m[i, j]`,
+`m[:, j]`, chained `m[i][j]`), unpacking, transpose (`.T`), and the array factories `np.array`/`asarray`/`asanyarray`;
+only scalar leaves reach HIR, so the supported source is executable numpy. Module-level numeric and ndarray globals
+fold into constants.
+
+List/tuple vs. array. A front-end aggregate carries its Python flavor. The guiding principle is to follow Python
+semantics where sensible and otherwise reject a construct rather than silently reinterpret it; in particular a Python
+list/tuple is never given numpy semantics. A Python list/tuple (a list/tuple literal, the `list()`/`tuple()` builtins,
+or a starred-unpack remainder) has sequence semantics: indexing, constant slicing, unpacking, splatting, building, and
+returning all work on it. A numpy array -- a shaped parameter, an ndarray module constant or state attribute,
+`np.array`/`asarray`/`asanyarray(...)`, or the result of any array operation -- additionally carries numpy semantics.
+The numpy-only operations (elementwise arithmetic, the matrix product, transpose, `.flatten()`, and multi-axis
+indexing) apply to arrays and are rejected on a list/tuple: on a Python sequence they mean something else or nothing
+(list `+`/`*` are concatenation/repetition, list `-`/`@`/`.T` are undefined), none of which is the array operation
+intended. A bare list is never coerced -- `matrix - [row0, row1]` is rejected; the user writes
+`matrix - np.array([row0, row1])`. `np.array([...])` is the list-accepting factory that converts a sequence into an
+array (numpy rejects a ragged literal, so a non-rectangular argument is rejected too), the idiomatic fix when a kernel
+needs array arithmetic over a value built as a list.
+
+Array arithmetic. The elementwise arithmetic operators `+ - * /` apply leafwise to same-shape arrays, and a scalar
+operand broadcasts over the other side's leaves; this is deliberately narrower than numpy broadcasting -- a mixed-rank
+pair (vector + matrix) is rejected rather than silently aligned along a different axis than numpy would pick, and `**`
+stays scalar-only. Augmented assignment to any aggregate (`+=`, `@=`) is rejected: an array would be mutated in place by
+numpy while the front-end rebinds (diverging for an alias), and a list `+=` is concatenation, which is unsupported. The
+matrix product `@` (equivalently `np.matmul`) follows numpy's shape rules for 1-D and 2-D operands -- inner dimensions
+must agree, a 1-D operand is promoted and its axis dropped from the result, vector @ vector is a scalar -- and expands
+into scalar multiply/add chains. Each dot product is a left fold, which keeps every product single-use feeding an add of
+the running sum: exactly the shape MIR's FMA contraction fuses into one multiply plus an FMA chain when configured. All
+shapes are static; there is no batching (ndim > 2) and no runtime sizing.
 
 Inlining. A pure function reachable through `__globals__` is inlined -- its body lowered in a fresh scope, its return
 consumed as an aggregate -- so kernels compose. A method call on the synthesized instance (`self.helper(...)`) is
@@ -171,14 +203,19 @@ inlined with the instance context kept, so the callee's own `self.<attr>` reads 
 class MRO; `@staticmethod` and `@property` getters are supported). A called method may read `self` but not write it --
 only the entry method owns the state-slot analysis. Name resolution follows Python.
 
-Parameters. Positional and keyword-only parameters become input ports and require an explicit scalar annotation:
-`float`-annotated scalars are floating-point ports, `bool`-annotated ones are 1-bit boolean ports; an unannotated
-scalar is rejected. An aggregate attribute's shape is read from its reset value, optionally validated against an
-explicit jaxtyping annotation; interior shapes are inferred.
+Parameters. Positional and keyword-only parameters become input ports and require an explicit annotation:
+`float`-annotated scalars are floating-point ports, `bool`-annotated ones are 1-bit boolean ports, and a jaxtyping
+array annotation with fixed 1-D/2-D dimensions and a floating dtype (e.g. `Float64[np.ndarray, "3 3"]`) decomposes
+row-major into one float port per element (a vector's are `name_0, name_1, ...`, a matrix's `name_0_0, name_0_1, ...`).
+The jaxtyping types are detected structurally, so jaxtyping stays a dependency of the user's code only. Symbolic or
+broadcastable dimensions are rejected -- shapes must be fully static. An unannotated parameter is rejected. An
+aggregate attribute's shape is read from its reset value, optionally validated against an explicit jaxtyping
+annotation; interior shapes are inferred.
 
 Return type. The return annotation is likewise mandatory and validated against the inferred output leaves: `float`,
-`bool`, an arbitrarily nested `tuple[...]`/`tuple[X, ...]`/`list[X]` of them, or `None` for a method that returns
-nothing. A missing annotation or any shape, arity, or scalar-type divergence rejects the kernel.
+`bool`, a fixed-shape jaxtyping array, an arbitrarily nested `tuple[...]`/`tuple[X, ...]`/`list[X]` of them, or
+`None` for a method that returns nothing. A missing annotation or any shape, arity, or scalar-type divergence rejects
+the kernel.
 
 ## HIR
 
@@ -277,6 +314,12 @@ Variable-trip `for` loops: a `for` above the unroll threshold is rejected, not l
 needs a runtime integer counter).
 
 Early return from a loop body.
+
+Static folding of a constant that reaches a static position (a branch/loop condition or a compile-time index) only
+through a local alias or an inline-built value, e.g. `g = CONST; if g[0] > 0:` or `if np.asarray([...])[0] > 0:`. Such
+a value still lowers correctly but is treated as dynamic, because folding it would require the reachability scan to
+track arbitrary local bindings it does not build. Only module-level constants, read-only instance attributes, and loop
+counters fold in static positions.
 
 Integer operands: typed int operands/constants/operators sharing the wide register bank when their width matches the
 build.

--- a/README.md
+++ b/README.md
@@ -206,9 +206,15 @@ For a detailed technical review of the design and trade-offs, please refer to `D
 
 Holoso follows Python with minimal deviations where it makes sense for hardware synthesis.
 
-- Static typing only. Parameters must be annotated `float` or `bool`; the return type must be annotated too — a
-  scalar, a `tuple`/`list` of scalars (arbitrarily nested), or `None` for a method that returns nothing — and is
-  validated against the kernel's actual outputs.
+- Static typing only. Parameters must be annotated `float`, `bool`, or a fixed-shape jaxtyping array
+  (`Float64[np.ndarray, "3 3"]`); the return type must be annotated too — a scalar, such an array, a `tuple`/`list` of
+  them (arbitrarily nested), or `None` for a method that returns nothing — and is validated against the actual outputs.
+- NumPy arrays and Python sequences are distinct, following Python. A numpy array (a shaped parameter, an `np.ndarray`
+  constant or state, `np.array([...])`, or the result of an array operation) supports elementwise arithmetic, the
+  matrix product `@`, transpose, and multi-axis indexing. A plain Python list/tuple keeps ordinary Python semantics
+  (indexing, slicing, unpacking, building) and those numpy-only operations are rejected on it: on a list `+`/`*` are
+  concatenation/repetition, not elementwise math, and `-`/`@`/`.T` are undefined. Wrap it in `np.array([...])` for array
+  arithmetic.
 - No implicit type conversions.
 - Boolean short-circuiting is not supported, all operands evaluated eagerly.
 - Floating-point precision depends on the selected floating-point format. See below for more info about floats.

--- a/README.md
+++ b/README.md
@@ -206,12 +206,23 @@ For a detailed technical review of the design and trade-offs, please refer to `D
 
 Holoso follows Python with minimal deviations where it makes sense for hardware synthesis.
 
-- Static typing only. Parameters must be annotated `float`, `bool`, or a fixed-shape jaxtyping array
-  (`Float64[np.ndarray, "3 3"]`); the return type must be annotated too — a scalar, such an array, a `tuple`/`list` of
-  them (arbitrarily nested), or `None` for a method that returns nothing — and is validated against the actual outputs.
+- Static typing only.
+
 - No implicit type conversions.
+
 - Boolean short-circuiting is not supported, all operands evaluated eagerly.
-- Floating-point precision depends on the selected floating-point format. See below for more info about floats.
+
+- Floating-point precision depends on the selected floating-point format.
+  The width of the float type in the type annotation is ignored.
+  See below for more info about floats.
+
+- Dynamically-sized tensors are not supported. Dimensions must be annotated using jaxtyping
+  (e.g., `Float64[np.ndarray, "3 3"]`).
+
+- Augmented assignment (`+=`, `@=`, etc.) is supported only for scalars, where it simply rebinds the result.
+  Tensors mutate in place, which diverges from a rebind when the tensor is aliased; supporting it correctly would
+  require complex escape analysis.
+
 - No exceptions: division by zero, domain errors, etc. produce the closest meaningful result and assert the error flag.
 
 ### Floating point

--- a/README.md
+++ b/README.md
@@ -209,12 +209,6 @@ Holoso follows Python with minimal deviations where it makes sense for hardware 
 - Static typing only. Parameters must be annotated `float`, `bool`, or a fixed-shape jaxtyping array
   (`Float64[np.ndarray, "3 3"]`); the return type must be annotated too — a scalar, such an array, a `tuple`/`list` of
   them (arbitrarily nested), or `None` for a method that returns nothing — and is validated against the actual outputs.
-- NumPy arrays and Python sequences are distinct, following Python. A numpy array (a shaped parameter, an `np.ndarray`
-  constant or state, `np.array([...])`, or the result of an array operation) supports elementwise arithmetic, the
-  matrix product `@`, transpose, and multi-axis indexing. A plain Python list/tuple keeps ordinary Python semantics
-  (indexing, slicing, unpacking, building) and those numpy-only operations are rejected on it: on a list `+`/`*` are
-  concatenation/repetition, not elementwise math, and `-`/`@`/`.T` are undefined. Wrap it in `np.array([...])` for array
-  arithmetic.
 - No implicit type conversions.
 - Boolean short-circuiting is not supported, all operands evaluated eagerly.
 - Floating-point precision depends on the selected floating-point format. See below for more info about floats.

--- a/examples/imu_frame_transform.py
+++ b/examples/imu_frame_transform.py
@@ -35,6 +35,10 @@ def main() -> None:
     args = (yaw90, np.array([1.0, 2.0, 3.0]), np.array([0.1, -0.2, 9.9]), np.array([2.0, 0.0, -1.0]))
     narrow = holoso.FloatFormat(wexp=6, wman=18)
     wide = holoso.FloatFormat(wexp=8, wman=36)
+    # Each format twice: the plain fmul+fadd expansion of the matrix products, and the ffma-contracted datapath where
+    # every dot-product multiply-accumulate fuses into one rounding (a*b+c). The staged variants show representative
+    # pipeline depths -- this script only elaborates and writes RTL/reports, so the knobs are illustrative rather than
+    # timing-closed; the wide FMA multiplicand exceeds one DSP tile, hence its STAGE_PRODUCT split.
     configs = [
         holoso.OpConfig(
             holoso.FAddOperator(narrow),
@@ -44,17 +48,35 @@ def main() -> None:
             holoso.FCmpOperator(narrow),
         ),
         holoso.OpConfig(
+            holoso.FAddOperator(narrow, stage_input=1, stage_decode=1, stage_pack=1),
+            holoso.FMulOperator(narrow, stage_product=1),
+            holoso.FDivOperator(narrow),
+            holoso.FMulILog2OperatorFamily(narrow),
+            holoso.FCmpOperator(narrow),
+            ffma=holoso.FFmaOperator(narrow, stage_product=1, stage_decode=1, stage_normalize=1, stage_pack=1),
+        ),
+        holoso.OpConfig(
             holoso.FAddOperator(wide, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
             holoso.FMulOperator(wide, stage_input=1, stage_product=1, stage_pack=1),
             holoso.FDivOperator(wide, stage_input=1, stage_pack=1, stage_output=1),
             holoso.FMulILog2OperatorFamily(wide),
             holoso.FCmpOperator(wide),
         ),
+        holoso.OpConfig(
+            holoso.FAddOperator(wide, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
+            holoso.FMulOperator(wide, stage_input=1, stage_product=1, stage_pack=1),
+            holoso.FDivOperator(wide, stage_input=1, stage_pack=1, stage_output=1),
+            holoso.FMulILog2OperatorFamily(wide),
+            holoso.FCmpOperator(wide),
+            ffma=holoso.FFmaOperator(
+                wide, stage_input=1, stage_product=2, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1
+            ),
+        ),
     ]
     base = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     flat_inputs = [float(x) for x in np.concatenate([a.flatten() for a in args])]
     for ops in configs:
-        label = f"e{ops.float_format.wexp}m{ops.float_format.wman}"
+        label = f"e{ops.float_format.wexp}m{ops.float_format.wman}" + ("_fma" if ops.ffma is not None else "")
         result = holoso.synthesize(transform, ops=ops)
         world = [float(v) for v in result.numerical_model.elaborate().run(*flat_inputs)]
         print(f"{label}: p_world/a_world/p_recovered = {world}")

--- a/examples/imu_frame_transform.py
+++ b/examples/imu_frame_transform.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Rigid-body frame transform for a strapdown IMU: place a body-frame point in the world frame and resolve a specific-force
+measurement into world-frame linear acceleration, using only matrix products (no inversion, no trigonometry).
+"""
+
+from pathlib import Path
+
+import numpy as np
+from jaxtyping import Float64
+
+import holoso
+
+GRAVITY = np.array([0.0, 0.0, 9.80665])  # world-frame gravity, subtracted from specific force to get linear accel
+# Fixed sensor-to-body mounting rotation (here a 90-degree yaw); applies to every measurement.
+MOUNT = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
+
+def transform(
+    R: Float64[np.ndarray, "3 3"],  # body-to-world rotation
+    t: Float64[np.ndarray, "3"],  # world-frame position of the body origin
+    a_meas: Float64[np.ndarray, "3"],  # accelerometer specific force, sensor frame
+    p_sensor: Float64[np.ndarray, "3"],  # a point, sensor frame
+) -> tuple[Float64[np.ndarray, "3"], Float64[np.ndarray, "3"], Float64[np.ndarray, "3"]]:
+    R_ws = R @ MOUNT  # world-from-sensor rotation
+    p_world = R_ws @ p_sensor + t
+    a_world = R_ws @ a_meas - GRAVITY
+    p_recovered = R_ws.T @ (p_world - t)  # world-to-sensor is the transpose, R_ws being orthonormal
+    return p_world, a_world, p_recovered
+
+
+def main() -> None:
+    # A right angle about z, so the transform stays exact and easy to read in the emitted report.
+    yaw90 = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    args = (yaw90, np.array([1.0, 2.0, 3.0]), np.array([0.1, -0.2, 9.9]), np.array([2.0, 0.0, -1.0]))
+    narrow = holoso.FloatFormat(wexp=6, wman=18)
+    wide = holoso.FloatFormat(wexp=8, wman=36)
+    configs = [
+        holoso.OpConfig(
+            holoso.FAddOperator(narrow),
+            holoso.FMulOperator(narrow),
+            holoso.FDivOperator(narrow),
+            holoso.FMulILog2OperatorFamily(narrow),
+            holoso.FCmpOperator(narrow),
+        ),
+        holoso.OpConfig(
+            holoso.FAddOperator(wide, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
+            holoso.FMulOperator(wide, stage_input=1, stage_product=1, stage_pack=1),
+            holoso.FDivOperator(wide, stage_input=1, stage_pack=1, stage_output=1),
+            holoso.FMulILog2OperatorFamily(wide),
+            holoso.FCmpOperator(wide),
+        ),
+    ]
+    base = Path(__file__).resolve().parent / "build" / Path(__file__).stem
+    flat_inputs = [float(x) for x in np.concatenate([a.flatten() for a in args])]
+    for ops in configs:
+        label = f"e{ops.float_format.wexp}m{ops.float_format.wman}"
+        result = holoso.synthesize(transform, ops=ops)
+        world = [float(v) for v in result.numerical_model.elaborate().run(*flat_inputs)]
+        print(f"{label}: p_world/a_world/p_recovered = {world}")
+        for filename, path in result.write(base / label).items():
+            print(f"{label}/{filename}: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -47,5 +47,5 @@ from ._operators import (
     OpConfig as OpConfig,
 )
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 __url__ = "https://holoso.digital"

--- a/holoso/_frontend/_aggregate.py
+++ b/holoso/_frontend/_aggregate.py
@@ -1,8 +1,9 @@
 """Compile-time lowering values: scalar wires and ordered aggregates, plus the persistent-attribute shape."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
+from math import prod
 
 from .._hir import Const
 from .._util import ValueId
@@ -24,8 +25,8 @@ class Value(ABC):
         return [vid for _, vid in self.walk([])]
 
     def flatten(self) -> "Aggregate":
-        """The leaves flatten in row-major order."""
-        return Aggregate(tuple(Scalar(vid) for vid in self.leaves()))
+        """The leaves flatten in row-major order; ``.flatten()`` is a numpy operation, so the result is an array."""
+        return Aggregate(tuple(Scalar(vid) for vid in self.leaves()), array=True)
 
     def output_leaves(self) -> list[tuple[Path, ValueId]]:
         return list(self.walk([]))
@@ -46,40 +47,95 @@ class Scalar(Value):
 
 @dataclass(frozen=True, slots=True)
 class Aggregate(Value):
+    """
+    An ordered aggregate of values with an explicit semantic marker: ``array`` is True for a numpy array (a shaped
+    parameter, an ndarray constant/state, ``np.array(...)``, or a result of an array operation) and False for a plain
+    Python list/tuple. The two spellings differ in Python -- list ``+`` concatenates, list ``-``/``@``/``.T`` are
+    errors -- so the numpy-only operations (arithmetic, the matrix product, transpose, ``.flatten()``, multi-axis
+    indexing) are rejected on a Python sequence, while the structural operations valid on both (indexing, slicing,
+    unpacking, building, returning) apply regardless of the flag.
+    """
+
     items: tuple[Value, ...]
+    array: bool
 
     def walk(self, path: Path) -> Iterator[tuple[Path, ValueId]]:
         for index, item in enumerate(self.items):
             yield from item.walk([*path, index])
 
 
+def array_shape(value: Value) -> tuple[int, ...] | None:
+    """
+    The numpy-style shape of a value when it forms a rectangular array: ``()`` for a scalar, ``(n,)`` for a flat
+    aggregate, ``(m, n)`` for an aggregate of equal-shape aggregates, and so on. A ragged or empty aggregate is not an
+    array and yields None; array-typed operations (matmul, transpose, shape validation) gate on this while purely
+    structural ones (tuple returns, unpacking) do not.
+    """
+    match value:
+        case Scalar():
+            return ()
+        case Aggregate(items=items):
+            if not items:
+                return None
+            shapes = {array_shape(item) for item in items}
+            if len(shapes) != 1 or (inner := next(iter(shapes))) is None:
+                return None
+            return (len(items), *inner)
+    raise TypeError(f"unexpected value {value!r}")
+
+
+def shape_name(shape: tuple[int, ...]) -> str:
+    """A shape for a diagnostic: ``a scalar``, ``a 3-element vector``, ``a 2×3 matrix``, ``a 2×2×2 array``."""
+    match shape:
+        case ():
+            return "a scalar"
+        case (n,):
+            return f"a {n}-element vector"
+        case (_, _):
+            return f"a {'×'.join(str(dim) for dim in shape)} matrix"
+        case _:
+            return f"a {'×'.join(str(dim) for dim in shape)} array"
+
+
+def array_of(shape: tuple[int, ...], leaves: Sequence[Value], *, array: bool) -> Value:
+    """Rebuild a value of the given shape from its row-major scalar leaves, stamping every level with ``array``."""
+    if shape == ():
+        (leaf,) = leaves
+        return leaf
+    assert leaves and len(leaves) % shape[0] == 0
+    stride = len(leaves) // shape[0]
+    return Aggregate(
+        tuple(array_of(shape[1:], leaves[stride * i : stride * (i + 1)], array=array) for i in range(shape[0])),
+        array=array,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class StateAttr:
     """
     The scalar-slot decomposition of one instance attribute, derived from the reset snapshot: a scalar occupies a single
-    bare-named slot, a vector one indexed slot per element. It is the single source of an attribute's shape -- its slot
-    names, its typed reset values, and whether an assigned value must be a scalar or a same-length flat aggregate. The
+    bare-named slot, a vector or matrix one indexed slot per element in row-major order. It is the single source of an
+    attribute's shape -- its slot names, its typed reset values, and the array shape an assigned value must have. The
     element type lives in the typed ``resets`` (a :class:`BoolConst` reset marks a boolean attribute, a scalar only
-    since boolean vectors are not supported), so no separate type flag is carried.
+    since boolean aggregates are not supported), so no separate type flag is carried.
     """
 
-    is_vector: bool
+    shape: tuple[int, ...]
     slots: list[str]
     resets: list[Const]
+    array: bool  # True when the reset snapshot is a numpy array, False for a Python list/tuple (or a scalar)
+
+    def __post_init__(self) -> None:
+        count = prod(self.shape)  # prod(()) == 1: a scalar occupies exactly one slot
+        assert len(self.slots) == count and len(self.resets) == count
 
     def accepts(self, value: Value) -> bool:
         """
-        Whether an assigned value matches this shape: a scalar attribute accepts only a scalar, a vector only a flat
-        aggregate of the same length. Checking the full shape -- not merely the leaf count -- keeps the assigned value
-        consistent with the per-element slot layout that the next transaction reconstructs from the reset snapshot.
+        Whether an assigned value matches this shape exactly. Checking the full shape -- not merely the leaf count --
+        keeps the assigned value consistent with the per-element slot layout that the next transaction reconstructs
+        from the reset snapshot.
         """
-        if not self.is_vector:
-            return isinstance(value, Scalar)
-        return (
-            isinstance(value, Aggregate)
-            and len(value.items) == len(self.slots)
-            and all(isinstance(item, Scalar) for item in value.items)
-        )
+        return array_shape(value) == self.shape
 
     def compose(self, scalars: tuple[Scalar, ...]) -> Value:
-        return Aggregate(scalars) if self.is_vector else scalars[0]
+        return array_of(self.shape, scalars, array=self.array)

--- a/holoso/_frontend/_ast_support.py
+++ b/holoso/_frontend/_ast_support.py
@@ -1,6 +1,7 @@
 """Stateless AST/walrus helpers and naming utilities shared by the front-end lowerer."""
 
 import ast
+import itertools
 from collections.abc import Iterator
 
 Path = list[int | str]
@@ -28,6 +29,15 @@ def port_name(path: Path) -> str:
 def state_port_name(slot: str) -> str:
     """Map a public state slot to its observable port name, e.g. ``"y"`` -> ``state_y``, ``"x_0"`` -> ``state_x_0``."""
     return f"state_{slot}"
+
+
+def indexed_names(base: str, shape: tuple[int, ...]) -> list[str]:
+    """
+    The row-major per-element names of a shaped base name: ``()`` -> ``[base]``, ``(2,)`` -> ``[base_0, base_1]``,
+    ``(2, 2)`` -> ``[base_0_0, base_0_1, base_1_0, base_1_1]``. The one naming convention shared by decomposed state
+    slots and decomposed array-parameter input ports.
+    """
+    return [base + "".join(f"_{i}" for i in index) for index in itertools.product(*(range(dim) for dim in shape))]
 
 
 def leaf_targets(target: ast.expr) -> Iterator[ast.expr]:

--- a/holoso/_frontend/_lower.py
+++ b/holoso/_frontend/_lower.py
@@ -19,6 +19,7 @@ from ._ast_support import (
     Path,
     UNROLL_THRESHOLD,
     contains_walrus,
+    indexed_names,
     leaf_targets,
     port_name,
     range_trip_count,
@@ -27,7 +28,7 @@ from ._ast_support import (
     statement_walrus_names,
     walrus_target_names,
 )
-from ._aggregate import Aggregate, Scalar, StateAttr, Value
+from ._aggregate import Aggregate, Scalar, StateAttr, Value, array_of, array_shape, shape_name
 from ._scope import ArmResult, Scope, parse_fndef
 
 _logger = logging.getLogger(__name__)
@@ -41,6 +42,78 @@ def _scalar_annotation_type(annotation: object) -> Type | None:
     if annotation is bool:
         return BoolType()
     return None
+
+
+def _is_array_annotation(annotation: object) -> bool:
+    """
+    A jaxtyping-style array annotation: a class carrying ``dims``. Detected structurally so that jaxtyping remains an
+    optional dependency of the user's code, never of Holoso itself.
+    """
+    return isinstance(annotation, type) and hasattr(annotation, "dims")
+
+
+def _real_or_none(value: object) -> float | None:
+    """The value as a float if it is a real number (a builtin or numpy int/float, never a boolean), else None."""
+    if isinstance(value, (int, float, np.integer, np.floating)) and not isinstance(value, (bool, np.bool_)):
+        return float(value)
+    return None
+
+
+def _ndarray_reals(
+    value: np.ndarray, what: str, loc: SourceLocation | None = None
+) -> tuple[tuple[int, ...], list[float]]:
+    """
+    Validate a numpy array used as a constant or reset value and return its shape and row-major real elements. An
+    ndarray subclass (``np.matrix``, a masked array) is rejected because its operators mean different things -- e.g.
+    ``np.matrix`` treats ``*`` as matrix multiplication -- so silently folding it as a plain array would diverge from
+    the value's own Python semantics.
+    """
+    if type(value) is not np.ndarray:
+        raise UnsupportedConstruct(
+            f"{what} must be a plain numpy array, not a {type(value).__name__} "
+            "(an ndarray subclass such as np.matrix has different operator semantics)",
+            loc,
+        )
+    if value.ndim not in (1, 2):
+        raise UnsupportedConstruct(f"{what} must be a 1-D or 2-D array, got a {value.ndim}-D array", loc)
+    if 0 in value.shape:
+        raise UnsupportedConstruct(f"{what} must not be an empty array", loc)
+    reals: list[float] = []
+    for element in value.flatten():
+        real = _real_or_none(element)
+        if real is None:
+            raise UnsupportedConstruct(f"{what} must hold real numbers, got {type(element).__name__}", loc)
+        reals.append(real)
+    return tuple(value.shape), reals
+
+
+def _annotation_shape(annotation: object, what: str, loc: SourceLocation) -> tuple[int, ...]:
+    """
+    The fixed shape of a jaxtyping-style array annotation. Everything must be static -- a symbolic, variadic, or
+    broadcastable dimension is rejected, since there is no memory to size at run time. The dtype category must be
+    floating-point; the concrete hardware format still comes from the operator configuration, not the annotation.
+    """
+    dims = getattr(annotation, "dims", None)
+    if not isinstance(dims, tuple):  # a real jaxtyping type always carries a dims tuple; anything else is not one
+        raise UnsupportedConstruct(f"{what}: not a valid fixed-shape array annotation", loc)
+    sizes: list[int] = []
+    for dim in dims:
+        size = getattr(dim, "size", None)
+        if not isinstance(size, int) or getattr(dim, "broadcastable", False):
+            raise UnsupportedConstruct(
+                f'{what}: array dimensions must be fixed integers (e.g. Float64[np.ndarray, "3 3"])', loc
+            )
+        if size < 1:
+            raise UnsupportedConstruct(f"{what}: array dimensions must be at least 1", loc)
+        sizes.append(size)
+    if len(sizes) not in (1, 2):
+        raise UnsupportedConstruct(f"{what}: only 1-D and 2-D arrays are supported, got {len(sizes)}-D", loc)
+    dtypes = getattr(annotation, "dtypes", None)  # e.g. jaxtyping Shaped carries a non-iterable any-dtype marker
+    if not isinstance(dtypes, (tuple, list)) or not all(
+        isinstance(name, str) and name.startswith(("float", "bfloat")) for name in dtypes
+    ):
+        raise UnsupportedConstruct(f"{what}: the array element type must be floating-point (e.g. Float64)", loc)
+    return tuple(sizes)
 
 
 def _aggregate_element_annotations(annotation: object, count: int) -> list[object] | None:
@@ -123,6 +196,7 @@ class _Lowerer:
         self._entry_fndef, self._lines, self._start, self._filename = parse_fndef(fn)
         self._builder = HirBuilder()
         self._env: dict[str, Value] = {}
+        self._input_port_names: set[str] = set()  # guards against aliasing between decomposed parameter ports
         # Stateful-class lowering context; all empty/None for a plain stateless function. The snapshot is the instance
         # as handed to the synthesizer (whatever __init__ and any later mutation produced); its values seed reset.
         self._instance = instance
@@ -196,22 +270,44 @@ class _Lowerer:
             self._assigned_attrs = self._syntactically_assigned_attrs(fndef)
             self._collect_written_attrs(fndef)
             self._check_state_slot_names()
-        # Positional then keyword-only parameters each become a scalar input port, in declaration order.
+        # Positional then keyword-only parameters bind in declaration order; arrays decompose into per-element ports.
         for arg in [*params, *args.kwonlyargs]:
-            self._env[arg.arg] = Scalar(self._input(arg))
+            self._env[arg.arg] = self._input(arg)
 
-    def _input(self, arg: ast.arg) -> ValueId:
+    def _input(self, arg: ast.arg) -> Value:
         annotations = self._fn.__annotations__
         if arg.arg not in annotations:
             raise UnsupportedConstruct(
-                f"parameter {arg.arg!r} requires an explicit type annotation (float or bool)", self._loc(arg)
+                f"parameter {arg.arg!r} requires an explicit type annotation "
+                "(float, bool, or a fixed-shape jaxtyping array)",
+                self._loc(arg),
             )
-        scalar_type = _scalar_annotation_type(annotations[arg.arg])
-        if scalar_type is None:
+        annotation = annotations[arg.arg]
+        scalar_type = _scalar_annotation_type(annotation)
+        shape: tuple[int, ...]
+        element_type: Type
+        if scalar_type is not None:
+            shape, element_type = (), scalar_type
+        elif _is_array_annotation(annotation):
+            shape, element_type = _annotation_shape(annotation, f"parameter {arg.arg!r}", self._loc(arg)), FloatType()
+        else:
             raise UnsupportedConstruct(
-                f"unsupported parameter annotation for {arg.arg!r}: expected float or bool", self._loc(arg)
+                f"unsupported parameter annotation for {arg.arg!r}: expected float, bool, or a jaxtyping array type "
+                'with fixed dimensions (e.g. Float64[np.ndarray, "3 3"])',
+                self._loc(arg),
             )
-        return self._builder.input(arg.arg, scalar_type)
+        # A decomposed port coinciding with another parameter's port (an array ``v`` beside a scalar ``v_0``)
+        # would alias distinct inputs, so it is rejected.
+        names = indexed_names(arg.arg, shape)
+        for name in names:
+            if name in self._input_port_names:
+                raise UnsupportedConstruct(
+                    f"parameter {arg.arg!r} produces input port {name!r} that collides with another parameter; "
+                    "rename a parameter to avoid the aliasing",
+                    self._loc(arg),
+                )
+            self._input_port_names.add(name)
+        return array_of(shape, [Scalar(self._builder.input(name, element_type)) for name in names], array=True)
 
     def _lower_body(self, fndef: ast.FunctionDef) -> None:
         returned = self._lower_stmts(fndef.body)
@@ -236,6 +332,9 @@ class _Lowerer:
         self._check_return_shape(self._return, declared, loc)
 
     def _check_return_shape(self, value: Value, declared: object, loc: SourceLocation) -> None:
+        if _is_array_annotation(declared):
+            self._check_array_return(value, declared, loc)
+            return
         match value:
             case Scalar(id=vid):
                 expected = _scalar_annotation_type(declared)
@@ -246,7 +345,7 @@ class _Lowerer:
                         )
                     raise UnsupportedConstruct(
                         f"unsupported return annotation {_annotation_name(declared)}: "
-                        "expected float, bool, a tuple or list of them, or None",
+                        "expected float, bool, a jaxtyping array, a tuple or list of them, or None",
                         loc,
                     )
                 actual = self._builder.type_of(vid)
@@ -269,6 +368,16 @@ class _Lowerer:
                     )
                 for item, element in zip(items, elements):
                     self._check_return_shape(item, element, loc)
+
+    def _check_array_return(self, value: Value, declared: object, loc: SourceLocation) -> None:
+        expected = _annotation_shape(declared, "return", loc)
+        actual = array_shape(value)
+        if actual != expected:
+            inferred = shape_name(actual) if actual is not None else "a non-rectangular value"
+            raise UnsupportedConstruct(
+                f"return shape mismatch: declared {shape_name(expected)}, inferred {inferred}", loc
+            )
+        self._require_float_leaves(value, "an array return must be floating-point", loc)
 
     def _lower_stmts(self, stmts: list[ast.stmt]) -> bool:
         """Lower a straight-line statement list, returning True when a ``return`` was reached."""
@@ -309,10 +418,13 @@ class _Lowerer:
                 self._reject_self_rebinding(name, self._loc(stmt))
                 if name not in self._env:
                     raise UnsupportedConstruct(f"augmented assignment to unknown name {name!r}", self._loc(stmt))
-                self._bind_name(name, self._apply_binop(op, self._env[name], self._lower_expr(value), self._loc(stmt)))
+                current = self._env[name]
+                self._reject_aggregate_augassign(current, self._loc(stmt))
+                self._bind_name(name, self._apply_binop(op, current, self._lower_expr(value), self._loc(stmt)))
                 return False
             case ast.AugAssign(target=ast.Attribute() as target, op=op, value=value):
                 current = self._read_attr(target)
+                self._reject_aggregate_augassign(current, self._loc(stmt))
                 self._assign_attr(target, self._apply_binop(op, current, self._lower_expr(value), self._loc(stmt)))
                 return False
             case ast.If(test=test, body=body, orelse=orelse):
@@ -650,8 +762,84 @@ class _Lowerer:
             case _:
                 raise UnsupportedConstruct("a for-loop must iterate over range(...)", loc)
 
+    def _static_ndarray_value(self, node: ast.expr) -> Any:
+        """
+        Resolve a compile-time constant-array expression to its numpy value (an array or a scalar element), or None.
+        It mirrors value-position lowering by applying the same numpy navigation (never arithmetic) directly to the
+        snapshot array, so a constant-array condition folds statically and reachability stays consistent with lowering
+        -- the array counterpart of the ``_static_int``/``_static_float`` mirrors. Only a plain ``np.ndarray`` base
+        qualifies, matching the subclass rejection elsewhere.
+        """
+        if isinstance(node, ast.Name) and not self._is_local(node.id):
+            glob = self._module_global(node.id)
+            return glob if type(glob) is np.ndarray else None
+        if isinstance(node, ast.Attribute):
+            if node.attr == "T" and not self._is_self_attr(node):
+                base = self._static_ndarray_value(node.value)
+                return base.T if isinstance(base, np.ndarray) else None
+            if self._is_self_attr(node):
+                value = self._readonly_snapshot_value(node.attr)
+                return value if type(value) is np.ndarray else None
+            return None
+        if isinstance(node, ast.Call):
+            return self._static_ndarray_call(node)
+        if isinstance(node, ast.Subscript):
+            base = self._static_ndarray_value(node.value)
+            key = self._static_index_key(node.slice)
+            if not isinstance(base, np.ndarray) or key is None:
+                return None
+            try:
+                return base[key]
+            except IndexError:
+                return None
+        return None
+
+    def _static_ndarray_call(self, node: ast.Call) -> Any:
+        """
+        The two shape-preserving call forms on a constant array: ``x.flatten()`` and the numpy array-identity wrappers
+        ``np.array``/``asarray``/``asanyarray`` (all no-ops on a value already resolved to an array).
+        """
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "flatten" and not node.args and not node.keywords:
+            base = self._static_ndarray_value(func.value)
+            return base.flatten() if isinstance(base, np.ndarray) else None
+        if self._numpy_function(func) in _NUMPY_IDENTITY and len(node.args) == 1 and not node.keywords:
+            return self._static_ndarray_value(node.args[0])
+        return None
+
+    def _static_index_key(self, index: ast.expr) -> tuple[int | slice, ...] | None:
+        """A subscript's axes as a numpy index tuple of static ints and step-free slices, or None if not all static."""
+        axes = index.elts if isinstance(index, ast.Tuple) else [index]
+        key: list[int | slice] = []
+        for axis in axes:
+            if isinstance(axis, ast.Slice):
+                if axis.step is not None:
+                    return None
+                lower = None if axis.lower is None else self._static_int(axis.lower)
+                upper = None if axis.upper is None else self._static_int(axis.upper)
+                if (axis.lower is not None and lower is None) or (axis.upper is not None and upper is None):
+                    return None
+                key.append(slice(lower, upper))
+            else:
+                selected = self._static_int(axis)
+                if selected is None:
+                    return None
+                key.append(selected)
+        return tuple(key)
+
+    def _static_ndarray_element(self, node: ast.expr) -> Any:
+        """
+        The scalar element of a compile-time constant-array expression, or None. Lets a constant-array element fold in
+        a static position exactly as it folds in value position.
+        """
+        value = self._static_ndarray_value(node)
+        return value if value is not None and np.ndim(value) == 0 else None
+
     def _static_int(self, node: ast.expr) -> int | None:
         """Evaluate an expression to a compile-time integer (counter, index, or exponent), or None if it is not one."""
+        element = self._static_ndarray_element(node)
+        if isinstance(element, np.integer) or type(element) is int:
+            return int(element)
         match node:
             case ast.Constant(value=int(literal)) if not isinstance(literal, bool):
                 return literal
@@ -1127,8 +1315,16 @@ class _Lowerer:
                         loc,
                     )
                 return Scalar(self._builder.phi(self._builder.type_of(ia), [(pred_a, ia), (pred_b, ib)]))
-            case (Aggregate(items=items_a), Aggregate(items=items_b)) if len(items_a) == len(items_b):
-                return Aggregate(tuple(self._merge_values(x, y, pred_a, pred_b, loc) for x, y in zip(items_a, items_b)))
+            case (Aggregate(items=items_a, array=array_a), Aggregate(items=items_b, array=array_b)) if len(
+                items_a
+            ) == len(items_b):
+                # The merged value is a numpy array only if BOTH arms are: if either arm is a Python list the runtime
+                # value may be a list, so the merge must not silently grant array semantics (which would make a later
+                # ``v * s`` accepted or rejected depending on arm order). Structural use stays valid on either flavor.
+                return Aggregate(
+                    tuple(self._merge_values(x, y, pred_a, pred_b, loc) for x, y in zip(items_a, items_b)),
+                    array=array_a and array_b,
+                )
             case _:
                 raise UnsupportedConstruct("the two branches produce incompatible shapes for a merged value", loc)
 
@@ -1173,6 +1369,20 @@ class _Lowerer:
         """
         self._static_ints.pop(name, None)
 
+    def _reject_aggregate_augassign(self, current: Value, loc: SourceLocation) -> None:
+        """
+        Reject augmented assignment (``+=``, ``@=``, ...) whose target currently holds an aggregate. For an array numpy
+        mutates in place, so an alias taken before the statement observes the update while Holoso rebinds the name to a
+        fresh value, diverging silently; for a list ``+=`` is concatenation, which is unsupported anyway. So the
+        explicit ``x = x + ...`` form is required. Scalars are immutable in Python, so they never diverge.
+        """
+        if isinstance(current, Aggregate):
+            raise UnsupportedConstruct(
+                "augmented assignment to a list or array is not supported (an array would be mutated in place by numpy "
+                "while Holoso rebinds, diverging for an alias; a list '+=' is concatenation); write 'x = x + ...'",
+                loc,
+            )
+
     def _assign_target(self, target: ast.expr, value: Value) -> None:
         match target:
             case ast.Name(id=name):
@@ -1212,7 +1422,9 @@ class _Lowerer:
                 f"cannot unpack {len(items)} values into at least {len(elts) - 1} targets", self._loc(node)
             )
         head = list(zip(elts[:star], items[:star]))
-        rest = Aggregate(tuple(items[star : len(items) - len(after)]))  # the starred target binds the surplus
+        # PEP 3132: a starred target always binds a plain list, even when unpacking an array -- so the remainder is a
+        # Python sequence (array=False), while its items keep their own flavor.
+        rest = Aggregate(tuple(items[star : len(items) - len(after)]), array=False)
         tail = list(zip(after, items[len(items) - len(after) :]))
         return [*head, (starred.value, rest), *tail]
 
@@ -1229,20 +1441,26 @@ class _Lowerer:
                 if bound is not None:
                     return bound
                 if not self._is_local(name):
-                    # A module-level numeric/boolean constant resolves like a literal, mirroring Python's global lookup
-                    # for a name the function never binds (a local name never falls through here: an unbound local is an
-                    # error, not a silent reach for a same-named global). bool is checked before int (it is a subclass).
+                    # A module-level numeric/boolean/array constant resolves like a literal, mirroring Python's global
+                    # lookup for a name the function never binds (a local name never falls through here: an unbound
+                    # local is an error, not a silent reach for a same-named global). bool is checked before int (it is
+                    # a subclass).
                     glob = self._module_global(name)
                     if isinstance(glob, bool):
                         return Scalar(self._builder.bool_const(glob))
                     if isinstance(glob, (int, float)):
                         return Scalar(self._builder.float_const(float(glob)))
+                    if isinstance(glob, np.ndarray):
+                        return self._constant_array(name, glob, self._loc(node))
                 raise UnsupportedConstruct(
-                    f"unknown name {name!r} (only parameters, locals, and module-level numeric constants are in scope)",
+                    f"unknown name {name!r} (only parameters, locals, and module-level numeric or array constants "
+                    "are in scope)",
                     self._loc(node),
                 )
             case ast.List(elts=elts) | ast.Tuple(elts=elts):
-                return Aggregate(tuple(self._lower_elements(elts)))
+                # A list/tuple literal has Python sequence semantics (array=False): numpy-only operations on it are
+                # rejected; wrapping it in np.array(...) converts it to an array.
+                return Aggregate(tuple(self._lower_elements(elts)), array=False)
             case ast.Subscript(value=value, slice=index):
                 return self._lower_subscript(self._lower_expr(value), index, self._loc(node))
             case ast.UnaryOp(op=ast.USub(), operand=ast.Constant(value=(int() | float()) as value)) if not isinstance(
@@ -1250,10 +1468,16 @@ class _Lowerer:
             ):
                 return Scalar(self._builder.float_const(-float(value)))
             case ast.UnaryOp(op=ast.USub(), operand=operand):
-                return Scalar(self._builder.operation(FloatNeg(), [self._scalar(self._lower_expr(operand), node)]))
+                return self._negate(self._lower_expr(operand), self._loc(node))
             case ast.UnaryOp(op=ast.UAdd(), operand=operand):
-                # Unary plus is scalar identity; like negation, it rejects an aggregate operand.
-                return Scalar(self._scalar(self._lower_expr(operand), node))
+                # Unary plus is identity on a float scalar or array, but a boolean operand is rejected like every other
+                # arithmetic position (Python's ``+True`` is int 1, which has no runtime representation here).
+                operand_value = self._lower_expr(operand)
+                self._reject_sequence_operand(operand_value, "arithmetic", self._loc(node))
+                self._require_float_leaves(
+                    operand_value, "arithmetic operands must be floating-point, not boolean", self._loc(node)
+                )
+                return operand_value
             case ast.UnaryOp(op=ast.Not()):
                 return self._lower_bool(node)
             case ast.BinOp(left=left, op=ast.Pow(), right=right):
@@ -1268,6 +1492,10 @@ class _Lowerer:
                 return self._lower_ifexp(test, body, orelse, self._loc(node))
             case ast.Call():
                 return self._lower_call(node)
+            case ast.Attribute(attr="T") if not self._is_self_attr(node):
+                # ``value.T`` is numpy transpose unless the receiver is the instance itself (an attribute named ``T``
+                # keeps Python's own resolution priority: ``self.T`` is a state read, ``self.P.T`` a transpose).
+                return self._transpose(self._lower_expr(node.value), self._loc(node))
             case ast.Attribute():
                 return self._read_attr(node)
             case ast.NamedExpr(target=ast.Name(id=name), value=value):
@@ -1281,7 +1509,7 @@ class _Lowerer:
                 raise UnsupportedConstruct(f"unsupported expression {type(node).__name__}", self._loc(node))
 
     def _lower_elements(self, elts: list[ast.expr]) -> Iterator[Value]:
-        """A ``*aggregate`` element is spliced in place (its leaves inlined into the surrounding sequence)."""
+        """A ``*aggregate`` element splices its top-level items (a matrix's rows) in place, as in Python."""
         for elt in elts:
             if isinstance(elt, ast.Starred):
                 yield from self._unpack(self._lower_expr(elt.value), elt)
@@ -1294,20 +1522,41 @@ class _Lowerer:
         return value.items
 
     def _lower_subscript(self, value: Value, index: ast.expr, loc: SourceLocation) -> Value:
+        if isinstance(index, ast.Tuple):
+            # Multi-axis ``m[i, j]`` is a numpy-array op with no meaning on a Python list/tuple (list ``[i, j]`` is a
+            # tuple key -- a TypeError), so it is rejected on a sequence; single-axis indexing works on any aggregate,
+            # matching plain list indexing. A numpy array is always rectangular by construction.
+            self._reject_sequence_operand(value, "multi-axis indexing", loc)
+            assert not isinstance(value, Aggregate) or array_shape(value) is not None
+            return self._subscript_axes(value, index.elts, loc)
+        return self._subscript_axes(value, [index], loc)
+
+    def _subscript_axes(self, value: Value, axes: list[ast.expr], loc: SourceLocation) -> Value:
+        """
+        Apply subscript axes left to right, numpy-style: an integer index selects along the current axis and consumes
+        it, a slice keeps the axis and applies the remaining axes within every kept element -- so ``M[i, j]``,
+        ``M[i][j]``, ``M[:, j]``, and ``M[1:, 0]`` all work over the nested aggregates.
+        """
+        if not axes:
+            return value
         if not isinstance(value, Aggregate):
             raise UnsupportedConstruct("cannot index or slice a scalar value", loc)
-        match index:
+        head, rest = axes[0], axes[1:]
+        match head:
             case ast.Slice(lower=lower, upper=upper, step=None):
                 start = 0 if lower is None else self._const_index(lower)
                 stop = len(value.items) if upper is None else self._const_index(upper)
-                return Aggregate(value.items[start:stop])
+                # A slice preserves the semantic flavor of the base: a slice of a list is a list, of an array an array.
+                return Aggregate(
+                    tuple(self._subscript_axes(item, rest, loc) for item in value.items[start:stop]), array=value.array
+                )
             case ast.Slice():
                 raise UnsupportedConstruct("a slice step is not supported", loc)
             case _:
-                i = self._const_index(index)
+                i = self._const_index(head)
                 if not -len(value.items) <= i < len(value.items):
                     raise UnsupportedConstruct(f"index {i} is out of range for a {len(value.items)}-element value", loc)
-                return value.items[i]
+                return self._subscript_axes(value.items[i], rest, loc)
 
     def _const_index(self, node: ast.expr) -> int:
         index = self._static_int(node)
@@ -1322,12 +1571,20 @@ class _Lowerer:
             receiver = self._lower_expr(func.value)
             if not isinstance(receiver, Aggregate):
                 raise UnsupportedConstruct(".flatten() is only supported on an aggregate value", self._loc(node))
+            self._reject_sequence_operand(receiver, "flattening", self._loc(node))
             return receiver.flatten()
         numpy_fn = self._numpy_function(func)
         if numpy_fn in _NUMPY_IDENTITY:
             if node.keywords or len(node.args) != 1 or isinstance(node.args[0], ast.Starred):
                 raise UnsupportedConstruct(f"np.{numpy_fn}() takes a single array-like argument", self._loc(node))
-            return self._lower_expr(node.args[0])
+            return self._as_array(self._lower_expr(node.args[0]), numpy_fn, self._loc(node))
+        if self._is_np_matmul(func):
+            if node.keywords:
+                raise UnsupportedConstruct("matmul() takes no keyword arguments", self._loc(node))
+            operands = self._lower_args(node)
+            if len(operands) != 2:
+                raise UnsupportedConstruct(f"matmul() takes 2 arguments, got {len(operands)}", self._loc(node))
+            return self._lower_matmul(operands[0], operands[1], self._loc(node))
         if isinstance(func, ast.Attribute) and self._is_self_name(func.value):
             return self._lower_method_call(node, func)
         intrinsic = self._intrinsic_call(node)
@@ -1357,7 +1614,7 @@ class _Lowerer:
             if func.id == "abs" and not node.keywords and builtin_unshadowed:
                 operands = self._lower_args(node)
                 if len(operands) == 1:
-                    return Scalar(self._builder.operation(FloatAbs(), [self._scalar(operands[0], node)]))
+                    return Scalar(self._builder.operation(FloatAbs(), [self._float_operand(operands[0], node)]))
             if func.id == "round" and not node.keywords and builtin_unshadowed:
                 # ``round(x)`` rounds to a whole-number float (ties to even); the format-aware hardware does the work.
                 # ``round(x, ndigits)`` (decimal rounding) is rejected rather than silently dropping the digit count.
@@ -1366,7 +1623,7 @@ class _Lowerer:
                     raise UnsupportedConstruct(
                         "round() takes a single argument; round(x, ndigits) is not supported", self._loc(node)
                     )
-                return Scalar(self._builder.operation(FloatRound(), [self._scalar(operands[0], node)]))
+                return Scalar(self._builder.operation(FloatRound(), [self._float_operand(operands[0], node)]))
             if func.id in ("min", "max") and not node.keywords and builtin_unshadowed:
                 # Binary min(a, b)/max(a, b) only; the variadic and iterable forms (and key=/default=) are not lowered.
                 operands = self._lower_args(node)
@@ -1375,13 +1632,15 @@ class _Lowerer:
                         f"{func.id}() is supported only with two scalar arguments", self._loc(node)
                     )
                 operator = FloatMin() if func.id == "min" else FloatMax()
-                return Scalar(self._builder.operation(operator, [self._scalar(operand, node) for operand in operands]))
+                return Scalar(
+                    self._builder.operation(operator, [self._float_operand(operand, node) for operand in operands])
+                )
             if func.id in ("list", "tuple") and not node.keywords and builtin_unshadowed:
-                # list(seq)/tuple(seq) of an aggregate is identity here: it carries the element order the model holds,
-                # and the front-end already treats list and tuple aggregates co-equally (the list/tuple-literal case).
+                # list(seq)/tuple(seq) produce a Python sequence (array=False) even from a numpy array; only the top
+                # level is rebuilt as a sequence, elements keep their own flavor (the rows of an array stay arrays).
                 operands = self._lower_args(node)
                 if len(operands) == 1 and isinstance(operands[0], Aggregate):
-                    return operands[0]
+                    return Aggregate(operands[0].items, array=False)
             if func.id == "bool" and not node.keywords and builtin_unshadowed:
                 operands = self._lower_args(node)
                 if len(operands) != 1:
@@ -1415,20 +1674,27 @@ class _Lowerer:
         operands = self._lower_args(node)
         if len(operands) != arity:
             raise UnsupportedConstruct(f"{name}() takes {arity} argument(s), got {len(operands)}", self._loc(node))
-        return Scalar(self._builder.operation(operator, [self._scalar(operand, node) for operand in operands]))
+        return Scalar(self._builder.operation(operator, [self._float_operand(operand, node) for operand in operands]))
 
-    def _intrinsic_name(self, func: ast.expr) -> str | None:
+    def _resolved_callee(self, func: ast.expr) -> object:
         """
-        The canonical intrinsic name if ``func`` targets a supported ``math``/``numpy`` function -- a
-        ``<module>.<name>`` attribute access or a bare name bound to the function. Both resolve the callee object and
-        defer the identity/shadow decision to ``_intrinsic_of``; spelling alone never dispatches.
+        The module-global object a call targets -- an unshadowed ``<module>.<attr>`` attribute access or an unshadowed
+        bare name -- else None. The object is returned so callers decide dispatch by identity (never by spelling): a
+        shadowing local, a rebound global, or an absent attribute all fail the downstream identity check.
         """
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and not self._is_local(func.value.id):
-            module = self._fn.__globals__.get(func.value.id)
-            return _intrinsic_of(getattr(module, func.attr, None)) if module is math or module is np else None
+            return getattr(self._fn.__globals__.get(func.value.id), func.attr, None)
         if isinstance(func, ast.Name) and not self._is_local(func.id):
-            return _intrinsic_of(self._fn.__globals__.get(func.id))
+            return self._fn.__globals__.get(func.id)
         return None
+
+    def _intrinsic_name(self, func: ast.expr) -> str | None:
+        """The canonical intrinsic name if ``func`` resolves to a supported ``math``/``numpy`` function, else None."""
+        return _intrinsic_of(self._resolved_callee(func))
+
+    def _is_np_matmul(self, func: ast.expr) -> bool:
+        """Dispatched apart from the scalar intrinsics because matmul is aggregate-valued."""
+        return self._resolved_callee(func) is np.matmul
 
     def _numpy_function(self, func: ast.expr) -> str | None:
         """
@@ -1441,7 +1707,7 @@ class _Lowerer:
         return None
 
     def _lower_args(self, node: ast.Call) -> list[Value]:
-        """A ``*aggregate`` argument is spliced in place (its leaves inlined into the positional list)."""
+        """A ``*aggregate`` argument is spliced in place: its top-level items (a matrix's rows) inline, as in Python."""
         args: list[Value] = []
         for arg in node.args:
             if isinstance(arg, ast.Starred):
@@ -1579,7 +1845,7 @@ class _Lowerer:
             if base_value is None:
                 raise UnsupportedConstruct("a negative power is only supported for a constant base", self._loc(base))
             return self._builder.float_const(base_value**n)
-        base_id = self._scalar(self._lower_expr(base), base)
+        base_id = self._float_operand(self._lower_expr(base), base)
         if n == 0:
             return self._builder.float_const(1.0)
         result = base_id
@@ -1599,6 +1865,9 @@ class _Lowerer:
         if cast is not None and cast[0] == "float":
             condition = self._static_bool(cast[1])  # float(<static bool>) -> 1.0 / 0.0; float(<static float>) identity
             return (1.0 if condition else 0.0) if condition is not None else self._static_float(cast[1])
+        element = _real_or_none(self._static_ndarray_element(node))
+        if element is not None:
+            return element
         match node:
             case ast.Constant(value=(int() | float()) as value) if not isinstance(value, bool):
                 return float(value)
@@ -1634,28 +1903,138 @@ class _Lowerer:
                 integer = self._static_int(node)
                 return None if integer is None else float(integer)
 
+    def _as_array(self, value: Value, numpy_fn: str, loc: SourceLocation) -> Value:
+        """
+        The ``np.array``/``asarray``/``asanyarray`` factory: convert a Python list/tuple into a numpy array by
+        rebuilding every nested aggregate with array semantics (scalar leaves unchanged, a scalar argument stays a
+        scalar). numpy rejects a ragged array literal, so a non-rectangular aggregate is rejected here too.
+        """
+        if isinstance(value, Aggregate) and array_shape(value) is None:
+            raise UnsupportedConstruct(f"np.{numpy_fn}() requires a rectangular (non-ragged) list/tuple", loc)
+        match value:
+            case Scalar():
+                return value
+            case Aggregate(items=items):
+                return Aggregate(tuple(self._as_array(item, numpy_fn, loc) for item in items), array=True)
+        raise TypeError(f"unexpected value {value!r}")
+
+    def _reject_sequence_operand(self, value: Value, what: str, loc: SourceLocation) -> None:
+        """
+        Reject a numpy-only operation applied to a plain Python list/tuple aggregate. Under Python sequence semantics
+        the operation is undefined (list ``+`` concatenates, list ``-``/``@``/``.T``/``.flatten()`` are errors), so the
+        user must build a numpy array; a scalar or an array operand passes.
+        """
+        if isinstance(value, Aggregate) and not value.array:
+            raise UnsupportedConstruct(
+                f"{what} on a Python list/tuple is not supported; build a numpy array with np.array([...])", loc
+            )
+
     def _apply_binop(self, op: ast.operator, a: Value, b: Value, loc: SourceLocation) -> Value:
+        if isinstance(op, ast.MatMult):
+            return self._lower_matmul(a, b, loc)
+        if isinstance(a, Aggregate) or isinstance(b, Aggregate):
+            # Elementwise arithmetic is a numpy operation; a Python list/tuple operand (including a scalar broadcast
+            # like ``list * s``) is rejected. The recursion below only ever revisits array-internal or scalar values.
+            self._reject_sequence_operand(a, "arithmetic", loc)
+            self._reject_sequence_operand(b, "arithmetic", loc)
+            return self._elementwise(op, a, b, loc)
+        # Reject an unsupported operator before the float-operand check, so its diagnostic wins over the operand one.
+        if not isinstance(op, (ast.Mult, ast.Add, ast.Sub, ast.Div)):
+            raise UnsupportedConstruct(f"unsupported binary operator {type(op).__name__}", loc)
+        a_id, b_id = self._float_operand(a, loc), self._float_operand(b, loc)
         match op:
             case ast.Mult():
-                # Scalar*scalar, or the elementwise broadcast of a scalar over an aggregate's leaves (vector*scalar).
-                if isinstance(a, Aggregate) and isinstance(b, Scalar):
-                    return self._broadcast(a, b.id)
-                if isinstance(a, Scalar) and isinstance(b, Aggregate):
-                    return self._broadcast(b, a.id)
-                if isinstance(a, Aggregate) or isinstance(b, Aggregate):
-                    raise UnsupportedConstruct(
-                        "elementwise aggregate-by-aggregate multiplication is not supported", loc
-                    )
-                return Scalar(self._builder.operation(FloatMul(), [self._scalar(a, loc), self._scalar(b, loc)]))
+                return Scalar(self._builder.operation(FloatMul(), [a_id, b_id]))
             case ast.Add():
-                return Scalar(self._builder.operation(FloatAdd(), [self._scalar(a, loc), self._scalar(b, loc)]))
+                return Scalar(self._builder.operation(FloatAdd(), [a_id, b_id]))
             case ast.Sub():
-                negated = self._builder.operation(FloatNeg(), [self._scalar(b, loc)])
-                return Scalar(self._builder.operation(FloatAdd(), [self._scalar(a, loc), negated]))
-            case ast.Div():
-                return Scalar(self._builder.operation(FloatDiv(), [self._scalar(a, loc), self._scalar(b, loc)]))
+                negated = self._builder.operation(FloatNeg(), [b_id])
+                return Scalar(self._builder.operation(FloatAdd(), [a_id, negated]))
             case _:
-                raise UnsupportedConstruct(f"unsupported binary operator {type(op).__name__}", loc)
+                return Scalar(self._builder.operation(FloatDiv(), [a_id, b_id]))
+
+    def _elementwise(self, op: ast.operator, a: Value, b: Value, loc: SourceLocation) -> Value:
+        """
+        Apply a binary arithmetic operator elementwise: two aggregate operands must have identical structure (zipped
+        level by level), while a scalar operand broadcasts against every leaf of the other side, preserving its shape.
+        This is deliberately narrower than numpy broadcasting -- a mixed-rank pair such as vector + matrix is rejected
+        rather than silently aligned along a different axis than numpy would pick.
+        """
+        # Name an unsupported operator before checking shapes, so its diagnostic wins over a mismatched-shape one.
+        if not isinstance(op, (ast.Mult, ast.Add, ast.Sub, ast.Div)):
+            raise UnsupportedConstruct(f"unsupported binary operator {type(op).__name__}", loc)
+        if isinstance(a, Aggregate) and isinstance(b, Aggregate):
+            return self._zip_elementwise(op, a, b, loc)
+        match (a, b):
+            case (Aggregate(items=items), Scalar()):
+                return Aggregate(tuple(self._elementwise(op, item, b, loc) for item in items), array=True)
+            case (Scalar(), Aggregate(items=items)):
+                return Aggregate(tuple(self._elementwise(op, a, item, loc) for item in items), array=True)
+            case _:
+                return self._apply_binop(op, a, b, loc)
+
+    def _zip_elementwise(self, op: ast.operator, a: Value, b: Value, loc: SourceLocation) -> Value:
+        match (a, b):
+            case (Scalar(), Scalar()):
+                return self._apply_binop(op, a, b, loc)
+            case (Aggregate(items=items_a), Aggregate(items=items_b)) if len(items_a) == len(items_b):
+                return Aggregate(
+                    tuple(self._zip_elementwise(op, x, y, loc) for x, y in zip(items_a, items_b)), array=True
+                )
+            case _:
+                raise UnsupportedConstruct(
+                    "elementwise operands have mismatched shapes "
+                    "(only same-shape operands and scalar broadcasts are supported)",
+                    loc,
+                )
+
+    def _lower_matmul(self, a: Value, b: Value, loc: SourceLocation) -> Value:
+        """
+        Expand ``a @ b`` into scalar multiply/add chains, following numpy's shape rules exactly: operands are 1-D or
+        2-D rectangular arrays with an agreeing inner dimension; a 1-D left operand is promoted to a row, a 1-D right
+        operand to a column, and each promoted axis is dropped from the result -- so vector @ vector is a scalar dot
+        product. There is no batching (ndim > 2) and no hardware aggregate: the result is an ordinary compile-time
+        aggregate of scalar dot products.
+        """
+        self._reject_sequence_operand(a, "the matrix product", loc)
+        self._reject_sequence_operand(b, "the matrix product", loc)
+        shape_a, shape_b = array_shape(a), array_shape(b)
+        if shape_a is None or shape_b is None:
+            raise UnsupportedConstruct("matmul operands must be rectangular vectors or matrices", loc)
+        if shape_a == () or shape_b == ():
+            raise UnsupportedConstruct("matmul does not accept scalar operands", loc)
+        if len(shape_a) > 2 or len(shape_b) > 2:
+            raise UnsupportedConstruct(
+                f"matmul operands must be 1-D or 2-D, got {len(shape_a)}-D @ {len(shape_b)}-D", loc
+            )
+        if shape_a[-1] != shape_b[0]:
+            raise UnsupportedConstruct(f"matmul dimension mismatch: {shape_name(shape_a)} @ {shape_name(shape_b)}", loc)
+        self._require_float_leaves(a, "matmul operands must be floating-point", loc)
+        self._require_float_leaves(b, "matmul operands must be floating-point", loc)
+        rows = [a] if len(shape_a) == 1 else list(self._row_items(a))
+        cols = [b] if len(shape_b) == 1 else list(self._row_items(self._transpose(b, loc)))
+        leaves = [self._dot(self._row_items(row), self._row_items(col), loc) for row in rows for col in cols]
+        return array_of((*shape_a[:-1], *shape_b[1:]), leaves, array=True)
+
+    @staticmethod
+    def _row_items(value: Value) -> tuple[Value, ...]:
+        assert isinstance(value, Aggregate)
+        return value.items
+
+    def _require_float_leaves(self, value: Value, message: str, loc: SourceLocation) -> None:
+        for vid in value.leaves():
+            if not isinstance(self._builder.type_of(vid), FloatType):
+                raise UnsupportedConstruct(message, loc)
+
+    def _dot(self, xs: tuple[Value, ...], ys: tuple[Value, ...], loc: SourceLocation) -> Scalar:
+        # A left fold rather than a balanced tree: it keeps every product single-use with an add of the running sum,
+        # which is exactly the shape MIR's FMA contraction fuses into one fmul plus a chain of ffma when configured.
+        acc: ValueId | None = None
+        for x, y in zip(xs, ys, strict=True):
+            term = self._builder.operation(FloatMul(), [self._scalar(x, loc), self._scalar(y, loc)])
+            acc = term if acc is None else self._builder.operation(FloatAdd(), [acc, term])
+        assert acc is not None
+        return Scalar(acc)
 
     _RELATIONAL_OPS: dict[type[ast.cmpop], RelationalOp] = {
         ast.Lt: RelationalOp.LT,
@@ -1809,18 +2188,50 @@ class _Lowerer:
         self._builder.position_at(merge_block)
         return self._merge_values(then, else_, then_end, else_end, loc)
 
-    def _broadcast(self, value: Value, scalar: ValueId) -> Value:
-        """The one elementwise vector op: every scalar leaf is multiplied by ``scalar``, preserving shape."""
-        if isinstance(value, Aggregate):
-            return Aggregate(tuple(self._broadcast(item, scalar) for item in value.items))
-        assert isinstance(value, Scalar)
-        return Scalar(self._builder.operation(FloatMul(), [value.id, scalar]))
+    def _transpose(self, value: Value, loc: SourceLocation) -> Value:
+        """
+        ``.T`` with numpy semantics over the supported shapes: identity on a 1-D vector, row/column swap on a 2-D
+        matrix; a scalar, a ragged aggregate, or a deeper nesting is rejected.
+        """
+        self._reject_sequence_operand(value, "transpose", loc)
+        match array_shape(value):
+            case None:
+                raise UnsupportedConstruct("only a rectangular vector or matrix can be transposed", loc)
+            case ():
+                raise UnsupportedConstruct("cannot transpose a scalar value", loc)
+            case (_,):
+                return value
+            case (_, _):
+                columns = zip(*[self._row_items(row) for row in self._row_items(value)])
+                return Aggregate(tuple(Aggregate(column, array=True) for column in columns), array=True)
+            case shape:
+                raise UnsupportedConstruct(f"transpose of a {len(shape)}-D value is not supported", loc)
+
+    def _negate(self, value: Value, loc: SourceLocation) -> Value:
+        self._reject_sequence_operand(value, "arithmetic", loc)
+        match value:
+            case Scalar():
+                return Scalar(self._builder.operation(FloatNeg(), [self._float_operand(value, loc)]))
+            case Aggregate(items=items):
+                return Aggregate(tuple(self._negate(item, loc) for item in items), array=True)
+        raise TypeError(f"unexpected value {value!r}")
 
     def _scalar(self, value: Value, where: ast.AST | SourceLocation) -> ValueId:
         if isinstance(value, Scalar):
             return value.id
         loc = where if isinstance(where, SourceLocation) else self._loc(where)
         raise UnsupportedConstruct(f"expected a scalar value here, got a {len(value.leaves())}-element aggregate", loc)
+
+    def _float_operand(self, value: Value, where: ast.AST | SourceLocation) -> ValueId:
+        """
+        A scalar operand for a floating-point operator, rejecting a boolean with a source location rather than letting
+        it reach HIR construction as a bare, location-less type error.
+        """
+        vid = self._scalar(value, where)
+        if isinstance(self._builder.type_of(vid), BoolType):
+            loc = where if isinstance(where, SourceLocation) else self._loc(where)
+            raise UnsupportedConstruct("arithmetic operands must be floating-point, not boolean", loc)
+        return vid
 
     def _reject_shortcircuit_walrus(self, node: ast.AST) -> None:
         """
@@ -1884,6 +2295,11 @@ class _Lowerer:
 
     def _is_local(self, name: str) -> bool:
         return name in self._local_names[self._fn]
+
+    def _constant_array(self, name: str, value: np.ndarray, loc: SourceLocation) -> Value:
+        """A module-level ndarray constant folds into an aggregate of interned float constants, like a literal."""
+        shape, reals = _ndarray_reals(value, f"module constant {name!r}", loc)
+        return array_of(shape, [Scalar(self._builder.float_const(x)) for x in reals], array=True)
 
     def _module_global(self, name: str) -> object:
         """
@@ -2020,7 +2436,8 @@ class _Lowerer:
         The reset-snapshot value of a self attribute eligible for compile-time folding, or ``_ABSENT`` when none is. An
         attribute folds only if it is never assigned on a reachable path (``_attr_assigned_set``) and is not a class
         data descriptor (read through the descriptor, never as a stored value -- ``_is_class_data_descriptor``). Shared
-        by ``_static_int``, ``_static_bool``, and ``_static_float`` so all three fold a read-only attribute the same.
+        by the static evaluators (``_static_int``/``_static_bool``/``_static_float``/``_static_ndarray_value``) so they
+        fold a read-only attribute the same.
         """
         if attr in self._attr_assigned_set() or self._is_class_data_descriptor(attr):
             return _ABSENT
@@ -2076,18 +2493,34 @@ class _Lowerer:
         attr = self._attr_of(target)
         shape = self._shape(attr)
         if not shape.accepts(value):
-            kind = f"a {len(shape.slots)}-element vector" if shape.is_vector else "a scalar"
             raise UnsupportedConstruct(
-                f"self.{attr} is {kind}; the assigned value has an incompatible shape", self._loc(target)
+                f"self.{attr} is {shape_name(shape.shape)}; the assigned value has an incompatible shape",
+                self._loc(target),
             )
+        # The reset snapshot fixes whether the attribute reads back as a numpy array or a Python list next transaction;
+        # storing the other flavor would round-trip wrong (a list stored into an ndarray slot reads back as an array),
+        # so the assigned value's flavor must match. A scalar attribute has no flavor.
+        if isinstance(value, Aggregate) and value.array != shape.array:
+            held, given = ("a numpy array", "a Python list") if shape.array else ("a Python list", "a numpy array")
+            raise UnsupportedConstruct(f"self.{attr} holds {held}; the assigned value is {given}", self._loc(target))
+        # The slot bank is fixed by the reset snapshot; a written leaf whose bank differs (a bool into a float slot or
+        # vice versa) would leave the slot's live-in and live-out disagreeing, so it is rejected here rather than
+        # producing a mistyped state register.
+        for reset, vid in zip(shape.resets, value.leaves()):
+            expected: Type = BoolType() if isinstance(reset, BoolConst) else FloatType()
+            if self._builder.type_of(vid) != expected:
+                raise UnsupportedConstruct(
+                    f"self.{attr} holds {_hir_type_name(expected)} values; the assigned value has an incompatible type",
+                    self._loc(target),
+                )
         self._state_env[attr] = value
 
     def _shape(self, attr: str) -> StateAttr:
         """
         The scalar-slot decomposition of an instance attribute, derived once from the reset snapshot and memoized so it
-        is the single source of the attribute's shape. A list/tuple or 1-D numpy array is a vector; a real number is a
-        scalar. A jaxtyping array annotation, when present, must agree with the value; a shape-less annotation
-        (``list``, ``numpy.typing.NDArray``) leaves the shape to the value.
+        is the single source of the attribute's shape. A list/tuple is a vector, a numpy array a vector or matrix, and
+        a real number a scalar. A jaxtyping array annotation, when present, must agree with the value; a shape-less
+        annotation (``list``, ``numpy.typing.NDArray``) leaves the shape to the value.
         """
         if attr not in self._shapes:
             self._shapes[attr] = self._derive_shape(attr)
@@ -2096,33 +2529,30 @@ class _Lowerer:
     def _derive_shape(self, attr: str) -> StateAttr:
         value = self._snapshot[attr]
         self._check_annotation(attr, value)
+        what = f"instance attribute self.{attr}"
         if isinstance(value, (bool, np.bool_)):  # checked before the numeric paths: bool is an int subclass
-            return StateAttr(is_vector=False, slots=[attr], resets=[BoolConst(bool(value))])
-        elements = self._aggregate_elements(attr, value)
-        if elements is None:
-            return StateAttr(False, [attr], [FloatConst(self._coerce_real(attr, value))])
-        slots = [f"{attr}_{index}" for index in range(len(elements))]
-        return StateAttr(True, slots, [FloatConst(self._coerce_real(attr, element)) for element in elements])
-
-    def _aggregate_elements(self, attr: str, value: object) -> list[object] | None:
+            return StateAttr(shape=(), slots=[attr], resets=[BoolConst(bool(value))], array=False)
+        # An ndarray reset carries numpy array semantics; a list/tuple reset carries Python sequence semantics.
+        array = isinstance(value, np.ndarray)
         if isinstance(value, np.ndarray):
-            if value.ndim != 1:
-                raise UnsupportedConstruct(
-                    f"instance attribute self.{attr} must be a scalar or 1-D array, got a {value.ndim}-D array"
-                )
-            return list(value)
-        if isinstance(value, (list, tuple)):
-            return list(value)
-        return None
+            shape, reals = _ndarray_reals(value, what)
+        elif isinstance(value, (list, tuple)):
+            if not value:
+                raise UnsupportedConstruct(f"{what} must not be an empty array")
+            shape, reals = (len(value),), [self._coerce_real(attr, element) for element in value]
+        else:
+            shape, reals = (), [self._coerce_real(attr, value)]
+        resets: list[Const] = [FloatConst(x) for x in reals]
+        return StateAttr(shape, indexed_names(attr, shape), resets, array=array)
 
     def _check_annotation(self, attr: str, value: object) -> None:
         """
         Enforce a jaxtyping array annotation against the reset value, so an explicitly declared shape cannot silently
-        disagree with it. A jaxtyping type is a class that exposes ``dims`` and validates shape and dtype via
-        ``isinstance``; a generic alias (``list[float]``, ``numpy.typing.NDArray``) is not a class and states no shape.
+        disagree with it. A jaxtyping type validates shape and dtype via ``isinstance``; a generic alias
+        (``list[float]``, ``numpy.typing.NDArray``) is not a class and states no shape.
         """
         annotation = self._annotation_of(attr)
-        if isinstance(annotation, type) and hasattr(annotation, "dims") and not isinstance(value, annotation):
+        if _is_array_annotation(annotation) and not isinstance(value, annotation):
             raise UnsupportedConstruct(f"self.{attr} value does not satisfy its declared array type {annotation}")
 
     def _annotation_of(self, attr: str) -> Any:
@@ -2135,17 +2565,19 @@ class _Lowerer:
         return None
 
     def _coerce_real(self, attr: str, value: object) -> float:
-        if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, float, np.integer, np.floating)):
+        real = _real_or_none(value)
+        if real is None:
             raise UnsupportedConstruct(
-                f"instance attribute self.{attr} must be a real number or a sequence of reals, "
-                f"got {type(value).__name__}"
+                f"instance attribute self.{attr} must hold real numbers (a matrix reset must be a 2-D numpy array, "
+                f"not nested lists), got {type(value).__name__}"
             )
-        return float(value)
+        return real
 
     def _check_state_slot_names(self) -> None:
         """
-        A vector attribute decomposes into slots ``attr_0, attr_1, ...``; guard against such a slot name coinciding with
-        another attribute's slot (e.g. a vector ``v`` and a scalar ``v_0``), which would otherwise alias distinct state.
+        A vector or matrix attribute decomposes into slots ``attr_0, attr_1, ...`` / ``attr_0_0, ...``; guard against
+        such a slot name coinciding with another attribute's slot (e.g. a vector ``v`` and a scalar ``v_0``), which
+        would otherwise alias distinct state.
         """
         owner: dict[str, str] = {}
         for attr in self._state_order:

--- a/tests/_examples.py
+++ b/tests/_examples.py
@@ -26,6 +26,7 @@ from ._modelref import (
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
 import ekf1_stateful as ekf1_stateful  # noqa: E402
 import ekf1_stateless as ekf1_stateless  # noqa: E402
+import imu_frame_transform as imu_frame_transform  # noqa: E402  # synth matrix only; matrix/vector I/O has no scalar SPEC
 import madd  # noqa: E402
 import poly3  # noqa: E402
 from cordic_sincos import CordicSinCos as CordicSinCos  # noqa: E402

--- a/tests/_examples.py
+++ b/tests/_examples.py
@@ -80,8 +80,9 @@ class ReferenceComparison(Enum):
     EXACT: every float output is exact in the format (boolean logic, integer-valued counters/bytes, or exact
     Sterbenz reductions), so it must match the float64 reference bit-for-bit. APPROXIMATE: float outputs
     accumulate rounding (continuous arithmetic), so the comparison allows a format-derived tolerance. EXCLUDED:
-    the result is purely persistent public VECTOR state with no scalar lane to compare, so the scalar harness
-    skips it -- its aggregate-state read-back is validated against Python separately in ``test_verify``.
+    the generic scalar-lane harness cannot drive the kernel -- it has public VECTOR state it would read by a
+    non-existent per-element attribute -- so its aggregate-state read-back is validated against Python separately in
+    ``test_verify``.
     """
 
     EXACT = "exact"

--- a/tests/_modelref.py
+++ b/tests/_modelref.py
@@ -11,7 +11,7 @@ import numpy as np
 from holoso import FAddOperator, FCmpOperator, FDivOperator, FMulILog2OperatorFamily, FMulOperator, OpConfig
 from holoso._backend.numerical import NumericalSimulator, generate as generate
 from holoso._frontend import lower as lower_frontend
-from holoso._hir import optimize
+from holoso._hir import Hir, Operation, Operator, optimize
 from holoso._lir import Lir, build
 from holoso._mir import MirInterpreter, lower as lower_to_mir
 from holoso._type import FloatFormat
@@ -45,6 +45,11 @@ def build_model_and_interpreter(
     return build_model(build(mir, name, fetch_stages=3)), MirInterpreter(mir)
 
 
+def arith_count(hir: Hir, op_type: type[Operator]) -> int:
+    """The number of HIR operations whose operator is exactly ``op_type`` -- a structural probe for lowering tests."""
+    return sum(1 for n in hir.nodes.values() if isinstance(n, Operation) and type(n.operator) is op_type)
+
+
 def show_value(value: FloatValue | bool) -> str:
     return f"{float(value):.6g}" if isinstance(value, FloatValue) else str(value)
 
@@ -64,9 +69,12 @@ def assert_model_equals_interpreter(
 
 
 def flatten_value(root: object) -> list[tuple[Path, Any]]:
+    # An ndarray flattens row-major (via tolist), matching the frontend's leaf order for array-valued kernel results.
     leaves: list[tuple[Path, Any]] = []
 
     def walk(node: object, path: Path) -> None:
+        if isinstance(node, np.ndarray):
+            node = node.tolist()
         if isinstance(node, (list, tuple)) and not isinstance(node, str):
             for index, item in enumerate(node):
                 walk(item, [*path, index])
@@ -76,6 +84,8 @@ def flatten_value(root: object) -> list[tuple[Path, Any]]:
         else:
             leaves.append((path, node))
 
+    if isinstance(root, np.ndarray):
+        root = root.tolist()
     if (isinstance(root, (list, tuple)) and not isinstance(root, str)) or (
         dataclasses.is_dataclass(root) and not isinstance(root, type)
     ):

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -19,6 +19,7 @@ from holoso import (
     FAddOperator,
     FCmpOperator,
     FDivOperator,
+    FFmaOperator,
     FloatFormat,
     FMulILog2OperatorFamily,
     FMulOperator,
@@ -26,7 +27,7 @@ from holoso import (
 )
 from synth.flows import FlowId
 
-from ._examples import SPECS, ekf1_stateful
+from ._examples import SPECS, ekf1_stateful, imu_frame_transform
 
 F_e6m18 = FloatFormat(6, 18)
 F_e8m36 = FloatFormat(8, 36)
@@ -41,14 +42,20 @@ def op_config(
     fdiv: FDivOperator | None = None,
     fmul_ilog2: FMulILog2OperatorFamily | None = None,
     fcmp: FCmpOperator | None = None,
+    ffma: FFmaOperator | None = None,
 ) -> OpConfig:
-    """The OpConfig for fmt; pass a fully-constructed operator to give it stage knobs, else that operator is lean."""
+    """
+    The OpConfig for fmt; pass a fully-constructed operator to give it stage knobs, else that operator is lean. ffma is
+    absent unless supplied, so multiply-accumulate chains stay expanded (fmul + fadd) rather than contracting to fused
+    FMAs.
+    """
     return OpConfig(
         fadd=fadd or FAddOperator(fmt),
         fmul=fmul or FMulOperator(fmt),
         fdiv=fdiv or FDivOperator(fmt),
         fmul_ilog2=fmul_ilog2 or FMulILog2OperatorFamily(fmt),
         fcmp=fcmp or FCmpOperator(fmt),
+        ffma=ffma,
     )
 
 
@@ -116,6 +123,12 @@ def _ekf1_stateful_kernel() -> Callable[..., object]:
     # synthesize. SPEC.make_kernel instead uses _fresh_stateful_ekf, a cosim-only divisor-safe reset that folds
     # different constants into different RTL, so the synth rows pass this explicitly.
     return ekf1_stateful.Ekf1().update
+
+
+def _imu_frame_transform_kernel() -> Callable[..., object]:
+    # Off-catalogue: the shaped matrix/vector ports have no scalar-lane SPEC, so this stateless kernel is referenced
+    # directly rather than through the cosim registry.
+    return imu_frame_transform.transform
 
 
 TARGETS: list[SynthTarget] = [
@@ -360,6 +373,71 @@ TARGETS: list[SynthTarget] = [
             fdiv=FDivOperator(F_e8m36, stage_input=1, stage_pack=1, stage_output=1),
         ),
         kernel=_ekf1_stateful_kernel,
+    ),
+    # imu_frame_transform: a stack of static 3x3 matrix products -- the widest, most multiply-heavy datapath in the
+    # suite -- off-catalogue (matrix/vector ports have no scalar-lane SPEC). Two datapaths per flow: the plain
+    # fmul+fadd expansion, and the ffma-contracted form where each dot-product multiply-accumulate fuses into a single
+    # rounding. Stage knobs are the measured lean-start closure per (flow, datapath).
+    SynthTarget(
+        kernel=_imu_frame_transform_kernel,
+        flow=FlowId.YOSYS_ECP5,
+        target_frequency_MHz=100,
+        ops=op_config(
+            F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_decode=1),
+            fmul=FMulOperator(F_e6m18, stage_product=1),
+            fmul_ilog2=FMulILog2OperatorFamily(F_e6m18, stage_decode=1),
+        ),
+        name="imu_frame_transform_e6m18",
+    ),
+    SynthTarget(
+        kernel=_imu_frame_transform_kernel,
+        flow=FlowId.DIAMOND_ECP5,
+        target_frequency_MHz=100,
+        ops=op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_input=1)),
+        name="imu_frame_transform_e6m18",
+    ),
+    SynthTarget(
+        kernel=_imu_frame_transform_kernel,
+        flow=FlowId.VIVADO_ARTIX7,
+        target_frequency_MHz=150,
+        ops=op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1)),
+        name="imu_frame_transform_e6m18",
+    ),
+    SynthTarget(
+        kernel=_imu_frame_transform_kernel,
+        flow=FlowId.YOSYS_ECP5,
+        target_frequency_MHz=100,
+        ops=op_config(
+            F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_input=1, stage_decode=1, stage_pack=1),
+            fmul=FMulOperator(F_e6m18, stage_product=1),
+            ffma=FFmaOperator(F_e6m18, stage_product=1, stage_decode=1, stage_normalize=1, stage_pack=1),
+        ),
+        name="imu_frame_transform_e6m18_fma",
+    ),
+    SynthTarget(
+        kernel=_imu_frame_transform_kernel,
+        flow=FlowId.DIAMOND_ECP5,
+        target_frequency_MHz=100,
+        ops=op_config(
+            F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_normalize=1),
+            fmul=FMulOperator(F_e6m18, stage_output=1),
+            ffma=FFmaOperator(F_e6m18, stage_normalize=1, stage_pack=1),
+        ),
+        name="imu_frame_transform_e6m18_fma",
+    ),
+    SynthTarget(
+        kernel=_imu_frame_transform_kernel,
+        flow=FlowId.VIVADO_ARTIX7,
+        target_frequency_MHz=150,
+        ops=op_config(
+            F_e6m18,
+            fmul=FMulOperator(F_e6m18, stage_product=1),
+            ffma=FFmaOperator(F_e6m18, stage_product=1, stage_normalize=1),
+        ),
+        name="imu_frame_transform_e6m18_fma",
     ),
 ]
 

--- a/tests/test_example_reference.py
+++ b/tests/test_example_reference.py
@@ -25,9 +25,9 @@ from holoso import BoolType, FloatFormat
 from ._examples import SPECS, ExampleSpec, ReferenceComparison
 from ._modelref import default_ops, default_tolerance, flatten_value, within
 
-# A kernel whose result is purely persistent PUBLIC VECTOR state (``ReferenceComparison.EXCLUDED`` -- ``ekf1_stateful``,
-# whose ``update`` returns nothing) is excluded: this generic harness compares scalar lanes only, and that kernel's
-# aggregate-state read-back is already validated against the Python reference in ``test_verify.py``. Every other example
+# A kernel the generic scalar-lane harness cannot drive (``ReferenceComparison.EXCLUDED``) is skipped here: it has
+# public VECTOR state this harness would read by a non-existent per-element attribute (``ekf1_stateful``); its
+# aggregate-state read-back is validated against the Python reference in ``test_verify.py`` instead. Every other example
 # returns its outputs (optionally alongside scalar public state), which this harness compares directly.
 #
 # A public state attribute drives an output port named ``state_<attr>``; a return value drives ``out_<n>``. The model

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -44,11 +44,7 @@ from holoso._hir import (
     StateRead,
 )
 
-from ._modelref import flatten_value, output_names
-
-
-def _arith_count(hir: Hir, op_type: type) -> int:
-    return sum(1 for n in hir.nodes.values() if isinstance(n, Operation) and type(n.operator) is op_type)
+from ._modelref import arith_count as _arith_count, flatten_value, output_names
 
 
 def test_scalar_is_output_zero() -> None:
@@ -1022,8 +1018,8 @@ def test_list_slice() -> None:
 
 def test_vector_scalar_broadcast() -> None:
     def f(a: float, b: float) -> list[float]:
-        v = [a, b]
-        return v * 0.5  # type: ignore[no-any-return, operator]
+        v = np.array([a, b])
+        return v * 0.5  # type: ignore[return-value]
 
     hir = lower(f)
     assert _arith_count(hir, FloatMul) == 2
@@ -1032,8 +1028,8 @@ def test_vector_scalar_broadcast() -> None:
 
 def test_flatten_collapses_nesting() -> None:
     def f(a: float, b: float) -> list[float]:
-        m = [[a], [b]]
-        return m.flatten()  # type: ignore[no-any-return, attr-defined]
+        m = np.array([[a], [b]])
+        return m.flatten()  # type: ignore[return-value]
 
     assert [o.name for o in lower(f).outputs] == ["out_0", "out_1"]
 
@@ -1216,18 +1212,25 @@ def test_abs_accepts_a_star_unpacked_argument() -> None:
     assert _arith_count(lower(f), FloatAbs) == 1
 
 
-def test_unary_plus_is_scalar_identity_and_rejects_aggregates() -> None:
+def test_unary_plus_and_minus_apply_elementwise_to_aggregates() -> None:
     def scalar_ok(a: float) -> float:
         return +a
 
     assert [o.name for o in lower(scalar_ok).outputs] == ["out_0"]
 
-    def aggregate_bad(a: float, b: float) -> list[float]:
-        v = [a, b]
-        return +v  # type: ignore[no-any-return, operator]
+    def aggregate_ok(a: float, b: float) -> list[float]:
+        v = np.array([a, b])
+        return +v  # type: ignore[return-value]
 
-    with pytest.raises(UnsupportedConstruct, match="scalar"):
-        lower(aggregate_bad)
+    assert [o.name for o in lower(aggregate_ok).outputs] == ["out_0", "out_1"]
+
+    def negated(a: float, b: float) -> list[float]:
+        v = np.array([a, b])
+        return -v  # type: ignore[return-value]
+
+    hir = lower(negated)
+    assert [o.name for o in hir.outputs] == ["out_0", "out_1"]
+    assert _arith_count(hir, FloatNeg) == 2
 
 
 def test_method_style_abs_call_is_rejected() -> None:
@@ -1381,7 +1384,7 @@ def test_name_assigned_later_is_local_before_its_assignment() -> None:
         lower(shadows_builtin)
 
 
-def test_multidimensional_array_state_is_rejected() -> None:
+def test_matrix_state_decomposes_row_major() -> None:
     @dataclasses.dataclass
     class Filt:
         m: np.ndarray
@@ -1389,8 +1392,22 @@ def test_multidimensional_array_state_is_rejected() -> None:
         def step(self, a: float) -> None:
             self.m = self.m * a
 
-    with pytest.raises(UnsupportedConstruct, match="1-D"):
-        lower(Filt(np.array([[1.0, 2.0], [3.0, 4.0]])).step)
+    hir = lower(Filt(np.array([[1.0, 2.0], [3.0, 4.0]])).step)
+    assert [s.name for s in hir.state_slots] == ["m_0_0", "m_0_1", "m_1_0", "m_1_1"]
+    assert [cast(FloatConst, s.reset_value).value for s in hir.state_slots] == [1.0, 2.0, 3.0, 4.0]
+    assert [o.name for o in hir.outputs] == ["state_m_0_0", "state_m_0_1", "state_m_1_0", "state_m_1_1"]
+
+
+def test_three_dimensional_array_state_is_rejected() -> None:
+    @dataclasses.dataclass
+    class Filt:
+        m: np.ndarray
+
+        def step(self, a: float) -> None:
+            self.m = self.m * a
+
+    with pytest.raises(UnsupportedConstruct, match="3-D"):
+        lower(Filt(np.zeros((2, 2, 2))).step)
 
 
 def test_ekf1_stateful_structure() -> None:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -79,6 +79,15 @@ def _run(sim: holoso.NumericalSimulator, *arrays: np.ndarray | float) -> np.ndar
     return np.array([float(v) for v in sim.run(*flat)])
 
 
+def _assert_python_matches_holoso(fn: Callable[..., object], *inputs: np.ndarray | float) -> None:
+    # Runs the kernel as plain Python and asserts it agrees with Holoso; the Python call also proves the kernel is
+    # genuinely valid, runnable Python, so a construct Holoso accepts but Python rejects fails here instead of passing
+    # as a spurious "positive" (e.g. ``mat + [1, 2]`` sneaking into a success test).
+    want = np.asarray(fn(*inputs)).flatten()
+    got = _run(_sim(fn), *inputs)
+    assert np.allclose(got, want, rtol=1e-9, atol=1e-300), fn.__name__
+
+
 # ---------------------------------------------------------------- structure
 
 
@@ -90,21 +99,33 @@ def test_matmul_shapes_and_port_layout() -> None:
     assert hir.input_names() == ["a_0_0", "a_0_1", "a_0_2", "a_1_0", "a_1_1", "a_1_2", "x_0", "x_1", "x_2"]
     assert [o.name for o in hir.outputs] == ["out_0", "out_1"]
     assert _arith_count(hir, FloatMul) == 6 and _arith_count(hir, FloatAdd) == 4
+    _assert_python_matches_holoso(mat_vec, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), np.array([1.0, 0.0, -1.0]))
+    _assert_python_matches_holoso(mat_vec, np.array([[0.5, -1.0, 2.0], [3.0, -2.0, 0.25]]), np.array([2.0, -1.0, 0.5]))
 
     def vec_mat(x: Float64[np.ndarray, "2"], a: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "3"]:
         return x @ a  # type: ignore[no-any-return]
 
     assert [o.name for o in lower(vec_mat).outputs] == ["out_0", "out_1", "out_2"]
+    _assert_python_matches_holoso(vec_mat, np.array([1.0, -2.0]), np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+    _assert_python_matches_holoso(vec_mat, np.array([0.5, 2.0]), np.array([[-1.0, 0.25, 3.0], [2.0, -2.0, 1.0]]))
 
     def dot(v: Float64[np.ndarray, "3"], w: Float64[np.ndarray, "3"]) -> float:
         return v @ w  # type: ignore[no-any-return]
 
     assert [o.name for o in lower(dot).outputs] == ["out_0"]
+    _assert_python_matches_holoso(dot, np.array([1.0, 2.0, 3.0]), np.array([4.0, -5.0, 6.0]))
+    _assert_python_matches_holoso(dot, np.array([0.5, -1.0, 2.0]), np.array([2.0, 3.0, -1.0]))
 
     def mat_mat(a: Float64[np.ndarray, "2 3"], b: Float64[np.ndarray, "3 2"]) -> Float64[np.ndarray, "2 2"]:
         return a @ b  # type: ignore[no-any-return]
 
     assert [o.name for o in lower(mat_mat).outputs] == ["out_0_0", "out_0_1", "out_1_0", "out_1_1"]
+    _assert_python_matches_holoso(
+        mat_mat, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    )
+    _assert_python_matches_holoso(
+        mat_mat, np.array([[0.5, -1.0, 2.0], [3.0, -2.0, 0.25]]), np.array([[2.0, -1.0], [0.5, 3.0], [-2.0, 1.0]])
+    )
 
 
 def test_matmul_rejections() -> None:
@@ -163,6 +184,8 @@ def test_dot_product_left_fold_contracts_to_fma_chain() -> None:
 
     assert mnemonic_counts(with_fma=True) == {"fmul": 1, "ffma": 2}
     assert mnemonic_counts(with_fma=False) == {"fmul": 3, "fadd": 2}
+    _assert_python_matches_holoso(dot, np.array([1.0, 2.0, 3.0]), np.array([4.0, -5.0, 6.0]))
+    _assert_python_matches_holoso(dot, np.array([0.5, -1.0, 2.0]), np.array([2.0, 3.0, -1.0]))
 
 
 def test_np_matmul_call_is_the_operator() -> None:
@@ -174,6 +197,9 @@ def test_np_matmul_call_is_the_operator() -> None:
 
     ops = (_arith_count(lower(with_operator), FloatMul), _arith_count(lower(with_operator), FloatAdd))
     assert ops == (_arith_count(lower(with_call), FloatMul), _arith_count(lower(with_call), FloatAdd))
+    for kernel in (with_operator, with_call):
+        _assert_python_matches_holoso(kernel, np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([1.0, -1.0]))
+        _assert_python_matches_holoso(kernel, np.array([[0.5, -1.0], [2.0, 0.25]]), np.array([2.0, 3.0]))
 
     def keywords(a: Float64[np.ndarray, "2 2"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
         return np.matmul(a, x, casting="no")  # type: ignore[no-any-return]
@@ -187,6 +213,8 @@ def test_np_matmul_bare_name_import_resolves() -> None:
         return _matmul(a, x)  # type: ignore[no-any-return]
 
     assert [o.name for o in lower(with_bare_name).outputs] == ["out_0", "out_1"]
+    _assert_python_matches_holoso(with_bare_name, np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([1.0, -1.0]))
+    _assert_python_matches_holoso(with_bare_name, np.array([[0.5, -1.0], [2.0, 0.25]]), np.array([2.0, 3.0]))
 
 
 def test_augmented_assignment_to_array_is_rejected() -> None:
@@ -378,11 +406,15 @@ def test_transpose_structure() -> None:
     hir = lower(t)
     assert [o.name for o in hir.outputs] == ["out_0_0", "out_0_1", "out_1_0", "out_1_1", "out_2_0", "out_2_1"]
     assert _arith_count(hir, FloatMul) == 0  # a pure reindexing, no hardware
+    _assert_python_matches_holoso(t, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+    _assert_python_matches_holoso(t, np.array([[-1.0, 0.5, 2.0], [3.0, -2.0, 0.25]]))
 
     def vector_identity(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
         return v.T
 
     assert [o.name for o in lower(vector_identity).outputs] == ["out_0", "out_1"]
+    _assert_python_matches_holoso(vector_identity, np.array([1.0, -2.0]))
+    _assert_python_matches_holoso(vector_identity, np.array([0.5, 3.0]))
 
     def scalar_t(a: float) -> float:
         return a.T  # type: ignore[attr-defined, no-any-return]
@@ -410,6 +442,8 @@ def test_numpy_subscripts() -> None:
         return m[0, 1], m[1][2], column[0], m[1:, 0][0]
 
     assert [o.name for o in lower(picks).outputs] == ["out_0", "out_1", "out_2", "out_3"]
+    _assert_python_matches_holoso(picks, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+    _assert_python_matches_holoso(picks, np.array([[-1.0, 0.5, 2.0], [3.0, -2.0, 0.25]]))
 
     def too_many(m: Float64[np.ndarray, "2 2"]) -> float:
         return m[0, 1, 0]  # type: ignore[no-any-return]

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -6,8 +6,10 @@ numpy executing the very same kernel.
 """
 
 import dataclasses
+import sys
 import warnings
 from collections.abc import Callable
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -1029,3 +1031,21 @@ def test_stateful_kalman_style_filter_matches_numpy_across_transactions() -> Non
         want = np.array([float(v) for v in (*prediction, *reference.x, *reference.P.flatten())])
         assert np.all(np.isfinite(want))
         assert np.allclose(got, want, rtol=1e-9, atol=1e-12), step
+
+
+def test_imu_frame_transform_example_matches_numpy() -> None:
+    # The bundled 3D rigid-body / IMU frame transform example must lower and agree with its own plain-numpy execution,
+    # confirming the matmul/transpose/broadcast composition it demonstrates is valid, runnable Python.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
+    import imu_frame_transform
+
+    yaw90 = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    roll90 = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
+    for rotation in (yaw90, roll90):
+        _assert_python_matches_holoso(
+            imu_frame_transform.transform,
+            rotation,
+            np.array([1.0, 2.0, 3.0]),
+            np.array([0.1, -0.2, 9.9]),
+            np.array([2.0, 0.0, -1.0]),
+        )

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,0 +1,997 @@
+"""
+Statically-shaped matrix/vector support: the ``@`` operator, elementwise aggregate arithmetic, transpose, numpy-style
+subscripts, jaxtyping-annotated parameters/returns, matrix state, and ndarray module constants. Structure and
+diagnostics are checked on the lowered HIR; numerical behavior is checked black-box through the public API against
+numpy executing the very same kernel.
+"""
+
+import dataclasses
+import warnings
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+from numpy import matmul as _matmul
+from jaxtyping import Bool, Float, Float64, Int, Shaped
+
+import holoso
+from holoso import FFmaOperator, FloatFormat, UnsupportedConstruct
+from holoso._frontend import lower
+from holoso._hir import FloatAdd, FloatMul, optimize
+from holoso._mir import lower as lower_to_mir
+
+from ._modelref import arith_count as _arith_count, default_ops
+
+# Wide enough that the model's arithmetic coincides with float64 up to the final rounding, so kernels can be compared
+# against their own native numpy execution with a tight tolerance.
+_FMT = FloatFormat(11, 52)
+
+GAIN = np.array([[0.5, -0.25], [0.125, 1.0]])
+COEFFS = np.array([2.0, -1.0, 0.5])
+INT_TAPS = np.array([1, 2, 3])
+
+# ndarray module constants for the self-contained stateful filter kernel below.
+PROC_NOISE = np.array([[1.0e-4, 0.0], [0.0, 1.0e-2]])
+OBS = np.eye(2)
+MEAS_VAR = np.array([4.0e-2, 2.5e-1])
+
+
+class TrackingFilter:
+    """
+    A self-contained 2-state Kalman-style filter exercising the full matrix feature surface in one stateful kernel:
+    matrix/vector parameters and state, ndarray module constants, ``@`` in every shape, transpose, elementwise scalar
+    broadcast, an annotated local, a static row loop, and a shaped return. It is ordinary executable numpy, so its own
+    native execution is the reference.
+    """
+
+    x: Float64[np.ndarray, "2"]
+    P: Float64[np.ndarray, "2 2"]
+
+    def __init__(self) -> None:
+        self.x = np.zeros(2)
+        self.P = np.eye(2) * 10.0
+
+    def update(self, F: Float64[np.ndarray, "2 2"], z: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        x = F @ self.x
+        P = F @ self.P @ F.T + PROC_NOISE
+        prediction: Float64[np.ndarray, "2"] = x  # annotated local carrying the a-priori forecast to the return port
+        for i in range(2):
+            h = OBS[i]
+            y = z[i] - h @ x
+            s = h @ P @ h + MEAS_VAR[i]  # innovation variance: a runtime scalar divisor
+            k = (P @ h) / s
+            x = x + k * y
+            hp = h @ P
+            P = P - np.array([k[0] * hp, k[1] * hp])
+        self.x = x
+        self.P = P
+        return prediction
+
+
+def _sim(fn: Callable[..., object]) -> holoso.NumericalSimulator:
+    return holoso.synthesize(fn, default_ops(_FMT), name="kernel").numerical_model.elaborate()
+
+
+def _run(sim: holoso.NumericalSimulator, *arrays: np.ndarray | float) -> np.ndarray:
+    flat: list[float] = []
+    for a in arrays:
+        flat += [float(a)] if isinstance(a, float) else np.asarray(a, dtype=np.float64).flatten().tolist()
+    return np.array([float(v) for v in sim.run(*flat)])
+
+
+# ---------------------------------------------------------------- structure
+
+
+def test_matmul_shapes_and_port_layout() -> None:
+    def mat_vec(a: Float64[np.ndarray, "2 3"], x: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "2"]:
+        return a @ x  # type: ignore[no-any-return]
+
+    hir = lower(mat_vec)
+    assert hir.input_names() == ["a_0_0", "a_0_1", "a_0_2", "a_1_0", "a_1_1", "a_1_2", "x_0", "x_1", "x_2"]
+    assert [o.name for o in hir.outputs] == ["out_0", "out_1"]
+    assert _arith_count(hir, FloatMul) == 6 and _arith_count(hir, FloatAdd) == 4
+
+    def vec_mat(x: Float64[np.ndarray, "2"], a: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "3"]:
+        return x @ a  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(vec_mat).outputs] == ["out_0", "out_1", "out_2"]
+
+    def dot(v: Float64[np.ndarray, "3"], w: Float64[np.ndarray, "3"]) -> float:
+        return v @ w  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(dot).outputs] == ["out_0"]
+
+    def mat_mat(a: Float64[np.ndarray, "2 3"], b: Float64[np.ndarray, "3 2"]) -> Float64[np.ndarray, "2 2"]:
+        return a @ b  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(mat_mat).outputs] == ["out_0_0", "out_0_1", "out_1_0", "out_1_1"]
+
+
+def test_matmul_rejections() -> None:
+    def scalar_operand(a: float, x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return a @ x  # type: ignore[operator, unused-ignore]
+
+    with pytest.raises(UnsupportedConstruct, match="scalar"):
+        lower(scalar_operand)
+
+    def dim_mismatch(a: Float64[np.ndarray, "2 3"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return a @ x  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="mismatch"):
+        lower(dim_mismatch)
+
+    def ragged(a: float, b: float) -> float:
+        # A bare Python list has no ``@`` (a TypeError in Python), so the matrix product is rejected as a list operation
+        # before rectangularity is even considered; the ragged literal cannot be wrapped in np.array either.
+        return [[a, b], [a]] @ [a, b]  # type: ignore[operator, no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+        lower(ragged)
+
+    def three_dee(a: float) -> float:
+        return np.array([[[a]]]) @ np.array([a])  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="1-D or 2-D"):
+        lower(three_dee)
+
+    def boolean(v: Float64[np.ndarray, "2"], flag: bool) -> float:
+        return v @ np.array([flag, flag])  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="floating-point"):
+        lower(boolean)
+
+
+def test_dot_product_left_fold_contracts_to_fma_chain() -> None:
+    # The documented reason for the left-fold dot expansion: with ffma configured, an n-element dot must lower to one
+    # fmul plus n-1 ffma (each running-sum add fuses the next single-use product). A balanced tree or product reuse
+    # would silently void this, so pin the exact MIR operator population in both configurations.
+    def dot(v: Float64[np.ndarray, "3"], w: Float64[np.ndarray, "3"]) -> float:
+        return v @ w  # type: ignore[no-any-return]
+
+    def mnemonic_counts(with_fma: bool) -> dict[str, int]:
+        ops = default_ops(_FMT)
+        if with_fma:
+            ops = dataclasses.replace(ops, ffma=FFmaOperator(_FMT))
+        mir = lower_to_mir(optimize(lower(dot)), ops)
+        counts: dict[str, int] = {}
+        for node in mir.nodes.values():
+            operator = getattr(node, "operator", None)
+            if operator is not None:
+                stem = operator.mnemonic.split("_")[0]
+                counts[stem] = counts.get(stem, 0) + 1
+        return counts
+
+    assert mnemonic_counts(with_fma=True) == {"fmul": 1, "ffma": 2}
+    assert mnemonic_counts(with_fma=False) == {"fmul": 3, "fadd": 2}
+
+
+def test_np_matmul_call_is_the_operator() -> None:
+    def with_operator(a: Float64[np.ndarray, "2 2"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return a @ x  # type: ignore[no-any-return]
+
+    def with_call(a: Float64[np.ndarray, "2 2"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return np.matmul(a, x)  # type: ignore[no-any-return]
+
+    ops = (_arith_count(lower(with_operator), FloatMul), _arith_count(lower(with_operator), FloatAdd))
+    assert ops == (_arith_count(lower(with_call), FloatMul), _arith_count(lower(with_call), FloatAdd))
+
+    def keywords(a: Float64[np.ndarray, "2 2"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return np.matmul(a, x, casting="no")  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="keyword"):
+        lower(keywords)
+
+
+def test_np_matmul_bare_name_import_resolves() -> None:
+    def with_bare_name(a: Float64[np.ndarray, "2 2"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return _matmul(a, x)  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(with_bare_name).outputs] == ["out_0", "out_1"]
+
+
+def test_augmented_assignment_to_array_is_rejected() -> None:
+    # Regression: numpy '+=' / '@=' mutate in place while the frontend rebinds, so an alias would diverge; the array
+    # augmented forms must be rejected in favor of the explicit 'x = x + ...' rebind.
+    def name_target(v: Float64[np.ndarray, "2"], s: float) -> Float64[np.ndarray, "2"]:
+        v += s
+        return v
+
+    with pytest.raises(UnsupportedConstruct, match="augmented assignment to a list or array"):
+        lower(name_target)
+
+    @dataclasses.dataclass
+    class State:
+        P: Float64[np.ndarray, "2 2"]
+
+        def step(self, f: Float64[np.ndarray, "2 2"]) -> None:
+            self.P @= f
+
+    with pytest.raises(UnsupportedConstruct, match="augmented assignment to a list or array"):
+        lower(State(np.eye(2)).step)
+
+    def scalar_ok(a: float, s: float) -> float:
+        a += s
+        return a
+
+    assert [o.name for o in lower(scalar_ok).outputs] == ["out_0"]
+
+
+def test_unary_minus_on_boolean_aggregate_is_rejected_with_location() -> None:
+    def f(a: bool, b: bool) -> float:
+        v = np.array([a, b])
+        return (-v)[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="boolean"):
+        lower(f)
+
+
+def test_elementwise_arithmetic_and_broadcast() -> None:
+    def combos(v: Float64[np.ndarray, "2"], w: Float64[np.ndarray, "2"], s: float) -> Float64[np.ndarray, "2"]:
+        return (v + w) * s - w / 2.0 + (s - v) * w  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(combos).outputs] == ["out_0", "out_1"]
+
+    def length_mismatch(v: Float64[np.ndarray, "2"], w: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "2"]:
+        return v + w  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="mismatched shapes"):
+        lower(length_mismatch)
+
+    def structure_mismatch(v: Float64[np.ndarray, "2"], m: Float64[np.ndarray, "2 2"]) -> Float64[np.ndarray, "2"]:
+        return v + m  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="mismatched shapes"):
+        lower(structure_mismatch)
+
+
+def test_python_list_arithmetic_is_rejected() -> None:
+    # A Python list/tuple is never given numpy semantics: list ``+``/``*`` mean concatenation/repetition (not the
+    # intended elementwise math) and list ``-`` is a TypeError, so arithmetic on a bare list/tuple is rejected rather
+    # than silently reinterpreted. The idiomatic fix is np.array([...]).
+    def list_add(a: float, b: float, c: float, d: float) -> float:
+        return ([a, b] + [c, d])[0]  # a valid Python list concatenation; Holoso rejects it as list arithmetic
+
+    def list_sub(a: float, b: float, c: float, d: float) -> float:
+        return ([a, b] - [c, d])[0]  # type: ignore[operator, no-any-return]
+
+    def list_scale(a: float, b: float, s: float) -> float:
+        return ([a, b] * s)[0]  # type: ignore[operator]
+
+    for kernel in (list_add, list_sub, list_scale):
+        with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+            lower(kernel)
+
+
+def test_np_array_of_ragged_list_is_rejected() -> None:
+    # The np.array/asarray/asanyarray factory mirrors numpy, which rejects a ragged array literal.
+    def ragged(a: float, b: float) -> float:
+        return np.array([[a, b], [a]])[0, 0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="rectangular"):
+        lower(ragged)
+
+
+def test_numpy_only_methods_on_a_list_are_rejected() -> None:
+    # `.T`, `.flatten()`, and multi-axis indexing are numpy-array operations undefined on a Python list, so they are
+    # rejected on a list literal; wrapping in np.array([...]) makes them valid.
+    def transpose(a: float, b: float) -> float:
+        return ([a, b].T)[0]  # type: ignore[attr-defined, no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="transpose"):
+        lower(transpose)
+
+    def flatten(a: float, b: float) -> float:
+        return ([[a, b]].flatten())[0]  # type: ignore[attr-defined, no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="flattening"):
+        lower(flatten)
+
+    def multi_axis(a: float, b: float) -> float:
+        m = [[a, b], [b, a]]
+        return m[0, 1]  # type: ignore[call-overload, no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="multi-axis"):
+        lower(multi_axis)
+
+
+def test_list_of_array_demotes_to_sequence_for_arithmetic() -> None:
+    # list(arr)/tuple(arr) produce Python sequences (as in Python), so arithmetic on the result is rejected even though
+    # the argument was an array -- guards against the builtins accidentally keeping array semantics.
+    def via_list(v: Float64[np.ndarray, "2"], s: float) -> float:
+        return (list(v) * s)[0]  # type: ignore[operator, no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+        lower(via_list)
+
+
+def test_star_unpack_remainder_is_a_python_list() -> None:
+    # Regression: a starred target binds a plain list even when unpacking an array (PEP 3132), so arithmetic on the
+    # remainder must be rejected -- it must not inherit the source array's semantics.
+    def spread(v: Float64[np.ndarray, "3"]) -> float:
+        first, *rest = v
+        return (rest + rest)[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+        lower(spread)
+
+
+def test_mismatched_branch_flavor_merge_rejects_array_ops() -> None:
+    # Regression: a value that is an array in one arm and a list in the other must not silently gain array semantics
+    # (that made acceptance depend on arm order). A numpy op on the merged value is rejected; structural use stays fine.
+    def arithmetic(c: bool, a: float, b: float) -> Float64[np.ndarray, "2"]:
+        if c:
+            v = np.array([a, b])
+        else:
+            v = [a, b]  # type: ignore[assignment]
+        return v * 2.0
+
+    with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+        lower(arithmetic)
+
+    def structural(c: bool, a: float, b: float) -> float:
+        if c:
+            v = np.array([a, b])
+        else:
+            v = [a, b]  # type: ignore[assignment]
+        return v[0]  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(structural).outputs] == ["out_0"]
+
+
+def test_state_assignment_flavor_must_match_reset() -> None:
+    # Regression: the reset snapshot fixes an attribute's read-back flavor, so storing the other flavor (a list into an
+    # ndarray-reset slot) is rejected -- otherwise it would round-trip back as an array and diverge from Python.
+    @dataclasses.dataclass
+    class ListIntoArray:
+        v: np.ndarray
+
+        def step(self, s: float) -> None:
+            w = self.v * s
+            self.v = [w[0], w[1]]  # type: ignore[assignment]
+
+    with pytest.raises(UnsupportedConstruct, match="numpy array"):
+        lower(ListIntoArray(np.array([1.0, 2.0])).step)
+
+
+def test_unsupported_operator_diagnostic_names_the_operator() -> None:
+    # An unsupported operator must be named even when its operands are boolean (its own diagnostic wins over the
+    # float-operand check), rather than being misreported as a boolean-operand error.
+    def bitor(a: bool, b: bool) -> bool:
+        return a | b
+
+    with pytest.raises(UnsupportedConstruct, match="unsupported binary operator BitOr"):
+        lower(bitor)
+
+    # Also on the aggregate path: an unsupported operator must be named even when the operands' shapes mismatch, rather
+    # than being masked by the shape-mismatch diagnostic.
+    def modulo(v: Float64[np.ndarray, "2"], w: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "2"]:
+        return v % w  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="unsupported binary operator Mod"):
+        lower(modulo)
+
+
+def test_transpose_structure() -> None:
+    def t(m: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "3 2"]:
+        return m.T
+
+    hir = lower(t)
+    assert [o.name for o in hir.outputs] == ["out_0_0", "out_0_1", "out_1_0", "out_1_1", "out_2_0", "out_2_1"]
+    assert _arith_count(hir, FloatMul) == 0  # a pure reindexing, no hardware
+
+    def vector_identity(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return v.T
+
+    assert [o.name for o in lower(vector_identity).outputs] == ["out_0", "out_1"]
+
+    def scalar_t(a: float) -> float:
+        return a.T  # type: ignore[attr-defined, no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="transpose"):
+        lower(scalar_t)
+
+
+def test_state_attribute_named_t_shadows_transpose() -> None:
+    @dataclasses.dataclass
+    class Holder:
+        T: float
+
+        def step(self, a: float) -> float:
+            self.T = self.T + a
+            return self.T
+
+    hir = lower(Holder(0.0).step)
+    assert [s.name for s in hir.state_slots] == ["T"]
+
+
+def test_numpy_subscripts() -> None:
+    def picks(m: Float64[np.ndarray, "2 3"]) -> tuple[float, float, float, float]:
+        column = m[:, 2]
+        return m[0, 1], m[1][2], column[0], m[1:, 0][0]
+
+    assert [o.name for o in lower(picks).outputs] == ["out_0", "out_1", "out_2", "out_3"]
+
+    def too_many(m: Float64[np.ndarray, "2 2"]) -> float:
+        return m[0, 1, 0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="scalar"):
+        lower(too_many)
+
+
+def test_multi_axis_index_on_list_is_rejected() -> None:
+    # Multi-axis m[i, j] is a numpy-array operation with no meaning on a Python list (list[i, j] is a tuple key, a
+    # TypeError), so it must be rejected as a list operation rather than silently indexed. Chained m[i][j] on the same
+    # (even ragged) list stays valid (plain list indexing).
+    def list_multi_axis(a: float, b: float) -> float:
+        m = [[a, b], [a]]
+        return m[0, 1]  # type: ignore[call-overload,no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+        lower(list_multi_axis)
+
+    def ragged_chained(a: float, b: float) -> float:
+        m = [[a, b], [a]]
+        return m[0][1]
+
+    assert [o.name for o in lower(ragged_chained).outputs] == ["out_0"]
+
+
+def test_shaped_parameter_annotation_rejections() -> None:
+    def symbolic(v: Float64[np.ndarray, "n"]) -> float:
+        return v[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="fixed"):
+        lower(symbolic)
+
+    def broadcastable(v: Float64[np.ndarray, "#3"]) -> float:
+        return v[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="fixed"):
+        lower(broadcastable)
+
+    def three_dee(v: Float64[np.ndarray, "2 2 2"]) -> float:
+        return v[0, 0, 0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="1-D and 2-D"):
+        lower(three_dee)
+
+    def boolean(v: Bool[np.ndarray, "2"]) -> float:
+        return v[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="floating-point"):
+        lower(boolean)
+
+    def integer(v: Int[np.ndarray, "2"]) -> float:
+        return v[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="floating-point"):
+        lower(integer)
+
+    def shape_only(v: Shaped[np.ndarray, "2"]) -> float:
+        return v[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="floating-point"):
+        lower(shape_only)
+
+    def shapeless(v: np.ndarray) -> float:
+        return v[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="jaxtyping"):
+        lower(shapeless)
+
+    class _FakeArray:  # structurally array-like (has ``dims``) but its dims is not a real jaxtyping tuple
+        dims = None
+
+    def fake(v: _FakeArray) -> float:
+        return 1.0
+
+    with pytest.raises(UnsupportedConstruct, match="not a valid fixed-shape array annotation"):
+        lower(fake)
+
+
+def test_wide_float_dtype_annotation_is_accepted() -> None:
+    def f(v: Float[np.ndarray, "2"]) -> float:
+        return v[0] + v[1]  # type: ignore[no-any-return]
+
+    assert lower(f).input_names() == ["v_0", "v_1"]
+
+
+def test_decomposed_parameter_port_collision_is_rejected() -> None:
+    def collides(v: Float64[np.ndarray, "2"], v_0: float) -> float:
+        return v[1] * v_0  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="collides"):
+        lower(collides)
+
+
+def test_array_return_annotation_is_validated() -> None:
+    def good(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return v * 2.0
+
+    assert [o.name for o in lower(good).outputs] == ["out_0", "out_1"]
+
+    def nested(v: Float64[np.ndarray, "2"], flag: bool) -> tuple[Float64[np.ndarray, "2"], bool]:
+        return v * 2.0, flag
+
+    assert [o.name for o in lower(nested).outputs] == ["out_0_0", "out_0_1", "out_1"]
+
+    def wrong_shape(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "3"]:
+        return v * 2.0
+
+    with pytest.raises(UnsupportedConstruct, match="shape mismatch"):
+        lower(wrong_shape)
+
+    def scalar_returned(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return v[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="shape mismatch"):
+        lower(scalar_returned)
+
+    def boolean_leaves(flag: bool) -> Float64[np.ndarray, "1"]:
+        return [flag]  # type: ignore[return-value]
+
+    with pytest.raises(UnsupportedConstruct, match="floating-point"):
+        lower(boolean_leaves)
+
+
+def test_matrix_state_annotation_and_assignment_validation() -> None:
+    @dataclasses.dataclass
+    class Declared:
+        P: Float64[np.ndarray, "2 2"]
+
+        def step(self, a: float) -> None:
+            self.P = self.P * a
+
+    with pytest.raises(UnsupportedConstruct, match="declared array type"):
+        lower(Declared(np.zeros((3, 3))).step)
+
+    @dataclasses.dataclass
+    class Reshaped:
+        P: Float64[np.ndarray, "2 2"]
+
+        def step(self, a: float) -> None:
+            self.P = self.P[0] * a
+
+    with pytest.raises(UnsupportedConstruct, match="incompatible shape"):
+        lower(Reshaped(np.zeros((2, 2))).step)
+
+    @dataclasses.dataclass
+    class Empty:
+        v: np.ndarray
+
+        def step(self, a: float) -> None:
+            self.v = self.v * a
+
+    with pytest.raises(UnsupportedConstruct, match="empty"):
+        lower(Empty(np.zeros(0)).step)
+
+
+def test_state_assignment_element_type_mismatch_is_rejected() -> None:
+    # Regression: a bool-leaved value assigned to a float attribute must be rejected, not stored as a float-reset slot
+    # whose live-out is a boolean -- which would leave the slot's live-in and live-out at different types.
+    @dataclasses.dataclass
+    class FloatMatrix:
+        P: Float64[np.ndarray, "2 2"]
+
+        def step(self, flag: bool) -> None:
+            # A bool-valued array (flavor matches the ndarray slot) so the check reached is the leaf-type one.
+            self.P = np.array([[flag, flag], [flag, flag]])
+
+    with pytest.raises(UnsupportedConstruct, match="incompatible type"):
+        lower(FloatMatrix(np.zeros((2, 2))).step)
+
+    @dataclasses.dataclass
+    class FloatScalar:
+        y: float
+
+        def step(self, flag: bool) -> None:
+            self.y = flag
+
+    with pytest.raises(UnsupportedConstruct, match="incompatible type"):
+        lower(FloatScalar(0.0).step)
+
+
+def test_arithmetic_on_boolean_operands_is_rejected_with_location() -> None:
+    # Regression: bool arithmetic reached HIR construction and raised a bare, location-less ValueError; it must be a
+    # source-located UnsupportedConstruct, in both scalar and elementwise-aggregate positions.
+    def scalar(a: bool, b: bool) -> float:
+        return a + b
+
+    with pytest.raises(UnsupportedConstruct, match="boolean"):
+        lower(scalar)
+
+    def aggregate(v: Float64[np.ndarray, "2"], flag: bool) -> Float64[np.ndarray, "2"]:
+        return v + np.array([flag, flag])  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="boolean"):
+        lower(aggregate)
+
+
+def test_matrix_carried_across_while_loop_is_rejected() -> None:
+    def f(m: Float64[np.ndarray, "2 2"], n: float) -> Float64[np.ndarray, "2 2"]:
+        x = n
+        while x > 0.0:
+            m = m * 0.5
+            x = x - 1.0
+        return m
+
+    with pytest.raises(UnsupportedConstruct, match="aggregate"):
+        lower(f)
+
+
+def test_ndarray_constant_element_folds_in_static_position() -> None:
+    # An ndarray-constant element is statically known, so it must fold a branch condition (and serve as a static index)
+    # exactly as it folds in value position -- otherwise the branch reads as dynamic and a single-arm return is
+    # wrongly rejected.
+    def gated(a: float) -> float:
+        if _GATE_CONST[1] > 0.0:  # statically true
+            return a * 2.0
+        return a  # statically dead
+
+    sim = _sim(gated)
+    assert float(sim.run(3.0)[0]) == 6.0
+
+    def indexed(v: Float64[np.ndarray, "3"]) -> float:
+        return v[_INDEX_CONST[0]]  # type: ignore[no-any-return]  # constant int-array element as a static index
+
+    assert [o.name for o in lower(indexed).outputs] == ["out_0"]
+
+    def chained(a: float) -> float:
+        if _GATE_CONST2[0][1] > 0.0:  # chained indexing of a 2-D constant, statically true
+            return a * 2.0
+        return a
+
+    assert float(_sim(chained).run(3.0)[0]) == 6.0
+
+
+def test_readonly_ndarray_attribute_element_folds_a_branch() -> None:
+    # Regression: a read-only ndarray instance attribute's element must fold a static branch, exactly as a module
+    # constant does -- otherwise the guarded write reads as dynamic and wrongly becomes a spurious persistent state slot
+    # (changing the synthesized interface).
+    @dataclasses.dataclass
+    class Filter:
+        gain: np.ndarray  # read-only 2-D configuration, never assigned in the method
+
+        def step(self, a: float) -> float:
+            out = a
+            if self.gain[0, 1] < 0.0:  # statically false: gain[0, 1] == 1.0
+                out = a * 2.0  # statically dead
+            return out
+
+    hir = lower(Filter(np.array([[0.0, 1.0]])).step)
+    assert [s.name for s in hir.state_slots] == []  # no spurious state from the statically-dead write
+    assert [o.name for o in hir.outputs] == ["out_0"]
+
+
+def test_sliced_and_transposed_constant_folds_in_static_position() -> None:
+    # Regression: the static evaluator must fold every constant-array operation the value lowerer supports -- including
+    # slicing and transpose -- or a statically-known guard reads as dynamic and creates a spurious state slot.
+    @dataclasses.dataclass
+    class WithSlice:
+        y: float
+
+        def step(self, a: float) -> float:
+            if _GATE_CONST[0:2][1] > 0.0:  # statically true
+                return a * 2.0
+            self.y = a  # statically dead
+            return self.y
+
+    hir_slice = lower(WithSlice(0.0).step)
+    assert [s.name for s in hir_slice.state_slots] == []
+    assert [o.name for o in hir_slice.outputs] == ["out_0"]
+
+    @dataclasses.dataclass
+    class WithTranspose:
+        y: float
+
+        def step(self, a: float) -> float:
+            if _GATE_CONST2.T[1, 0] < 0.0:  # _GATE_CONST2.T[1, 0] == _GATE_CONST2[0, 1] == 1.0, statically false
+                self.y = a  # statically dead
+            return a
+
+    hir_t = lower(WithTranspose(0.0).step)
+    assert [s.name for s in hir_t.state_slots] == []
+    assert [o.name for o in hir_t.outputs] == ["out_0"]
+
+    @dataclasses.dataclass
+    class WithFlatten:
+        y: float
+
+        def step(self, a: float) -> float:
+            if _GATE_CONST2.flatten()[1] > 0.0:  # flatten()[1] == 1.0, statically true
+                return a * 2.0
+            self.y = a  # statically dead
+            return self.y
+
+    hir_f = lower(WithFlatten(0.0).step)
+    assert [s.name for s in hir_f.state_slots] == []
+    assert [o.name for o in hir_f.outputs] == ["out_0"]
+
+    def via_identity(a: float) -> float:
+        if np.asarray(_GATE_CONST2)[0, 1] > 0.0:  # array-identity wrapper then index, statically true
+            return a * 2.0
+        return a
+
+    assert float(_sim(via_identity).run(3.0)[0]) == 6.0
+
+
+def test_transpose_of_matrix_state_attribute() -> None:
+    # Coverage: ``self.P.T`` transposes state (the chained case of the ``.T``-vs-``self.T`` resolution), distinct from
+    # the ``self.T`` state-read carve-out.
+    @dataclasses.dataclass
+    class Holder:
+        P: Float64[np.ndarray, "2 2"]
+
+        def step(self, s: float) -> Float64[np.ndarray, "2 2"]:
+            return self.P.T * s
+
+    sim = holoso.synthesize(
+        Holder(np.array([[1.0, 2.0], [3.0, 4.0]])).step, default_ops(_FMT), name="pt"
+    ).numerical_model.elaborate()
+    got = _run(sim, 2.0).reshape(2, 2)
+    assert np.allclose(got, np.array([[1.0, 2.0], [3.0, 4.0]]).T * 2.0)
+
+
+def test_unary_plus_rejects_boolean_but_is_identity_on_floats() -> None:
+    # Regression: unary plus skipped the boolean guard the other arithmetic operators apply, silently passing a bool
+    # through (Python's +True is int 1, which has no runtime type here).
+    def scalar(flag: bool) -> float:
+        return +flag
+
+    with pytest.raises(UnsupportedConstruct, match="boolean"):
+        lower(scalar)
+
+    def aggregate(a: bool, b: bool) -> Float64[np.ndarray, "2"]:
+        return +np.array([a, b])
+
+    with pytest.raises(UnsupportedConstruct, match="boolean"):
+        lower(aggregate)
+
+    def floats(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return +v
+
+    assert [o.name for o in lower(floats).outputs] == ["out_0", "out_1"]
+
+
+def test_ndarray_module_constant_rejections() -> None:
+    def boolean(a: float) -> float:
+        return _BOOL_CONST[0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="real numbers"):
+        lower(boolean)
+
+    def three_dee(a: float) -> float:
+        return _CUBE_CONST[0, 0, 0]  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="1-D or 2-D"):
+        lower(three_dee)
+
+
+def test_ndarray_subclass_constant_and_state_are_rejected() -> None:
+    # Regression: an ndarray subclass (np.matrix) redefines operators (``*`` is matmul), so folding it as a plain array
+    # would silently diverge from its own Python semantics; it must be rejected, both as a module constant and a reset.
+    def constant(a: float) -> float:
+        return _MATRIX_CONST[0, 1] + a  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="plain numpy array"):
+        lower(constant)
+
+    @dataclasses.dataclass
+    class Stateful:
+        P: np.ndarray
+
+        def step(self, a: float) -> None:
+            self.P = self.P * a
+
+    with pytest.raises(UnsupportedConstruct, match="plain numpy array"):
+        lower(Stateful(_np_matrix()).step)
+
+
+def test_power_of_boolean_is_rejected_with_location() -> None:
+    # Regression: '**' bypassed the boolean-operand guard applied to the other arithmetic operators, raising a bare
+    # ValueError (flag**2) or silently returning the bool (flag**1) instead of a source-located UnsupportedConstruct.
+    def squared(flag: bool) -> float:
+        return flag**2
+
+    with pytest.raises(UnsupportedConstruct, match="boolean"):
+        lower(squared)
+
+    def first_power(flag: bool) -> float:
+        return flag**1
+
+    with pytest.raises(UnsupportedConstruct, match="boolean"):
+        lower(first_power)
+
+
+def test_boolean_operand_to_float_builtin_or_intrinsic_is_rejected_with_location() -> None:
+    # Regression: abs/min/max/round and the math/numpy float intrinsics passed a boolean operand straight to HIR
+    # construction, raising a bare location-less ValueError; each must reject it with a source-located error.
+    def with_abs(flag: bool) -> float:
+        return abs(flag)
+
+    def with_min(flag: bool, x: float) -> float:
+        return min(flag, x)
+
+    def with_round(flag: bool) -> float:
+        return round(flag)
+
+    def with_floor(flag: bool) -> float:
+        return np.floor(flag)  # type: ignore[no-any-return]
+
+    for kernel in (with_abs, with_min, with_round, with_floor):
+        with pytest.raises(UnsupportedConstruct, match="boolean"):
+            lower(kernel)
+
+
+def _np_matrix() -> np.ndarray:
+    # np.matrix is an ndarray subclass with different operator semantics; construct it under a warning filter since it
+    # is deliberately used to check that such subclasses are rejected.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", PendingDeprecationWarning)
+        return np.matrix([[1.0, 2.0], [3.0, 4.0]])
+
+
+_BOOL_CONST = np.array([True, False])
+_CUBE_CONST = np.zeros((2, 2, 2))
+_MATRIX_CONST = _np_matrix()
+_GATE_CONST = np.array([0.0, 1.0])
+_GATE_CONST2 = np.array([[0.0, 1.0], [1.0, 0.0]])
+_INDEX_CONST = np.array([2, 0, 1])
+
+
+# ---------------------------------------------------------------- behavior (model vs numpy)
+
+
+def test_matmul_matches_numpy() -> None:
+    def transform(a: Float64[np.ndarray, "3 3"], x: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "3"]:
+        return a @ x  # type: ignore[no-any-return]
+
+    def chained(
+        a: Float64[np.ndarray, "2 3"], b: Float64[np.ndarray, "3 3"], x: Float64[np.ndarray, "3"]
+    ) -> Float64[np.ndarray, "2"]:
+        return a @ b @ x  # type: ignore[no-any-return]
+
+    def row_form(x: Float64[np.ndarray, "3"], a: Float64[np.ndarray, "3 2"]) -> Float64[np.ndarray, "2"]:
+        return x @ a  # type: ignore[no-any-return]
+
+    def dot(v: Float64[np.ndarray, "4"], w: Float64[np.ndarray, "4"]) -> float:
+        return v @ w  # type: ignore[no-any-return]
+
+    def quadratic_form(m: Float64[np.ndarray, "2 2"], v: Float64[np.ndarray, "2"]) -> float:
+        return v @ m @ v  # type: ignore[no-any-return]
+
+    def gram(a: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "3 3"]:
+        return a.T @ a  # type: ignore[no-any-return]
+
+    rng = np.random.default_rng(0xA11CE)
+    cases: list[tuple[Callable[..., object], list[np.ndarray]]] = [
+        (transform, [rng.normal(size=(3, 3)), rng.normal(size=3)]),
+        (chained, [rng.normal(size=(2, 3)), rng.normal(size=(3, 3)), rng.normal(size=3)]),
+        (row_form, [rng.normal(size=3), rng.normal(size=(3, 2))]),
+        (dot, [rng.normal(size=4), rng.normal(size=4)]),
+        (quadratic_form, [rng.normal(size=(2, 2)), rng.normal(size=2)]),
+        (gram, [rng.normal(size=(2, 3))]),
+    ]
+    for fn, arrays in cases:
+        got = _run(_sim(fn), *arrays)
+        want = np.asarray(fn(*arrays)).flatten()
+        assert np.allclose(got, want, rtol=1e-12, atol=1e-300), fn.__name__
+
+
+def test_np_array_factory_converts_list_and_matches_numpy() -> None:
+    # np.array([...]) converts a Python list/tuple into a numpy array on which arithmetic, the matrix product, and
+    # elementwise combination with another array are all defined; the results match numpy executing the same kernel.
+    def vec_add(a: float, b: float, c: float, d: float) -> Float64[np.ndarray, "2"]:
+        return np.array([a, b]) + np.array([c, d])  # type: ignore[no-any-return]
+
+    def dot(a: float, b: float, c: float, d: float) -> float:
+        return np.array([a, b]) @ np.array([c, d])  # type: ignore[no-any-return]
+
+    def mat_minus_rows(m: Float64[np.ndarray, "2 2"], a: float, b: float) -> Float64[np.ndarray, "2 2"]:
+        row = np.array([a, b])
+        return m - np.array([row, row])  # type: ignore[no-any-return]
+
+    a, b, c, d = 1.5, -2.0, 0.25, 3.0
+    assert np.allclose(_run(_sim(vec_add), a, b, c, d), vec_add(a, b, c, d), rtol=1e-12, atol=1e-300)
+    assert np.allclose(_run(_sim(dot), a, b, c, d), np.asarray(dot(a, b, c, d)), rtol=1e-12, atol=1e-300)
+
+    m = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert np.allclose(_run(_sim(mat_minus_rows), m, a, b), np.asarray(mat_minus_rows(m, a, b)).flatten(), rtol=1e-12)
+
+
+def test_elementwise_and_globals_match_numpy() -> None:
+    def kernel(x: Float64[np.ndarray, "2"], s: float) -> Float64[np.ndarray, "2"]:
+        y = GAIN @ (x + COEFFS[0:2]) - x / 4.0
+        return (y * s + GAIN[1]) @ GAIN  # type: ignore[no-any-return]
+
+    rng = np.random.default_rng(0xB0B)
+    x, s = rng.normal(size=2), float(rng.normal())
+    got = _run(_sim(kernel), x, s)
+    assert np.allclose(got, np.asarray(kernel(x, s)), rtol=1e-12, atol=1e-300)
+
+
+def test_integer_dtype_module_constant_folds_to_floats() -> None:
+    def kernel(v: Float64[np.ndarray, "3"]) -> float:
+        return v @ INT_TAPS  # type: ignore[no-any-return]
+
+    v = np.array([0.5, -1.5, 2.0])
+    got = _run(_sim(kernel), v)
+    assert got[0] == float(v @ INT_TAPS)
+
+
+def test_matrix_state_update_matches_numpy_across_transactions() -> None:
+    @dataclasses.dataclass
+    class Decay:
+        P: Float64[np.ndarray, "2 2"]
+
+        def step(self, f: Float64[np.ndarray, "2 2"]) -> None:
+            self.P = f @ self.P @ f.T
+
+    sim = holoso.synthesize(Decay(np.eye(2)).step, default_ops(_FMT), name="decay").numerical_model.elaborate()
+    assert [p.name for p in sim.outputs] == ["state_P_0_0", "state_P_0_1", "state_P_1_0", "state_P_1_1"]
+    reference = Decay(np.eye(2))
+    f = np.array([[1.0, 0.125], [-0.25, 0.9375]])
+    for _ in range(4):
+        got = _run(sim, f)
+        reference.step(f)
+        assert np.allclose(got, reference.P.flatten(), rtol=1e-12, atol=1e-300)
+
+
+def test_annotated_local_assignment_matches_numpy() -> None:
+    # Locks in the annotated local-assignment statement ``name: T = value`` (both array- and scalar-annotated forms) --
+    # the annotation is decorative and the value binds like a plain assignment; a frontend branch no other kernel hits.
+    def kernel(a: Float64[np.ndarray, "2 2"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        y: Float64[np.ndarray, "2"] = a @ x  # array-annotated local bound to an expression
+        t: float = y[0] - y[1]  # scalar-annotated local
+        return y * t
+
+    rng = np.random.default_rng(0xDEC1)
+    a, x = rng.normal(size=(2, 2)), rng.normal(size=2)
+    got = _run(_sim(kernel), a, x)
+    assert np.allclose(got, np.asarray(kernel(a, x)), rtol=1e-12, atol=1e-300)
+
+
+def test_runtime_divisor_division_matches_numpy() -> None:
+    # Locks in float division by a RUNTIME divisor -- the strength reducer's fallthrough to a real FloatDiv, the fdiv
+    # operator's execution, and the value model's exact divide -- none of which a constant/power-of-two divisor reaches.
+    def scalar_div(a: float, b: float) -> float:
+        return a / b
+
+    def vector_over_scalar(v: Float64[np.ndarray, "3"], s: float) -> Float64[np.ndarray, "3"]:
+        return v / s
+
+    def kalman_gain(P: Float64[np.ndarray, "2 2"], h: Float64[np.ndarray, "2"], s: float) -> Float64[np.ndarray, "2"]:
+        return (P @ h) / s  # type: ignore[no-any-return]  # matrix-vector product over a runtime scalar
+
+    scalar_cases = [(6.0, 3.0), (1.0, -4.0), (2.5, 0.5), (0.0, 7.0)]  # each divides exactly in both formats; last: 0/b
+    for fmt in (_FMT, FloatFormat(6, 18)):  # a second, narrower datapath width also exercises the divide
+        sim = holoso.synthesize(scalar_div, default_ops(fmt), name="div").numerical_model.elaborate()
+        for a, b in scalar_cases:
+            assert np.allclose(_run(sim, a, b), a / b, rtol=1e-12, atol=1e-300), (fmt, a, b)
+
+    rng = np.random.default_rng(0x0D17)
+    v, s = rng.normal(size=3), float(rng.uniform(0.5, 2.0))
+    assert np.allclose(_run(_sim(vector_over_scalar), v, s), v / s, rtol=1e-12, atol=1e-300)
+
+    P, h, s = rng.normal(size=(2, 2)), rng.normal(size=2), float(rng.uniform(0.5, 2.0))
+    assert np.allclose(_run(_sim(kalman_gain), P, h, s), (P @ h) / s, rtol=1e-12, atol=1e-300)
+
+
+def test_stateful_kalman_style_filter_matches_numpy_across_transactions() -> None:
+    # Locks in the whole matrix feature surface composed in one stateful kernel across transactions: matrix/vector
+    # parameters and carried state, ndarray module constants, ``@`` in every shape with transpose, elementwise scalar
+    # broadcast, an annotated local, a static row loop, a shaped return, and the runtime-divisor Kalman gain.
+    sim = holoso.synthesize(TrackingFilter().update, default_ops(_FMT), name="tracker").numerical_model.elaborate()
+    assert [p.name for p in sim.outputs] == [
+        "out_0", "out_1", "state_x_0", "state_x_1", "state_P_0_0", "state_P_0_1", "state_P_1_0", "state_P_1_1",
+    ]  # fmt: skip
+    reference = TrackingFilter()
+    rng = np.random.default_rng(0xF117E5)
+    F = np.array([[1.0, 0.1], [0.0, 1.0]])
+    for step in range(6):
+        z = np.array([float(rng.uniform(-1.0, 1.0)), float(rng.uniform(-1.0, 1.0))])
+        got = _run(sim, F, z)
+        prediction = reference.update(F, z)
+        want = np.array([float(v) for v in (*prediction, *reference.x, *reference.P.flatten())])
+        assert np.all(np.isfinite(want))
+        assert np.allclose(got, want, rtol=1e-9, atol=1e-12), step

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1049,3 +1049,19 @@ def test_imu_frame_transform_example_matches_numpy() -> None:
             np.array([0.1, -0.2, 9.9]),
             np.array([2.0, 0.0, -1.0]),
         )
+
+
+def test_imu_frame_transform_fma_matches_numpy() -> None:
+    # The ffma-contracted datapath the synth matrix's FMA rows exercise (each dot-product multiply-accumulate fused into
+    # a single-rounded a*b+c) must compute the same transform: FMA changes only the rounding, not the result.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
+    import imu_frame_transform
+
+    ops = dataclasses.replace(default_ops(_FMT), ffma=FFmaOperator(_FMT))
+    sim = holoso.synthesize(imu_frame_transform.transform, ops, name="imu_fma").numerical_model.elaborate()
+    yaw90 = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    roll90 = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
+    for rotation in (yaw90, roll90):
+        inputs = (rotation, np.array([1.0, 2.0, 3.0]), np.array([0.1, -0.2, 9.9]), np.array([2.0, 0.0, -1.0]))
+        want = np.asarray(imu_frame_transform.transform(*inputs)).flatten()
+        assert np.allclose(_run(sim, *inputs), want, rtol=1e-9, atol=1e-300)


### PR DESCRIPTION
Adds the matrix product operator `@` (and `np.matmul`) plus the statically-shaped numpy
matrix/vector support it needs, confined to the frontend. `@` expands into scalar mul/add
chains in HIR (a left fold, so MIR's existing FMA contraction fuses each dot product), and
nothing below HIR changes.

- `@`/`np.matmul` with numpy shape rules (1-D promotion with axis drop, `vec @ vec` → scalar,
  no batching); elementwise `+ - * /` with scalar broadcast; `.T` transpose; numpy-style
  subscripts (`m[i, j]`, `m[:, j]`, chained).

- jaxtyping-annotated fixed-shape parameters and returns (`Float64[np.ndarray, "3 3"]`),
  decomposed row-major into per-element scalar ports; 2-D state attributes; ndarray module
  constants; static folding of constant-array elements in branch/index positions.

- List/tuple-vs-array policy following Python: a Python list/tuple keeps sequence semantics
  (indexing, slicing, unpacking, building); numpy-only operations are rejected on it, and
  `np.array([...])` is the list-accepting factory (a bare list is never coerced).

- New black-box test suite (`tests/test_matrix.py`) checking structure, diagnostics, and
  numerical output against numpy; `DESIGN.md`/`README.md` updated. Version bumped to 0.1.9.
