### PR TITLE
Add more aggressive degenerate expression and identity elimination

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -291,11 +291,14 @@ Newton-Raphson reciprocal iterated to a tolerance illustrates this, on its conve
 
 ### HIR optimization
 
-HIR optimization is hardware-agnostic and ordered so each pass sees final costs: const-fold + algebraic simplify
-(SymPy-assisted) -> CSE -> strength reduction (powers of two to shifts, `x/c` to `x*(1/c)`, `x**n` to a multiply chain)
--> diamond if-conversion (after folding, so arm costs are final; before DCE, which then sweeps a converted diamond's
-now-dead condition cone) -> merge threading -> DCE. Constant folding is typed, so bool/int constants need no
-float-specific rebuilding.
+Holoso is intentionally very liberal when it comes to expression optimization.
+Bit-exactness, numerical determinism, or strict IEEE 754 compliance are anti-goals.
+
+HIR optimization is hardware-agnostic and ordered so each pass sees final costs: const-fold -> strength reduction
+(trivial fast-math identities, powers of two to shifts, `x/c` to `x*(1/c)`) -> diamond if-conversion (after folding, so
+arm costs are final; before DCE, which then sweeps a converted diamond's now-dead condition cone) -> a second
+const-fold/strength-reduction pass for the muxes created by if-conversion -> merge threading -> DCE. Constant folding
+is typed, so bool/int constants need no float-specific rebuilding.
 
 Merge threading eliminates an empty pass-through merge block -- the shape a non-convertible diamond leaves when its
 merge feeds a following control structure -- by retargeting each predecessor's jump onto the merge's successor and
@@ -303,8 +306,11 @@ composing the phi arms. A merge phi reached any other way (e.g. a loop-invariant
 back-edge arm) keeps its real branch -- deferred (see LIR DEFERRED).
 
 FP math is non-associative, so some of these optimizations may produce non-bit-exact results -- accepted, analogous to
-fast-math in C/C++ compilers. The transcendental folds likewise take the ideal (infinite-precision) result,
-so a folded constant can differ from the datapath's own value.
+fast-math in C/C++ compilers. Division identities may also rewrite zero/infinity special cases and drop sidebands when
+they remove an error-bearing op; sign/identity folds may preserve or expose a zero sign through raw sign conditioning.
+NaN constants are rejected because ZKF has no NaN, including float64 constant folds of ZKF-defined infinity cases;
+infinities are ordinary float values. The transcendental folds likewise take the ideal (infinite-precision) result, so
+a folded constant can differ from the datapath's own value.
 
 ### DEFERRED
 
@@ -509,9 +515,10 @@ measures smaller and faster on every flow. A single-source read port drives its 
 opcode field (a single-source register still carries a 1-bit write opcode -- its folded write-enable/NOP); every opcode
 is sized to its own codebook, never the file-wide index, so the ROM word stays narrow.
 
-Errors are non-fatal and informative: each error-bearing operator's flag (`div0`, `domain_error`, etc.) ORs into a
-global `err` gated by whether some destination register's write opcode selects that instance's output this step (its
-commit window), and an `err_pc` latch records the executing step of the last error (reset at every accept).
+For error-bearing operators that survive optimization, errors are non-fatal and informative: each flag (`div0`,
+`domain_error`, etc.) ORs into a global `err` gated by whether some destination register's write opcode selects that
+instance's output this step (its commit window), and an `err_pc` latch records the executing step of the last error
+(reset at every accept).
 
 Reset covers the control registers and the persistent state registers: the reset arm loads each state register with its
 snapshot while the non-reset arm applies that register's opcode-selected update and its boundary install (a

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ including the register liveness, operator pipeline occupancy/utilization, latenc
 Holoso implements essentially a separate programming language whose syntax is a strict subset of Python,
 and whose semantics is largely equivalent to Python with minor deviations that make sense in chip design context.
 Save for the minor differences in semantics, Holoso ensures that one can execute the original Python code
-and run the generated circuit (RTL) side by side, and obtain equivalent results (bit-exact unless floating points
-are used, in which case small errors inherent to floats may creep up).
+and run the generated circuit (RTL) side by side, and obtain equivalent results
+(modulo non-bit-exact fast math optimizations).
 
 Holoso designs a narrowly specialized computing core (a zero-instruction-set computer, ZISC)
 with custom statically scheduled microcode that implements the behavior of the original Python kernel.
@@ -233,18 +233,27 @@ Holoso follows Python with minimal deviations where it makes sense for hardware 
   Tensors mutate in place, which diverges from a rebind when the tensor is aliased; supporting it correctly would
   require complex escape analysis.
 
-- No exceptions: division by zero, domain errors, etc. produce the closest meaningful result and assert the error flag.
+- Math optimizations are non-bit-exact, fastmath style, aggressive. Holoso assumes commutativity/associativity,
+  may perform constant folding using higher-precision arithmetic than the target format,
+  assumes that domain errors do not occur, may freely discard constant and non-constant operations
+  (e.g., Holoso assumes `x/x==1` but this does not hold per IEEE 754),
+  arbitrarily increase the local precision (e.g., by FMA-folding nearby multiplications and additions), etc.
+
+- No exceptions: division by zero, domain errors, etc. produce zero or infinity (depending on context) and assert
+  the error flag (unless the operation is thrown away by the optimizer).
 
 ### Floating point
 
 The floating point engine is based on [Zubax Kulibin Float (ZKF)](https://github.com/Zubax/zkf).
 
 Differences from IEEE 754: no NaN, no subnormals (exponent 0 always encodes +0; finite magnitudes in `(0, min_normal/2)`
-round to +0; magnitudes in `[min_normal/2, min_normal)` round to signed min_normal), no exceptions, overflow produces ±∞.
+round to +0; magnitudes in `[min_normal/2, min_normal)` round to signed min_normal), no exceptions,
+overflow produces ±∞.
 Canonical representations do not include negative zero (it is not an error to pass negative zero though).
 
 Floating-point optimizations are fast-math style, assuming commutativity and associativity,
-allowing non-bit-exact rewrites.
+allowing non-bit-exact rewrites. They may also rewrite the zero/infinity special cases below and erase the associated
+error flags when an operation is optimized away.
 
 Infinity cases that would be NaN in IEEE 754:
 

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -51,5 +51,5 @@ from ._operators import (
     OpConfig as OpConfig,
 )
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 __url__ = "https://holoso.digital"

--- a/holoso/_frontend/_lower.py
+++ b/holoso/_frontend/_lower.py
@@ -1057,8 +1057,7 @@ class _Lowerer:
         """
         Fold one relational link of compile-time operands, or None if either is not compile-time. Two integers are
         compared exactly (a float64 fold would round operands beyond 2**53 and misfold, e.g.
-        ``9007199254740993 == 9007199254740992``); otherwise the fast-math float64 fold is used (accepted per
-        DESIGN.md), leaving a NaN operand to the comparator.
+        ``9007199254740993 == 9007199254740992``); otherwise the fast-math float64 fold is used.
         """
         left_int, right_int = self._static_int(left), self._static_int(right)
         if left_int is not None and right_int is not None:

--- a/holoso/_hir/_const.py
+++ b/holoso/_hir/_const.py
@@ -1,8 +1,10 @@
 """Typed HIR constant values."""
 
+import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+from .._errors import UnsupportedConstruct
 from ._types import BoolType, FloatType, Type
 
 
@@ -18,6 +20,8 @@ class FloatConst(Const):
     value: float
 
     def __post_init__(self) -> None:
+        if math.isnan(self.value):
+            raise UnsupportedConstruct("Holoso cannot represent a NaN constant. Only [in]finite numbers are supported.")
         if self.value == 0.0:  # Normalize -0.0 to +0.0.
             object.__setattr__(self, "value", 0.0)
 

--- a/holoso/_hir/_operators.py
+++ b/holoso/_hir/_operators.py
@@ -381,8 +381,6 @@ class FloatFma(Operator):
 
 @dataclass(frozen=True, slots=True)
 class FloatMin(Operator):
-    """Binary minimum of two floats."""
-
     mnemonic: ClassVar[str] = "min"
     speculatable: ClassVar[bool] = True
 
@@ -392,15 +390,13 @@ class FloatMin(Operator):
 
     def fold_constants(self, operands: list[Const]) -> Const | None:
         a, b = [_float_const(operand) for operand in operands]
-        if not (math.isfinite(a.value) and math.isfinite(b.value)):
-            return None  # do not let selection silently discard a non-finite operand
+        if math.isnan(a.value) or math.isnan(b.value):
+            return None
         return a if a.value < b.value else b
 
 
 @dataclass(frozen=True, slots=True)
 class FloatMax(Operator):
-    """Binary maximum of two floats."""
-
     mnemonic: ClassVar[str] = "max"
     speculatable: ClassVar[bool] = True
 
@@ -410,8 +406,8 @@ class FloatMax(Operator):
 
     def fold_constants(self, operands: list[Const]) -> Const | None:
         a, b = [_float_const(operand) for operand in operands]
-        if not (math.isfinite(a.value) and math.isfinite(b.value)):
-            return None  # do not let selection silently discard a non-finite operand
+        if math.isnan(a.value) or math.isnan(b.value):
+            return None
         return b if a.value < b.value else a
 
 

--- a/holoso/_hir/_strength_reduce.py
+++ b/holoso/_hir/_strength_reduce.py
@@ -6,7 +6,19 @@ from ._const import BoolConst, FloatConst
 from ._copy import copy_node, rebuild
 from .._util import ValueId
 from ._ir import Hir, HirBuilder, Node, Operation
-from ._operators import BoolAnd, BoolNot, BoolOr, BoolSelect, FloatDiv, FloatMul, FloatMulPow2, Select
+from ._operators import (
+    BoolAnd,
+    BoolNot,
+    BoolOr,
+    BoolSelect,
+    FloatAdd,
+    FloatDiv,
+    FloatMul,
+    FloatMulPow2,
+    FloatNeg,
+    Operator,
+    Select,
+)
 
 
 def _ilog2_exact(c: float) -> int | None:
@@ -19,11 +31,81 @@ def _ilog2_exact(c: float) -> int | None:
 
 def run(hir: Hir) -> Hir:
     """
-    Rewrite exact power-of-two scaling and finite constant division, and reduce the if-conversion muxes: a ``select``
-    with identical arms drops out, and a ``bool_select`` with one or two constant arms collapses to ``and``/``or``/
-    ``not``/passthrough (the common state-machine merge with ``True``/``False`` arms). All before hardware selection.
+    Rewrite trivial fast-math float identities, exact power-of-two scaling, and finite constant division, and reduce
+    the if-conversion muxes. All before hardware selection.
     """
     cval: dict[ValueId, float] = {}
+    neg_of: dict[ValueId, ValueId] = {}
+
+    def emit_float_const(builder: HirBuilder, value: float) -> ValueId:
+        new_id = builder.float_const(value)
+        cval[new_id] = value
+        return new_id
+
+    def emit_float_operation(builder: HirBuilder, operation: Operator, operands: list[ValueId]) -> ValueId:
+        return builder.operation(operation, operands)
+
+    def is_zero(vid: ValueId) -> bool:
+        return cval.get(vid) == 0.0
+
+    def is_one(vid: ValueId) -> bool:
+        return cval.get(vid) == 1.0
+
+    def is_neg_one(vid: ValueId) -> bool:
+        return cval.get(vid) == -1.0
+
+    def make_neg(builder: HirBuilder, value: ValueId) -> ValueId:
+        base = neg_of.get(value)
+        if base is not None:
+            return base
+        new_id = emit_float_operation(builder, FloatNeg(), [value])
+        neg_of[new_id] = value
+        return new_id
+
+    def reduce_add(builder: HirBuilder, a: ValueId, b: ValueId) -> ValueId:
+        if is_zero(a):
+            return b
+        if is_zero(b):
+            return a
+        if neg_of.get(a) == b or neg_of.get(b) == a:
+            return emit_float_const(builder, 0.0)
+        return emit_float_operation(builder, FloatAdd(), [a, b])
+
+    def reduce_mul(builder: HirBuilder, a: ValueId, b: ValueId) -> ValueId:
+        if is_zero(a) or is_zero(b):
+            return emit_float_const(builder, 0.0)
+        if is_one(a):
+            return b
+        if is_one(b):
+            return a
+        if is_neg_one(a):
+            return make_neg(builder, b)
+        if is_neg_one(b):
+            return make_neg(builder, a)
+        for const_side, other in ((b, a), (a, b)):
+            if const_side in cval:
+                k = _ilog2_exact(cval[const_side])
+                if k is not None:
+                    return emit_float_operation(builder, FloatMulPow2(k), [other])
+        return emit_float_operation(builder, FloatMul(), [a, b])
+
+    def reduce_div(builder: HirBuilder, a: ValueId, b: ValueId) -> ValueId:
+        if a == b:
+            return emit_float_const(builder, 1.0)  # Fast-math fold: intentionally ignores div0 for 0.0 / 0.0.
+        if is_zero(a):
+            return emit_float_const(builder, 0.0)  # Fast-math fold: intentionally drops the fdiv error sideband.
+        if is_one(b):
+            return a
+        if is_neg_one(b):
+            return make_neg(builder, a)
+        if b in cval:
+            c = cval[b]
+            k = _ilog2_exact(c)
+            if k is not None:
+                return emit_float_operation(builder, FloatMulPow2(-k), [a])
+            if c != 0.0 and math.isfinite(c):
+                return emit_float_operation(builder, FloatMul(), [a, emit_float_const(builder, 1.0 / c)])
+        return emit_float_operation(builder, FloatDiv(), [a, b])
 
     def bool_const(vid: ValueId) -> bool | None:
         node = hir.nodes[vid]
@@ -32,16 +114,24 @@ def run(hir: Hir) -> Hir:
     def build_value(builder: HirBuilder, vid: ValueId, node: Node, remap: dict[ValueId, ValueId]) -> ValueId:
         match node:
             case FloatConst(value=value):
-                new_id = builder.float_const(value)
-                cval[new_id] = value
-                return new_id
+                return emit_float_const(builder, value)
+            case Operation(operator=FloatNeg(), operands=(a,)):
+                return make_neg(builder, remap[a])
+            case Operation(operator=FloatAdd(), operands=(a, b)):
+                return reduce_add(builder, remap[a], remap[b])
             case Operation(operator=FloatMul(), operands=(a, b)):
-                return _reduce_mul(builder, remap[a], remap[b], cval)
+                return reduce_mul(builder, remap[a], remap[b])
             case Operation(operator=FloatDiv(), operands=(a, b)):
-                return _reduce_div(builder, remap[a], remap[b], cval)
+                return reduce_div(builder, remap[a], remap[b])
+            case Operation(operator=FloatMulPow2(k=0), operands=(a,)):
+                return remap[a]
+            case Operation(operator=FloatMulPow2(k=k), operands=(a,)):
+                return emit_float_operation(builder, FloatMulPow2(k), [remap[a]])
             case Operation(operator=Select(), operands=(_cond, a, b)) if remap[a] == remap[b]:
                 return remap[a]  # select(c, X, X) == X
             case Operation(operator=BoolSelect(), operands=(cond, a, b)):
+                if remap[a] == remap[b]:
+                    return remap[a]
                 return _reduce_bool_select(builder, remap[cond], remap[a], remap[b], bool_const(a), bool_const(b))
             case _:
                 return copy_node(builder, node, remap)
@@ -66,23 +156,3 @@ def _reduce_bool_select(
     if b_const is False:
         return builder.operation(BoolAnd(), [cond, a])  # (c, a, False) == c and a
     return builder.operation(BoolSelect(), [cond, a, b])  # both arms dynamic: keep the mux
-
-
-def _reduce_mul(builder: HirBuilder, a: ValueId, b: ValueId, cval: dict[ValueId, float]) -> ValueId:
-    for const_side, other in ((b, a), (a, b)):
-        if const_side in cval:
-            k = _ilog2_exact(cval[const_side])
-            if k is not None:
-                return builder.operation(FloatMulPow2(k), [other])
-    return builder.operation(FloatMul(), [a, b])
-
-
-def _reduce_div(builder: HirBuilder, a: ValueId, b: ValueId, cval: dict[ValueId, float]) -> ValueId:
-    if b in cval:
-        c = cval[b]
-        k = _ilog2_exact(c)
-        if k is not None:
-            return builder.operation(FloatMulPow2(-k), [a])
-        if c != 0.0 and math.isfinite(c):
-            return builder.operation(FloatMul(), [a, builder.float_const(1.0 / c)])
-    return builder.operation(FloatDiv(), [a, b])

--- a/holoso/_lir/_construct.py
+++ b/holoso/_lir/_construct.py
@@ -240,8 +240,8 @@ def build_const_pool(
     pool: dict[ValueId, PooledConst] = {}
     for vid in ids:
         value = mir.const_nodes[vid].value
-        if not math.isfinite(value):
-            raise UnsupportedConstruct(f"non-finite constant {value!r} is not representable in the ZKF format")
+        if math.isnan(value):
+            raise UnsupportedConstruct(f"Cannot represent a NaN constant. Only [in]finite numbers are supported.")
         magnitude = abs(value)
         index = magnitude_index.get(magnitude)
         if index is None:

--- a/holoso/_mir/_lower.py
+++ b/holoso/_mir/_lower.py
@@ -919,9 +919,7 @@ class _FloatLowerer:
             operator = _select_hardware(semantic, self.context.ops.fmul_ilog2.instantiate(k))
         except ValueError as exc:
             # An out-of-range exponent is rejected rather than lowered to a constant multiply by 2**k: such a k always
-            # lies outside the format's representable range, so the constant would overflow to a (rejected) infinity or
-            # underflow to zero -- the fallback multiply would be degenerate, so there is nothing useful to fall back
-            # to.
+            # lies outside the format's representable range, so the fallback multiply would be degenerate.
             raise UnsupportedConstruct(f"unsupported power-of-two float scale 2**{k}: {exc}") from exc
         return self.context.builder.operation(operator, [self.context.remap[base]], [sign])
 

--- a/tests/test_arithmetic_behavior.py
+++ b/tests/test_arithmetic_behavior.py
@@ -1,11 +1,11 @@
 """
-Public-API, black-box behavioral tests for floating-point edge behavior, the full relational/boolean breadth, the
-fmul_ilog2 power-of-two strength reduction, and constant folding / static evaluation (round-3 axes B-F).
+Public-API behavioral tests for floating-point edge behavior, the full relational/boolean breadth, fmul_ilog2
+power-of-two strength reduction, trivial fast-math float folding, and constant folding / static evaluation.
 
-Every test drives the compiler ONLY through the public API (``holoso.synthesize(fn, ops).numerical_model.elaborate()``
-then the simulator's ``run``) and asserts solely on observable output VALUES -- bits for floats, identity for bools --
-never on any internal structure. The references are chosen to be FALSIFIABLE without a tolerance fudge wherever the
-hardware must be exact:
+Every test drives the compiler only through the public API (``holoso.synthesize(fn, ops)`` and the numerical simulator).
+Most assertions are on observable output values -- bits for floats, identity for bools -- while explicit operator
+selection guards inspect generated Verilog text through the public synthesis result. The references are chosen to be
+FALSIFIABLE without a tolerance fudge wherever the hardware must be exact:
 
   - Axis B (float edge behavior): kernels driven with ``format_edge_bits``-derived inputs (±0, ±smallest-normal,
     ±largest-finite, ±0.5, ±1) passed as exact ``FloatValue`` bit patterns, asserting algebraic identities the hardware
@@ -24,6 +24,9 @@ hardware must be exact:
     lowers to the fmul_ilog2 family and is EXACT (a power-of-two only shifts the exponent, barring overflow/underflow);
     a non-power-of-two constant (x*3) stays an ordinary fmul and is still correct; a power-of-two that pushes a normal
     input to overflow (largest*2 -> inf) and to underflow (smallest_normal*0.25 -> 0).
+
+  - Trivial fast-math folds: algebraic identities, zero folds, sign folds, self-division, and self-subtraction remove
+    fadd/fmul/fdiv/fmul_ilog2 hardware where policy permits, including observable sideband and signed-zero deviations.
 
   - Axis E (boolean connectives + float<->bool casts): full truth tables for ``a and b``, ``a or b``, ``a and b or c``,
     De Morgan equivalence ``not (a and b)`` == ``(not a) or (not b)``; ``float(cond)`` (exactly 0.0/1.0) feeding
@@ -349,6 +352,93 @@ def test_power_of_two_overflow_and_underflow_edges() -> None:
     assert isinstance(under, FloatValue)
     # smallest_normal * 0.125 underflows below the half-MIN_NORMAL boundary -> rounds to +0 (the format's own rule).
     assert under.bits == 0, f"smallest_normal*0.125 not +0: bits=0x{under.bits:x} ({float(under)})"
+
+
+def _trivial_float_folds(x: float, y: float) -> list[float]:
+    return [
+        x * 1.0,
+        1.0 * x,
+        x / 1.0,
+        x + 0.0,
+        0.0 + x,
+        x - 0.0,
+        0.0 - x,
+        x * 0.0,
+        0.0 * x,
+        0.0 / y,
+        x * -1.0,
+        -1.0 * x,
+        x / -1.0,
+        x / x,
+        x - x,
+    ]
+
+def test_trivial_fast_math_float_folds_are_operator_free_and_bit_exact() -> None:
+    result = holoso.synthesize(_trivial_float_folds, _ops(), name="trivial_float_folds")
+    verilog = result.verilog_output.verilog
+    assert "holoso_fadd #" not in verilog
+    assert "holoso_fmul #" not in verilog
+    assert "holoso_fdiv #" not in verilog
+    assert "holoso_fmul_ilog2_const" not in verilog
+
+    sim = result.numerical_model.elaborate()
+    vectors = [
+        FloatValue.from_float(FMT, 0.0),
+        FloatValue.from_bits(FMT, 1 << (FMT.width - 1)),
+        FloatValue.from_float(FMT, 1.5),
+        FloatValue.from_float(FMT, -2.0),
+        FloatValue.from_float(FMT, float("inf")),
+        FloatValue.from_float(FMT, float("-inf")),
+    ]
+    one = FloatValue.from_float(FMT, 1.0)
+    for x in vectors:
+        for y in vectors:
+            out = sim.run(x, y)
+            values: list[FloatValue] = []
+            for value in out:
+                assert isinstance(value, FloatValue)
+                values.append(value)
+            negated = x.apply_sign(negate=True, absolute=False).bits
+            expected_bits = [
+                x.bits,
+                x.bits,
+                x.bits,
+                x.bits,
+                x.bits,
+                x.bits,
+                negated,
+                0,
+                0,
+                0,
+                negated,
+                negated,
+                negated,
+                one.bits,
+                0,
+            ]
+            for index, (got, want) in enumerate(zip(values, expected_bits, strict=True)):
+                assert got.bits == want, f"fold {index} x=0x{x.bits:x} y=0x{y.bits:x}: 0x{got.bits:x} != 0x{want:x}"
+
+
+def _dynamic_div(x: float, y: float) -> float:
+    return x / y
+
+
+def test_dynamic_non_identical_division_still_emits_fdiv() -> None:
+    result = holoso.synthesize(_dynamic_div, _ops(), name="dynamic_div")
+    assert "holoso_fdiv #" in result.verilog_output.verilog
+
+
+def _div_by_zero_const(x: float) -> float:
+    return x / 0.0
+
+
+def test_nonzero_division_by_zero_constant_still_emits_fdiv_and_value_path() -> None:
+    result = holoso.synthesize(_div_by_zero_const, _ops(), name="div_by_zero_const")
+    assert "holoso_fdiv #" in result.verilog_output.verilog
+    out = result.numerical_model.elaborate().run(FloatValue.from_float(FMT, 1.0))[0]
+    assert isinstance(out, FloatValue)
+    assert math.isinf(float(out)) and float(out) > 0.0
 
 
 def _k_and(a: bool, b: bool) -> bool:

--- a/tests/test_arithmetic_behavior.py
+++ b/tests/test_arithmetic_behavior.py
@@ -373,6 +373,7 @@ def _trivial_float_folds(x: float, y: float) -> list[float]:
         x - x,
     ]
 
+
 def test_trivial_fast_math_float_folds_are_operator_free_and_bit_exact() -> None:
     result = holoso.synthesize(_trivial_float_folds, _ops(), name="trivial_float_folds")
     verilog = result.verilog_output.verilog

--- a/tests/test_extended_operators.py
+++ b/tests/test_extended_operators.py
@@ -499,18 +499,22 @@ def test_min_max_of_constants_fold() -> None:
         assert _bits(sim.run(x)[0]) == ref.bits, f"x={x}"
 
 
-def test_min_max_nonfinite_constant_is_rejected() -> None:
-    # A non-finite constant operand must not be hidden by the fold's selection: even when the finite side would be
-    # selected, the non-finite constant must reach the validator and be rejected, as a bare non-finite literal is.
-    def min_selects_finite(x: float) -> float:
-        return x + min(1e400, 2.0)  # 1e400 overflows to +inf; the fold would select 2.0 but must not drop the inf
+def test_min_max_infinity_constants_fold() -> None:
+    def kernel(x: float) -> float:
+        return x + min(1e400, 2.0) + max(-1e400, 3.0)
 
+    sim = holoso.synthesize(kernel, _ops(with_sort=False), name="min_max_inf_fold").numerical_model.elaborate()
+    for x in [0.0, 3.0, -1.5, 100.25]:
+        ref = (_v(x) + _v(2.0)) + _v(3.0)
+        assert _bits(sim.run(x)[0]) == ref.bits, f"x={x}"
+
+
+def test_min_max_nan_constant_is_rejected() -> None:
     def max_selects_finite(x: float) -> float:
-        return x + max(2.0, 1e400 - 1e400)  # 1e400 - 1e400 is NaN; must be rejected, not selected away
+        return x + max(2.0, 1e400 - 1e400)
 
-    for fn in (min_selects_finite, max_selects_finite):
-        with pytest.raises(UnsupportedConstruct):
-            holoso.synthesize(fn, _ops(), name=fn.__name__)
+    with pytest.raises(UnsupportedConstruct):
+        holoso.synthesize(max_selects_finite, _ops(), name="max_selects_finite")
 
 
 def _ulp32(value: float) -> float:
@@ -862,21 +866,19 @@ def test_trig_of_constants_fold() -> None:
         assert _bits(out[index]) == _v(ref).bits, f"folded output {index}"
 
 
-def test_constant_fold_declines_nonfinite_result() -> None:
-    # A constant subexpression that overflows to inf must be left unfolded, not baked into a non-finite FloatConst.
-    # Regression: the inf previously reached sin/cos's fold and crashed with a raw ValueError from math.sin. Mirrors
-    # the exp2/log2 finiteness convention.
+def test_constant_fold_declines_unsupported_transcendental_results() -> None:
+    # Regression: an inf input to sin/cos's fold crashed with a raw ValueError from math.sin. The fold is declined
+    # instead, leaving the legal infinity operand for the hardware path.
     def unfoldable(x: float) -> tuple[float, float]:
         overflow = math.hypot(1.5e308, 1.5e308)  # stays unfolded -> a hardware op, so sin/cos of it lower normally
         return math.sin(overflow), math.cos(overflow)
 
-    holoso.synthesize(unfoldable, _ops(), name="nonfinite_fold_unfold").numerical_model.elaborate()
+    holoso.synthesize(unfoldable, _ops(), name="inf_fold_unfold").numerical_model.elaborate()
 
     def sin_of_inf(x: float) -> float:
-        return math.sin(1e300 * 1e300) + x  # the product folds to inf; sin must decline it with a clean diagnostic
+        return math.sin(1e300 * 1e300) + x
 
-    with pytest.raises(UnsupportedConstruct):  # rejected, not a raw ValueError crash
-        holoso.synthesize(sin_of_inf, _ops(), name="nonfinite_fold_reject")
+    holoso.synthesize(sin_of_inf, _ops(), name="inf_fold_decline").numerical_model.elaborate()
 
 
 def test_atan2_fold_normalizes_signed_zero() -> None:

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -1,6 +1,7 @@
 """End-to-end tests of the public synthesize() API, the report, artifact writing, and the generated testbench."""
 
 import html
+import math
 import re
 import sys
 from pathlib import Path
@@ -24,6 +25,7 @@ def _kernel(a: float, b: float) -> float:  # module-level so inspect.getsource w
 
 
 FMT32 = FloatFormat(8, 24)
+_NAN = float("nan")
 
 
 def _ops(fmt: FloatFormat = FMT32) -> OpConfig:
@@ -84,16 +86,31 @@ def test_synthesize_threads_pipeline_stages() -> None:
     assert ".LATENCY(5)" in staged.verilog_output.verilog and ".LATENCY(3)" in staged.verilog_output.verilog
 
 
-def test_rejects_non_finite_constants() -> None:
-    def overflow(a: float) -> float:
-        return a + 1e400  # overflows to +inf, not representable in the ZKF format
+def test_rejects_nan_constants() -> None:
+    def nan_global(a: float) -> float:
+        return a + _NAN
 
     def folds_to_nan(a: float) -> float:
-        return a + (1e400 - 1e400)  # inf - inf const-folds to NaN
+        return a + (1e400 - 1e400)
 
-    for fn in (overflow, folds_to_nan):
+    for fn in (nan_global, folds_to_nan):
         with pytest.raises(holoso.UnsupportedConstruct):
             holoso.synthesize(fn, ops=_ops())
+
+
+def test_infinity_constants_are_allowed() -> None:
+    def overflow(a: float) -> float:
+        return a + 1e400
+
+    def hidden_by_fast_math(a: float) -> tuple[float, float, float]:
+        t = a + 1e400
+        return 0.0 * t, 0.0 / t, t / t
+
+    out = holoso.synthesize(overflow, ops=_ops()).numerical_model.elaborate().run(1.0)[0]
+    assert math.isinf(float(out)) and float(out) > 0.0
+
+    folded = holoso.synthesize(hidden_by_fast_math, ops=_ops()).numerical_model.elaborate().run(1.0)
+    assert [float(value) for value in folded] == [0.0, 0.0, 1.0]
 
 
 def test_write_artifacts(tmp_path: Path) -> None:


### PR DESCRIPTION
Constant-fold `x*1`, `x+0`, `x/x`, etc. with nondeterministic behavior involving non-finite operands. E.g. `x/x==1` does not hold per IEEE 754 but the optimization philisophy here assumes operands are valid, domain errors do not occur; with that framing that identity holds.