### PR TITLE
Linear algebra library functions; math library via executable-stub registry

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,13 +148,34 @@ Each operator declares a per-instance initiation interval; most operators have I
 
 Abstract interpretation over the Python AST/CFG with a binding-time lattice (static vs. dynamic). Static values (shapes,
 `__init__`-derived constants, compile-time tables) are evaluated concretely -- real Python/NumPy runs at synthesis time.
-Dynamic values (input ports, persistent state) become SSA handles that accumulate HIR. A `for` over a static `range` is
-unrolled (unless the count exceeds the unroll threshold); a `while` lowers to a real back-edge loop; an `if` on a static
-test takes one branch, on a dynamic test emits a real branch. Static evaluation (used for branch/loop reachability and
-compile-time indices) resolves only the operands that both the reachability scan and lowering reconstruct identically:
-numeric literals, module-level numeric/array constants, read-only instance attributes, and loop counters -- including
-numpy navigation (indexing, slicing, transpose, `.flatten()`) of a module-level array constant or read-only array
-attribute.
+Dynamic values (input ports, persistent state) become SSA handles that accumulate HIR. A `for` over a static `range` or
+an aggregate is unrolled (unless the count exceeds the unroll threshold); a list comprehension unrolls the same way
+(its generator count is likewise bounded, so the unroller cannot recurse without limit),
+yielding a Python list, with every `if` filter folded statically and its targets confined to the comprehension -- which,
+being its own scope in Python, also has them shadow a same-named module constant while bound; a `while` lowers to a real
+back-edge loop; an `if` on a static test takes one branch, on a dynamic test emits a real branch. Static evaluation
+(used for branch/loop reachability and compile-time indices) resolves only the operands that both the reachability
+scan and lowering reconstruct identically: numeric literals, module-level numeric/array constants,
+read-only instance attributes, and loop counters -- including numpy navigation (indexing, slicing, transpose,
+`.flatten()`) of a module-level array constant or read-only array attribute.
+
+Shape queries. An aggregate's shape is a static value, so `len`, `.ndim`, and `.shape[k]` evaluate to compile-time
+integers usable wherever one is expected, there being no runtime integer type to carry one into a value position.
+`len` follows Python and counts the items of any aggregate; `.ndim` and `.shape` are numpy-only and rejected on
+a list/tuple, whatever expression the receiver is spelled as.
+A scalar is rank zero, as a numpy scalar is and a bare Python float is not, which is how the matrix product
+rejects a scalar operand by asking its rank; consistently, an empty-tuple key `x[()]` yields the scalar itself, as it
+does for a numpy scalar, while `x[0]` or a slice is rejected. The resolver sees a closed set of receivers --
+a bound name, a static subscript of one, a state attribute, a module constant,
+a transpose of those -- so a shape query on anything else is rejected rather than guessed at.
+
+Rejecting from within the subset. Lowering descends only the arms the static fold selects, so a `raise` it reaches sits
+on a path taken unconditionally within its own function: it becomes a synthesis error carrying the exception's own
+message (a literal, or an f-string interpolating compile-time integers), located at the raising line. Guarded by a
+data-dependent test it would have to become a runtime exception, which the hardware cannot signal, so it is rejected.
+Branch depth restarts per inlined function -- whether a `raise` is data-dependent is a property of the function that
+writes it, not of a call site that happens to sit in a branch arm. This is what lets a library stub validate its own
+operand shapes while remaining ordinary, executable Python that raises the very same error.
 
 Persistent state. A synthesized method's `self` is not a port: each instance attribute the method writes becomes a
 persistent register (a loop-carried value, the back-edge of the initiation loop), and each attribute it only reads is a
@@ -163,16 +184,33 @@ and writes interleave freely. Public attributes additionally drive a `state_<att
 return anything (and a returned value that is by dataflow a public attribute is deduped onto that state port);
 underscore-prefixed attributes stay internal. A vector-valued attribute (list, tuple, or 1-D numpy array) decomposes
 into one scalar register per element (`attr_0`, `attr_1`, ...), a matrix-valued one (2-D numpy array) row-major into
-`attr_0_0`, `attr_0_1`, ...; a scalar keeps its bare name. Whether an attribute is state follows reachability.
-Reassigning `self` itself is rejected: attributes resolve against the fixed original instance, so a rebinding would
-silently miscompile.
+`attr_0_0`, `attr_0_1`, ...; a scalar keeps its bare name. Reassigning `self` itself is rejected: attributes resolve
+against the fixed original instance, so a rebinding would silently miscompile.
+
+Whether an attribute is state follows reachability, and the scan that decides it runs before the body is lowered, so
+it cannot always fold what lowering folds -- a branch on the shape of a local, or a `for` over an aggregate whose trip
+count it does not know. Where it cannot see a trip count it must fold less, not guess: it walks such a body once with
+the loop target and every counter the body rebinds demoted, and restores that same context afterwards, since an empty
+aggregate runs the body zero times and an unrolled one runs it many. The contract is therefore one-sided: the scan
+yields a conservative superset, trimmed back to the truth once lowering has run, since an attribute lowering never
+touched keeps its reset value for good and is no more state than a read-only one. An attribute lowering only read is
+the other half of that trim: its reads are already in the graph, so it stays a slot whose live-out is its live-in -- a
+register that holds, and, if the attribute is public, a port. Dead code can therefore cost a register and a port an
+exact scan would have folded away, and can make an otherwise read-only attribute look written, costing it the constant
+folding a frozen attribute enjoys -- but never a wrong value. The opposite direction is forbidden and asserted
+against, a write lowering reaches but the scan missed having nowhere to land. The duality is a wart, not a design: see
+DEFERRED.
+
+State lives in the float registers, so an integer reset the format cannot represent exactly is rejected rather than
+silently rounded: it would read back as a different number than the source compares against, and there is no integer
+type to fall back on yet -- see DEFERRED.
 
 Matrices/vectors are statically shaped and unrolled to scalar operations; arrays never exist as hardware aggregates,
 only as compile-time bookkeeping over scalar registers. That bookkeeping is a front-end value -- either a scalar wire or
-an ordered aggregate -- supporting list/tuple literals, numpy-style indexing and constant slicing (`m[i, j]`,
-`m[:, j]`, chained `m[i][j]`), unpacking, transpose (`.T`), and the array factories `np.array`/`asarray`/`asanyarray`;
-only scalar leaves reach HIR, so the supported source is executable numpy. Module-level numeric and ndarray globals
-fold into constants.
+an ordered aggregate -- supporting list/tuple literals and comprehensions, numpy-style indexing and constant slicing
+(`m[i, j]`, `m[:, j]`, chained `m[i][j]`), iteration, unpacking, transpose (`.T`), and the array factories
+`np.array`/`asarray`/`asanyarray`; only scalar leaves reach HIR, so the supported source is executable numpy.
+Module-level numeric and ndarray globals fold into constants.
 
 List/tuple vs. array. A front-end aggregate carries its Python flavor. The guiding principle is to follow Python
 semantics where sensible and otherwise reject a construct rather than silently reinterpret it; in particular a Python
@@ -190,12 +228,16 @@ operand broadcasts over the other side's leaves; this is deliberately narrower t
 pair (vector + matrix) is rejected rather than silently aligned along a different axis than numpy would pick, and `**`
 stays scalar-only (base two with a runtime exponent lowers to exp2; otherwise the exponent must be a compile-time
 integer). Augmented assignment to any aggregate (`+=`, `@=`) is rejected: an array would be mutated in place by
-numpy while the front-end rebinds (diverging for an alias), and a list `+=` is concatenation, which is unsupported. The
-matrix product `@` (equivalently `np.matmul`) follows numpy's shape rules for 1-D and 2-D operands -- inner dimensions
-must agree, a 1-D operand is promoted and its axis dropped from the result, vector @ vector is a scalar -- and expands
-into scalar multiply/add chains. Each dot product is a left fold, which keeps every product single-use feeding an add of
-the running sum: exactly the shape MIR's FMA contraction fuses into one multiply plus an FMA chain when configured. All
-shapes are static; there is no batching (ndim > 2) and no runtime sizing.
+numpy while the front-end rebinds (diverging for an alias), and a list `+=` is concatenation, which is unsupported.
+
+Linear algebra is ordinary library code. The matrix product `@` and the transpose `.T` lower by resolving `np.matmul`
+and `np.transpose` in the same registry a spelled call goes through, so an operator and its call are necessarily
+one implementation. The stubs follow numpy's shape rules for 1-D and 2-D operands and expand into scalar
+multiply/add chains. Each dot product is a left fold, enabling FMA contraction in the MIR.
+Also provided are `np.dot` (the matrix product, since the two agree on this domain), `np.trace`,
+and `np.outer`. Because the stubs expand through the same comprehensions any kernel uses, a matrix dimension is
+bounded by the unroll threshold exactly as a loop trip count is -- an operand axis wider than the threshold is
+rejected rather than unrolled into thousands of scalar operations.
 
 Inlining. A pure function reachable through `__globals__` is inlined -- its body lowered in a fresh scope, its return
 consumed as an aggregate -- so kernels compose. A method call on the synthesized instance (`self.helper(...)`) is
@@ -205,8 +247,10 @@ only the entry method owns the state-slot analysis. Name resolution follows Pyth
 
 Math library. A call dispatches through a registry on the object identity its callee resolves to, not the spelled name,
 so an alias resolves and a shadow does not. The registry maps that object to its lowering: an intrinsic stub (1:1 onto
-an HIR float operator) or a composite stub (built from the intrinsics and inlined).
-Each stub is its own numerical reference.
+an HIR float operator) or a composite stub (built from the intrinsics and inlined). A composite is ordinary Python in
+the supported subset -- shape queries, comprehensions, and `raise` let the linear-algebra stubs be shape-polymorphic and
+self-validating -- so each stub is its own numerical reference, and a rejection inside one is re-attributed to the
+user's call site under the spelling they wrote.
 
 Parameters. Positional and keyword-only parameters become input ports and require an explicit annotation:
 `float`-annotated scalars are floating-point ports, `bool`-annotated ones are 1-bit boolean ports, and a jaxtyping
@@ -330,8 +374,22 @@ a value still lowers correctly but is treated as dynamic, because folding it wou
 track arbitrary local bindings it does not build. Only module-level constants, read-only instance attributes, and loop
 counters fold in static positions.
 
+The scan/lowering duality itself. The reachability scan runs before the body it describes, so it cannot see the local
+bindings lowering will have, and shape queries on locals therefore fold at lowering but not in the scan. Today the
+mismatch is contained by making the contract one-sided -- the scan over-approximates, the truth is trimmed out
+afterwards, and the opposite direction is asserted against -- so the cost is a stray register or port, an attribute
+that stops folding as a constant, or a conservative rejection, never a wrong value. It remains a duality, and every
+new static-evaluation source has to be checked against it by hand. The way out is to give the scan a real
+binding-time environment over locals (shapes at least, values where cheap) so that scan and lowering fold identically
+and neither the trim nor the assertion is needed; short of that, folding could be confined to bindings both phases
+reconstruct. Either is a redesign of the scan, not a patch to it.
+
 Integer operands: typed int operands/constants/operators sharing the wide register bank when their width matches the
-build.
+build. Until then every integer enters the float datapath, so one that binary64 cannot represent exactly is rejected
+rather than silently rounded -- otherwise a stored integer reads back as a different number than the source compares
+against. The check is against binary64, not against the build's own float format: the front end does not know that
+format, and a narrow one rounds every constant, integer or not. An integer attribute in a narrow build can therefore
+still lose its exact value, which typed integers, not a wider check here, are what fix.
 
 ## MIR
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -203,6 +203,11 @@ inlined with the instance context kept, so the callee's own `self.<attr>` reads 
 class MRO; `@staticmethod` and `@property` getters are supported). A called method may read `self` but not write it --
 only the entry method owns the state-slot analysis. Name resolution follows Python.
 
+Math library. A call dispatches through a registry on the object identity its callee resolves to, not the spelled name,
+so an alias resolves and a shadow does not. The registry maps that object to its lowering: an intrinsic stub (1:1 onto
+an HIR float operator) or a composite stub (built from the intrinsics and inlined).
+Each stub is its own numerical reference.
+
 Parameters. Positional and keyword-only parameters become input ports and require an explicit annotation:
 `float`-annotated scalars are floating-point ports, `bool`-annotated ones are 1-bit boolean ports, and a jaxtyping
 array annotation with fixed 1-D/2-D dimensions and a floating dtype (e.g. `Float64[np.ndarray, "3 3"]`) decomposes

--- a/TODO.md
+++ b/TODO.md
@@ -1,18 +1,5 @@
 # TODO
 
-## Scheduler
-
-Multi-instance pooling: `resolve_pool` (`_schedule.py:91`) is hardcoded to budget 1. Downstream is already
-N>1-ready (verified firsthand: budget 2 binds two `fmul` instances, II 21→20, model==interpreter on 300 vectors).
-Needs (a) a demand/feedback signal — `resolve_pool(nodes, prior_schedule)` reading `busy_until` saturation — and
-(b) a scored evaluation surface over `_layout_and_allocate` (II / mux fan-in / reg count). Revisit the reuse bound
-in `OperatorInstance.__post_init__` (now `latency + boundary_step(0) + 1` since the read-latch removal); its deferred
-re-entry-distance check is exactly what an II>1 instance on a back-edge loop would need.
-
-Aggressive cross-block overlap (DEFERRED in DESIGN): cleanly separable — loosen `_issue_side_envelope`'s floor,
-replicate commit-side control per mutually-exclusive successor arm in the emitter, exercise the single-writer
-validator (`_microcode.py`). Promote write-control to a first-class edge/path event.
-
 ## Integer support adjacent
 
 Front-end `_apply_binop` (`_lower.py`) dispatches arithmetic by AST syntax, not operand type; make it
@@ -28,3 +15,72 @@ microcode/emit/html/model today), and one shared scalar port codec (cocotb + mod
 
 Strength reduction is float-keyed (`cval: dict[ValueId, float]`); add a sibling int reduction + a typed-constant
 cache when int lands.
+
+## Frontend subset limitations
+
+A few valid kernels are conservatively rejected rather than compiled. None is a wrong answer; each is a located
+rejection, and each is unusual enough that the precision has not been worth its cost yet.
+
+Arithmetic on an empty aggregate (`-v[:0]`, `v[:0] + v[:0]`) is rejected. An empty aggregate carries no leaves, so the
+leaf-type and shape checks cannot run -- which is exactly what must reject `-boolflags[:0]` (a boolean negation) and
+`a[:0,:] + b[:0,:]` (a width mismatch), both of which CPython rejects. Distinguishing the valid empty-float case would
+need an empty-but-typed aggregate in the value model. This is acceptable, no fix required at the moment.
+
+An empty aggregate loop inside a `while` (`for i in range(2): pass` then `while c: for i in []: pass`) demotes the
+outer counter `i`, so a later `v[i]` is rejected as a non-static index though `i` is still 1 at runtime. This is the
+safe side of the scan/lowering demotion that keeps the state-write invariant sound; making it exact would require the
+demotion to see that an empty aggregate rebinds nothing. This is acceptable, no fix required at the moment.
+
+A comprehension target named `self` (`[self for self in [x]]`) is rejected as rebinding the instance parameter, though
+a comprehension has its own scope and the name is a fresh local there. The self-rebinding guard should not apply to a
+comprehension target. This is acceptable, no fix required at the moment.
+
+## Known defects needing resolution
+
+Several compile-time integer→float folds round an inexact integer where CPython stays exact, so a guarded branch can
+take the wrong arm silently. The recently-added `_reject_inexact_integer` guard covers a literal, a module global, a
+negated literal, and a for/comprehension counter in value position, but not: `_static_relation` (a mixed int/float
+comparison such as `A + B == float(2**53)` with `A = 2**53`, `B = 1`, which folds true where CPython yields false);
+a ternary whose two arms are the same inexact int; a read-only inexact-int attribute read into the datapath; and an
+inexact-int element of a module-level numpy array. Each reproduces at HEAD. The new `raise` and comprehension-`if`
+surfaces re-expose the comparison variant but do not cause it. Fix: route every compile-time integer→float fold
+(`_static_float` and the ternary/attribute/ndarray-element paths) through the exactness check, closing the family.
+
+Two loop-carried variables that read each other silently miscompile. When a `while` body updates two carried
+variables in one step and one new value reads the other, the result is wrong with no diagnostic: `a, b = b, a + x`
+over three iterations returns 6.0 where Python gives 3.0, and it is already wrong at a single iteration (2.0 vs 1.0).
+A hand-rolled swap through a temporary (`t = b; b = a + x; a = t`) fails the same way, so it is not tuple-assignment
+specific; a lone accumulator (`a = a + x`) is correct. The front-end is sound -- `_loop_carried` reports both names
+and both header phis are built with the right mutually-recursive arms -- so the fault is downstream in how those phis
+are lowered, scheduled, and register-allocated: the two carried updates get ordered so one reads the other's
+already-updated value within the step. The numerical model and the MIR interpreter share the defect, so cosimulation
+cannot see it. This is the most serious of the four: an everyday construct, a silent wrong answer. Worth a dedicated
+look at loop-carried-phi scheduling.
+
+Closure free variables are not consulted, so a captured name resolves to a same-named module global (or to the
+builtin). A kernel reading a closure variable folds in a module-level global sharing its name (`x * gain` takes a
+module `gain`, not the freevar), and a captured rebinding of `range`/`len` is treated as the builtin (a freevar
+`range` returning a one-element list still unrolls as `builtin range(2)`, giving two trips where Python runs one).
+Both are silent. `_resolve_name` (`_lower.py:2635`) consults closure cells but is only reached when resolving a
+callee; the value-position paths (`_lower_expr`, `_static_int`, `_static_float`, `_static_ndarray_value`) call
+`_module_global` (`_lower.py:2611`) directly, and `_is_builtin_name` (`_lower.py:946`) checks `__globals__` only --
+all skip `__closure__`. Absent a shadowing global the name is correctly rejected as unknown, which is why it has
+hidden. Fix: route every name lookup, builtin detection included, through one resolver that checks `__closure__`
+before `__globals__`, mirroring Python's LEGB order; it touches several static evaluators and wants its own tests.
+
+`del` of a module global is not recognized as making the name local. `_collect_local_names` (`_lower.py:2580`) does
+not handle `ast.Delete`, so a function that does `del GLOBAL` anywhere binds the name as local throughout in CPython
+(a later read is `UnboundLocalError`), but Holoso still resolves it to the module global and folds its value in. The
+collector also omits names bound by a nested `def`/`class`. Fix: add `ast.Delete` (and nested-definition targets) to
+the local-name walk. A contrived case, but a silent divergence from Python's scoping.
+
+Bare `AssertionError` when two public state slots share a live-out. `assert RegRef(reg) not in write_books, "a
+boundary-install slot must carry no opcode write sources"` (`_emit.py:639`) fires when two public state slots end a
+transaction on the same live-out register -- e.g. two writes to `self.a` followed by `self.b = self.a` (a single copy
+is fine). The front-end, HIR, MIR, and LIR all accept it; only Verilog emission trips. It fails loudly with no output,
+but the message is addressed to a compiler developer, not the user, who deserves a located `SynthesisError`.
+
+A huge integer exponent hangs the compiler. `_lower_pow` (`_lower.py:2194`) expands `x ** n` into an `n - 1` multiply
+chain without bounding `n`, so a large literal exponent spins `lower()` indefinitely. Check the exponent against
+`UNROLL_THRESHOLD` before expanding and raise a located `UnsupportedConstruct`, as the `for`/comprehension unroll paths
+already do.

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -21,10 +21,10 @@ from ._type import (
 from ._value import FloatValue as FloatValue
 from ._errors import (
     HolosoError as HolosoError,
-    MissingIntrinsic as MissingIntrinsic,
     SourceUnavailable as SourceUnavailable,
     SynthesisError as SynthesisError,
     UnsupportedConstruct as UnsupportedConstruct,
+    UnsupportedLibraryFunction as UnsupportedLibraryFunction,
 )
 
 from ._backend.cocotb import CocotbOutput as CocotbOutput

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -51,5 +51,5 @@ from ._operators import (
     OpConfig as OpConfig,
 )
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 __url__ = "https://holoso.digital"

--- a/holoso/_errors.py
+++ b/holoso/_errors.py
@@ -33,8 +33,8 @@ class UnsupportedConstruct(SynthesisError):
     """The input uses a Python construct that Holoso cannot (yet) synthesize."""
 
 
-class MissingIntrinsic(SynthesisError):
-    """The input calls a numeric operator that has no Holoso implementation yet."""
+class UnsupportedLibraryFunction(SynthesisError):
+    """The input calls a recognized math/numpy library function that Holoso does not implement yet."""
 
 
 class SourceUnavailable(SynthesisError):

--- a/holoso/_frontend/_ast_support.py
+++ b/holoso/_frontend/_ast_support.py
@@ -89,16 +89,17 @@ def statement_walrus_names(stmt: ast.stmt) -> set[str]:
 def scope_local_walrus_targets(node: ast.AST) -> set[str]:
     """
     Every walrus target name bound in ``node``'s OWN scope, descending into nested statements/expressions but NOT into a
-    nested function/lambda/comprehension/class (a walrus there binds in that scope, not this one). Unlike the
-    reachability scans, this is purely syntactic: a walrus target is a function local throughout the body -- as in
-    Python -- even inside a dead or out-of-subset statement, so it shadows a same-named global everywhere.
+    nested function/lambda/class (a walrus there binds in that scope, not this one). Unlike the reachability scans, this
+    is purely syntactic: a walrus target is a function local throughout the body -- as in Python -- even inside a dead
+    or out-of-subset statement, so it shadows a same-named global everywhere. A comprehension is also its own scope in
+    Python, but a walrus inside one is rejected outright, so over-collecting from it here can bind no name.
     """
     names: set[str] = set()
     for child in ast.iter_child_nodes(node):
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
             # The body is a separate scope, but a nested def/lambda/class's default-argument, decorator, and base
-            # expressions execute in THIS scope, so a walrus in one of them binds an enclosing local (comprehensions
-            # are out of subset). The body itself is not descended into.
+            # expressions execute in THIS scope, so a walrus in one of them binds an enclosing local.
+            # The body itself is not descended into.
             enclosing: list[ast.expr] = []
             if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
                 enclosing += [d for d in (*child.args.defaults, *child.args.kw_defaults) if d is not None]

--- a/holoso/_frontend/_lib/__init__.py
+++ b/holoso/_frontend/_lib/__init__.py
@@ -4,5 +4,6 @@ resolve(callee) maps a callee object to the Match saying how to lower a call to 
 """
 
 from . import _intrinsics as _intrinsics
+from . import _linalg as _linalg
 from . import _numpy as _numpy
 from ._registry import Intrinsic as Intrinsic, Library as Library, resolve as resolve

--- a/holoso/_frontend/_lib/__init__.py
+++ b/holoso/_frontend/_lib/__init__.py
@@ -1,0 +1,8 @@
+"""
+Executable library stubs and the registry boundary the frontend dispatches calls through.
+resolve(callee) maps a callee object to the Match saying how to lower a call to it, or None when unregistered.
+"""
+
+from . import _intrinsics as _intrinsics
+from . import _numpy as _numpy
+from ._registry import Intrinsic as Intrinsic, Library as Library, resolve as resolve

--- a/holoso/_frontend/_lib/_intrinsics.py
+++ b/holoso/_frontend/_lib/_intrinsics.py
@@ -1,0 +1,107 @@
+"""
+Stubs that map 1:1 onto HIR operators. Stub names are irrelevant to dispatch.
+The bodies delegate to library functions so each stub doubles as a plain-Python numerical reference.
+"""
+
+import math
+import numpy as np
+from ..._hir import *
+from ._registry import intrinsic
+
+
+@intrinsic(FloatFloor, math.floor, np.floor)
+def floor_(x: float) -> float:
+    return float(np.floor(x))
+
+
+@intrinsic(FloatCeil, math.ceil, np.ceil)
+def ceil_(x: float) -> float:
+    return float(np.ceil(x))
+
+
+@intrinsic(FloatTrunc, math.trunc, np.trunc, np.fix)
+def trunc_(x: float) -> float:
+    return float(np.trunc(x))
+
+
+@intrinsic(FloatRound, round, np.round, np.rint, np.around)
+def round_(x: float) -> float:
+    return float(np.round(x))
+
+
+@intrinsic(FloatAbs, abs, math.fabs, np.abs, np.absolute, np.fabs)
+def abs_(x: float) -> float:
+    return math.fabs(x)
+
+
+# np.minimum/maximum (and NaN-suppressing np.fmin/fmax) are the binary elementwise forms; np.min/np.max are reductions
+# and are deliberately unregistered. NaN-propagation differences between the spellings are moot under the fast-math /
+# no-NaN policy, so all binary spellings collapse onto one operator.
+@intrinsic(FloatMin, min, np.minimum, np.fmin)
+def min_(a: float, b: float) -> float:
+    return min(a, b)
+
+
+@intrinsic(FloatMax, max, np.maximum, np.fmax)
+def max_(a: float, b: float) -> float:
+    return max(a, b)
+
+
+@intrinsic(FloatFma, math.fma)
+def fma_(a: float, b: float, c: float) -> float:
+    return math.fma(a, b, c)
+
+
+@intrinsic(FloatExp2, math.exp2, np.exp2)
+def exp2_(x: float) -> float:
+    return float(np.exp2(x))
+
+
+@intrinsic(FloatLog2, math.log2, np.log2)
+def log2_(x: float) -> float:
+    return math.log2(x)
+
+
+@intrinsic(FloatSqrt, math.sqrt, np.sqrt)
+def sqrt_(x: float) -> float:
+    return math.sqrt(x)
+
+
+@intrinsic(FloatSin, math.sin, np.sin)
+def sin_(x: float) -> float:
+    return math.sin(x)
+
+
+@intrinsic(FloatCos, math.cos, np.cos)
+def cos_(x: float) -> float:
+    return math.cos(x)
+
+
+@intrinsic(FloatAtan2, math.atan2, np.arctan2, np.atan2)
+def atan2_(y: float, x: float) -> float:
+    return math.atan2(y, x)
+
+
+@intrinsic(FloatHypot2, math.hypot, np.hypot)
+def hypot_(x: float, y: float) -> float:
+    return math.hypot(x, y)
+
+
+@intrinsic(FloatIsFinite, math.isfinite, np.isfinite)
+def isfinite_(x: float) -> bool:
+    return math.isfinite(x)
+
+
+@intrinsic(FloatIsInf, math.isinf, np.isinf)
+def isinf_(x: float) -> bool:
+    return math.isinf(x)
+
+
+@intrinsic(FloatIsPosInf, np.isposinf)
+def isposinf_(x: float) -> bool:
+    return bool(np.isposinf(x))
+
+
+@intrinsic(FloatIsNegInf, np.isneginf)
+def isneginf_(x: float) -> bool:
+    return bool(np.isneginf(x))

--- a/holoso/_frontend/_lib/_linalg.py
+++ b/holoso/_frontend/_lib/_linalg.py
@@ -1,0 +1,81 @@
+"""
+Linear algebra library functions.
+The stubs are ordinary executable Python over numpy arrays, so each doubles as its own numerical reference.
+
+Batched (`ndim > 2`) operands are unsupported everywhere; there is no runtime sizing.
+
+Booleans reach the arithmetic of every stub and are rejected there; no stub passes one through.
+
+A scalar has `ndim == 0` here, as a numpy scalar does and a Python float does not; that is what lets `matmul`
+reject a scalar operand by asking its rank rather than by a type test the subset cannot express.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from ._registry import lib
+
+
+def _dot(u: np.ndarray, v: np.ndarray) -> Any:
+    """A left fold to enable FMA contraction."""
+    acc = u[0] * v[0]
+    for k in range(1, len(u)):
+        acc = acc + u[k] * v[k]
+    return acc
+
+
+@lib(np.transpose)
+def transpose_(a: np.ndarray) -> Any:
+    if a.ndim == 0:
+        raise ValueError("cannot transpose a scalar value")
+    if a.ndim > 2:
+        raise ValueError(f"transpose of a {a.ndim}-D value is not supported")
+    if a.ndim == 1:
+        return a  # numpy leaves a vector alone: it has no second axis to swap
+    return np.array([[a[i][j] for i in range(len(a))] for j in range(len(a[0]))])
+
+
+@lib(np.matmul, np.dot)
+def matmul_(a: np.ndarray, b: np.ndarray) -> Any:
+    """
+    numpy's shape rules for 1-D and 2-D operands: inner dimensions must agree, a 1-D left operand is promoted to a row
+    and a 1-D right operand to a column, and each promoted axis is dropped from the result -- so vector @ vector is a
+    scalar dot product. Rows iterate outermost and the contraction innermost, one dot product per output element.
+    FIXME Scalars are currently not supported.
+    """
+    if a.ndim == 0 or b.ndim == 0:
+        raise ValueError("FIXME matmul does not accept scalar operands")
+    if a.ndim > 2 or b.ndim > 2:
+        raise ValueError(f"matmul operands must be 1-D or 2-D, got {a.ndim}-D @ {b.ndim}-D")
+    if a.shape[-1] != len(b):
+        raise ValueError(f"matmul dimension mismatch: inner dimensions {a.shape[-1]} and {len(b)} disagree")
+    if b.ndim == 1:
+        if a.ndim == 1:
+            return _dot(a, b)
+        return np.array([_dot(a[i], b) for i in range(len(a))])
+    bt = transpose_(b)  # the columns of b, so every output element is the dot product of two rows
+    if a.ndim == 1:
+        return np.array([_dot(a, bt[j]) for j in range(len(bt))])
+    return np.array([[_dot(a[i], bt[j]) for j in range(len(bt))] for i in range(len(a))])
+
+
+@lib(np.trace)
+def trace_(a: np.ndarray) -> Any:
+    """FIXME Support non-square matrices by running the shorter diagonal."""
+    if a.ndim != 2:
+        raise ValueError(f"trace requires a matrix, got a {a.ndim}-D value")
+    if len(a) != len(a[0]):
+        raise ValueError(f"trace requires a square matrix, got {len(a)}×{len(a[0])}")
+    acc = 0.0
+    for i in range(len(a)):
+        acc = acc + a[i][i]
+    return acc
+
+
+@lib(np.outer)
+def outer_(u: np.ndarray, v: np.ndarray) -> Any:
+    """FIXME Currently does not flatten its operands."""
+    if u.ndim != 1 or v.ndim != 1:
+        raise ValueError(f"outer requires 1-D operands, got {u.ndim}-D and {v.ndim}-D")
+    return np.array([[u[i] * v[j] for j in range(len(v))] for i in range(len(u))])

--- a/holoso/_frontend/_lib/_numpy.py
+++ b/holoso/_frontend/_lib/_numpy.py
@@ -1,0 +1,181 @@
+"""
+Composite math/numpy stubs the frontend inlines like ordinary user functions, expressed via the intrinsics,
+that is, bare-hardware operators. Fast-math transforms are legal here, which may alter semantics.
+
+Math domain violations raise in plain Python but garbage-in-garbage-out in hardware,
+with the error output signals asserted; refer to the operator RTL for details.
+
+Composites compute through the intrinsic stubs (exp2_, atan2_, ...) instead of the library functions directly even
+though the library spellings would lower identically (they are registered intrinsic keys too). The intrinsic stub
+pins each primitive to the numpy/math variant matching the hardware behavior -- e.g. exp2_ saturates to inf like
+the hardware where math.exp2 would raise -- so a composite built on the stubs inherits that hardware-faithful behavior,
+and its plain-Python run uses exactly the primitives (and fast-math choices) it lowers to.
+
+Stub names are irrelevant to dispatch; underscores dodge the builtin names.
+"""
+
+import math
+
+import numpy as np
+
+from ._intrinsics import atan2_, cos_, exp2_, isinf_, log2_, sin_, sqrt_
+from ._registry import lib
+
+_LOG2E = math.log2(math.e)
+_LN2 = math.log(2.0)
+_LOG10_2 = math.log10(2.0)
+_DEG_PER_RAD = 180.0 / math.pi
+_RAD_PER_DEG = math.pi / 180.0
+_INF = math.inf
+
+
+@lib(np.sign)
+def sign_(x: float) -> float:
+    if x > 0.0:
+        r = +1.0
+    elif x < 0.0:
+        r = -1.0
+    else:
+        r = x
+    return r
+
+
+@lib(math.cbrt, np.cbrt)
+def cbrt_(x: float) -> float:
+    """Fastmath: cbrt(−0.0) may return +0.0"""
+    return sign_(x) * exp2_(log2_(abs(x)) / 3.0) if bool(x) else 0.0
+
+
+@lib(math.tan, np.tan)
+def tan_(x: float) -> float:
+    """
+    tan = sin/cos may diverge to +-inf at a pole where cos rounds to zero (the format-nearest pi/2),
+    whereas the float64 reference stays finite there.
+    """
+    s, c = sin_(x), cos_(x)
+    if c == 0.0:  # a real branch (div is unspeculatable), so the pole skips the divide and asserts no div-by-zero flag
+        r = _INF if s >= 0.0 else -_INF
+    else:
+        r = s / c
+    return r
+
+
+@lib(math.atan, np.arctan, np.atan)
+def atan_(x: float) -> float:
+    return atan2_(x, 1.0)
+
+
+@lib(math.asin, np.arcsin, np.asin)
+def asin_(x: float) -> float:
+    return atan2_(x, sqrt_(1.0 - x * x))
+
+
+@lib(math.acos, np.arccos, np.acos)
+def acos_(x: float) -> float:
+    return atan2_(sqrt_(1.0 - x * x), x)
+
+
+@lib(math.exp, np.exp)
+def exp_(x: float) -> float:
+    return exp2_(x * _LOG2E)
+
+
+@lib(math.log, np.log)
+def log_(x: float) -> float:
+    return log2_(x) * _LN2
+
+
+@lib(math.log10, np.log10)
+def log10_(x: float) -> float:
+    return log2_(x) * _LOG10_2
+
+
+@lib(math.expm1, np.expm1)
+def expm1_(x: float) -> float:
+    """FIXME Loses the small-argument precision the reference exists to preserve."""
+    return exp_(x) - 1.0
+
+
+@lib(math.log1p, np.log1p)
+def log1p_(x: float) -> float:
+    """FIXME Loses the small-argument precision the reference exists to preserve."""
+    return log_(1.0 + x)
+
+
+@lib(math.sinh, np.sinh)
+def sinh_(x: float) -> float:
+    return exp_(x - _LN2) - exp_(-x - _LN2)  # the /2 folded into the exponent, so exp does not overflow before it
+
+
+@lib(math.cosh, np.cosh)
+def cosh_(x: float) -> float:
+    return exp_(x - _LN2) + exp_(-x - _LN2)
+
+
+@lib(math.tanh, np.tanh)
+def tanh_(x: float) -> float:
+    """Stable sigmoid form: no exp overflow for large |x|. FIXME Loses precision to cancellation near zero."""
+    return 2.0 / (1.0 + exp2_(-2.0 * x * _LOG2E)) - 1.0
+
+
+@lib(math.asinh, np.asinh, np.arcsinh)
+def asinh_(x: float) -> float:
+    """
+    Sign/abs form avoids the large-negative-x cancellation; the branch avoids x*x overflowing (to +inf, over a huge
+    in-range band) before the sqrt recovers -- there sqrt(x*x + 1) == |x|, so asinh(x) == sign(x)*ln(2|x|).
+    """
+    t = x * x
+    if isinf_(t):
+        r = sign_(x) * (log_(abs(x)) + _LN2)
+    else:
+        r = sign_(x) * log_(abs(x) + sqrt_(t + 1.0))
+    return r
+
+
+@lib(math.acosh, np.acosh, np.arccosh)
+def acosh_(x: float) -> float:
+    """The branch avoids x*x overflowing before the sqrt; there sqrt(x*x - 1) == x, so acosh(x) == ln(2x)."""
+    t = x * x
+    if isinf_(t):
+        r = log_(x) + _LN2
+    else:
+        r = log_(x + sqrt_(t - 1.0))
+    return r
+
+
+@lib(math.atanh, np.atanh, np.arctanh)
+def atanh_(x: float) -> float:
+    return 0.5 * log_((1.0 + x) / (1.0 - x))
+
+
+@lib(math.degrees, np.degrees, np.rad2deg)
+def degrees_(x: float) -> float:
+    return x * _DEG_PER_RAD
+
+
+@lib(math.radians, np.radians, np.deg2rad)
+def radians_(x: float) -> float:
+    return x * _RAD_PER_DEG
+
+
+@lib(pow, math.pow, np.power, np.pow, np.float_power)
+def pow_(b: float, e: float) -> float:
+    """
+    General path is the a>0 identity exp2(e*log2(b)); a negative base is only honored on small-integer e.
+    TODO generalize.
+    """
+    if e == 0.0 or b == 1.0:  # b==1 avoids IEEE 754 divergence on non-finite e
+        r = 1.0
+    elif e == 1.0 or b == 0.0:  # b==0 avoids the pole error signal on log2(0)
+        r = b
+    elif e == 2.0:
+        r = b * b
+    elif e == 3.0:
+        r = b * b * b
+    elif e == 4.0:
+        r = (b * b) * (b * b)
+    elif e == 5.0:
+        r = (b * b) * (b * b * b)
+    else:
+        r = exp2_(e * log2_(b))
+    return r

--- a/holoso/_frontend/_lib/_registry.py
+++ b/holoso/_frontend/_lib/_registry.py
@@ -1,0 +1,68 @@
+"""
+The library registry: a single `resolve(callee)` dispatch boundary that maps a callee object to the Match that
+says how to lower a call to it, or None when it is unregistered.
+"""
+
+import types
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from ..._hir import Operator
+
+
+@dataclass(frozen=True, slots=True)
+class Intrinsic:
+    """A call that lowers to a single HIR float operator."""
+
+    operator: Operator
+
+
+@dataclass(frozen=True, slots=True)
+class Library:
+    """A call that inlines a composite stub function."""
+
+    stub: types.FunctionType
+
+
+type Match = Intrinsic | Library
+
+_REGISTRY: dict[object, Match] = {}
+
+
+def _register(match: Match, keys: Iterable[object]) -> None:
+    for key in keys:
+        assert callable(key), key
+        # A key holds exactly one Match; an alias to an equal Match (e.g. np.atan2 is np.arctan2) is tolerated.
+        assert _REGISTRY.get(key, match) == match, key
+        _REGISTRY[key] = match
+
+
+def intrinsic[F: Callable[..., object]](operator: Callable[[], Operator], *substituted: object) -> Callable[[F], F]:
+    op = operator()  # instantiated once here, so the registry stores an operator instance rather than a live factory
+
+    def register(fn: F) -> F:
+        assert isinstance(fn, types.FunctionType)
+        assert fn.__code__.co_argcount == op.signature.arity
+        _register(Intrinsic(op), (fn, *substituted))
+        return fn
+
+    return register
+
+
+def lib[F: Callable[..., object]](*substituted: object) -> Callable[[F], F]:
+    assert substituted
+
+    def register(fn: F) -> F:
+        assert isinstance(fn, types.FunctionType)
+        _register(Library(fn), substituted)
+        return fn
+
+    return register
+
+
+def resolve(callee: object) -> Match | None:
+    """The Match for a callee object, or None if it is unregistered."""
+    try:
+        return _REGISTRY.get(callee)
+    except TypeError:  # something unhashable -- certainly not in the registry.
+        return None

--- a/holoso/_frontend/_lower.py
+++ b/holoso/_frontend/_lower.py
@@ -11,9 +11,10 @@ from typing import Any, get_args, get_origin
 
 import numpy as np
 
-from .._errors import MissingIntrinsic, SourceLocation, UnsupportedConstruct
+from .._errors import SourceLocation, SynthesisError, UnsupportedConstruct, UnsupportedLibraryFunction
 from .._util import BlockId, ValueId
 from .._hir import *
+from ._lib import Intrinsic, Library, resolve
 
 from ._ast_support import (
     Path,
@@ -137,57 +138,19 @@ def _hir_type_name(scalar_type: Type) -> str:
     return "bool" if isinstance(scalar_type, BoolType) else "float"
 
 
-_NUMPY_IDENTITY = frozenset({"array", "asarray", "asanyarray"})
-
-_SCALAR_INTRINSICS: dict[str, Callable[[], Operator]] = {
-    "floor": FloatFloor,
-    "ceil": FloatCeil,
-    "trunc": FloatTrunc,
-    "fma": FloatFma,
-    "minimum": FloatMin,  # numpy.minimum/maximum are the binary elementwise forms; np.min/np.max are reductions
-    "maximum": FloatMax,
-    "exp2": FloatExp2,
-    "log2": FloatLog2,
-    "sin": FloatSin,
-    "cos": FloatCos,
-    "sqrt": FloatSqrt,
-    "atan2": FloatAtan2,  # numpy spells it arctan2; np.atan2 is the same object on numpy>=2.0
-    "hypot": FloatHypot2,
-    "isfinite": FloatIsFinite,
-    "isinf": FloatIsInf,
-    "isposinf": FloatIsPosInf,
-    "isneginf": FloatIsNegInf,
-}
+# The numpy array factories, matched by object identity: shape-preserving wrappers that are no-ops on a value already
+# resolved to an aggregate. A tuple (probed with ``is``) rather than a set, so an unhashable shadow cannot crash it.
+_NUMPY_ARRAY_FACTORIES = (np.array, np.asarray, np.asanyarray)
 
 
-def _intrinsic_of(obj: object) -> str | None:
-    """
-    The canonical intrinsic name whose actual ``math``/``numpy`` function object is ``obj``, by identity and
-    independent of the bound spelling -- so an alias (``from math import floor as f``) resolves while a shadow
-    (``ceil = abs``), a non-callable (``fma = None``), or a name a module lacks (``np.fma``) yields None.
-    """
-    if obj is None:
-        return None
-    for name in _SCALAR_INTRINSICS:
-        if obj is getattr(math, name, None) or obj is getattr(np, name, None):
+def _spelled_callee(func: ast.expr) -> str:
+    match func:
+        case ast.Name(id=name):
             return name
-    return None
-
-
-# Standard numeric operators that are recognized but not yet implemented; calling them fails with a clear message.
-_KNOWN_INTRINSICS = frozenset(
-    {
-        "cbrt",
-        "tan",
-        "asin",
-        "acos",
-        "atan",
-        "exp",
-        "log",
-        "log10",
-        "pow",
-    }
-)
+        case ast.Attribute(attr=attr):
+            return attr
+        case _:
+            return "<expr>"
 
 
 class _Lowerer:
@@ -803,8 +766,9 @@ class _Lowerer:
         if isinstance(func, ast.Attribute) and func.attr == "flatten" and not node.args and not node.keywords:
             base = self._static_ndarray_value(func.value)
             return base.flatten() if isinstance(base, np.ndarray) else None
-        if self._numpy_function(func) in _NUMPY_IDENTITY and len(node.args) == 1 and not node.keywords:
-            return self._static_ndarray_value(node.args[0])
+        if any(self._resolved_callee(func) is factory for factory in _NUMPY_ARRAY_FACTORIES):
+            if len(node.args) == 1 and not node.keywords:
+                return self._static_ndarray_value(node.args[0])
         return None
 
     def _static_index_key(self, index: ast.expr) -> tuple[int | slice, ...] | None:
@@ -874,21 +838,11 @@ class _Lowerer:
             case _:
                 return None
 
-    def _resolves_to_builtin(self, name: str) -> bool:
-        """
-        Whether a bare ``name`` resolves to the actual Python builtin -- absent from the module globals, or explicitly
-        rebound to the builtin itself -- rather than being shadowed by a user global (a local, or any other object).
-        A shadow is what Python would call, so the name is not the builtin cast/intrinsic it spells.
-        """
-        if self._is_local(name):
-            return False
-        callee = self._fn.__globals__.get(name, _ABSENT)
-        return callee is _ABSENT or callee is getattr(builtins, name, None)
-
     def _cast_call(self, node: ast.expr) -> tuple[str, ast.expr] | None:
         """
-        If ``node`` is an unshadowed builtin ``bool(x)`` / ``float(x)`` call on a single positional argument, return
-        ``(builtin name, argument)``; else None. Lets the static evaluators see through a cast exactly as lowering does.
+        If ``node`` is a builtin ``bool(x)`` / ``float(x)`` call on a single positional argument -- the callee resolved
+        to the actual builtin by identity, under any spelling and never a shadow -- return ``(builtin name, argument)``;
+        else None. Lets the static evaluators see through a cast exactly as lowering does.
         """
         if (
             not isinstance(node, ast.Call)
@@ -897,10 +851,12 @@ class _Lowerer:
             or isinstance(node.args[0], ast.Starred)
         ):
             return None
-        func = node.func
-        if not isinstance(func, ast.Name) or func.id not in ("bool", "float") or not self._resolves_to_builtin(func.id):
-            return None
-        return func.id, node.args[0]
+        resolved = self._resolved_callee(node.func)
+        if resolved is bool:
+            return "bool", node.args[0]
+        if resolved is float:
+            return "float", node.args[0]
+        return None
 
     def _static_bool(self, test: ast.expr) -> bool | None:
         """
@@ -1572,101 +1528,90 @@ class _Lowerer:
                 raise UnsupportedConstruct(".flatten() is only supported on an aggregate value", self._loc(node))
             self._reject_sequence_operand(receiver, "flattening", self._loc(node))
             return receiver.flatten()
-        numpy_fn = self._numpy_function(func)
-        if numpy_fn in _NUMPY_IDENTITY:
+        if isinstance(func, ast.Attribute) and self._is_self_name(func.value):
+            return self._lower_method_call(node, func)
+        # Everything else dispatches on the resolved callee OBJECT, by identity -- never by spelling, so an alias
+        # (``from numpy import asarray as aa``) resolves and a shadow does not. resolve() owns the registry lookup and
+        # its unhashable-shadow guard; the aggregate factories and casts below are the non-operator builtins.
+        resolved = self._resolved_callee(func)
+        name = _spelled_callee(func)
+        if any(resolved is factory for factory in _NUMPY_ARRAY_FACTORIES):
             if node.keywords or len(node.args) != 1 or isinstance(node.args[0], ast.Starred):
-                raise UnsupportedConstruct(f"np.{numpy_fn}() takes a single array-like argument", self._loc(node))
-            return self._as_array(self._lower_expr(node.args[0]), numpy_fn, self._loc(node))
-        if self._is_np_matmul(func):
+                raise UnsupportedConstruct(f"{name}() takes a single array-like argument", self._loc(node))
+            return self._as_array(self._lower_expr(node.args[0]), name, self._loc(node))
+        if resolved is np.matmul:
             if node.keywords:
                 raise UnsupportedConstruct("matmul() takes no keyword arguments", self._loc(node))
             operands = self._lower_args(node)
             if len(operands) != 2:
                 raise UnsupportedConstruct(f"matmul() takes 2 arguments, got {len(operands)}", self._loc(node))
             return self._lower_matmul(operands[0], operands[1], self._loc(node))
-        if isinstance(func, ast.Attribute) and self._is_self_name(func.value):
-            return self._lower_method_call(node, func)
-        intrinsic = self._intrinsic_call(node)
-        if intrinsic is not None:
-            return intrinsic
-        # Resolve a bare name as Python does: a locally bound name shadows any global (and is not callable); a
-        # user-defined global function shadows the built-in ``abs``; ``abs`` is a bare-name builtin, so a method-style
-        # call such as ``x.abs(...)`` is never mistaken for it and falls through to the unsupported-call error.
+        match resolve(resolved):
+            case Intrinsic(operator=operator):
+                return self._lower_intrinsic(node, operator)
+            case Library(stub=stub):
+                return self._inline_library_stub(node, stub)
+        cast = self._lower_cast_builtin(node, resolved)  # bool/float casts and list/tuple sequence rebuilds
+        if cast is not None:
+            return cast
+        # A bare-name GLOBAL function is inlined; a non-callable global shadow is rejected. Gated on ``resolved is
+        # glob`` so this fires only when the module global is what the name actually resolves to -- a freevar shadowing
+        # it makes ``resolved`` the freevar instead, and the global must not be lowered in its place.
         if isinstance(func, ast.Name):
             if self._is_local(func.id):
                 raise UnsupportedConstruct(f"{func.id!r} is a local name, not a callable function", self._loc(node))
-            callee = self._fn.__globals__.get(func.id, _ABSENT)
-            if isinstance(callee, types.FunctionType):
-                return self._inline_call(callee, node)
-            if callee is not _ABSENT and not callable(callee):
-                # A non-callable global shadows the built-in (Python raises ``TypeError`` when calling it), so the name
-                # is not the intrinsic it spells; reject rather than silently lowering, e.g., ``abs`` to a FloatAbs. The
-                # _ABSENT sentinel distinguishes a missing global from one explicitly bound to None, which also shadows.
-                raise UnsupportedConstruct(
-                    f"{func.id!r} is shadowed by a non-callable global; it cannot be called", self._loc(node)
-                )
-            # A bare name is one of the recognized builtins (abs/list/tuple/bool/float) only when it is the actual
-            # builtin. A callable GLOBAL of the same name (a class, partial, or callable instance) is a shadow Python
-            # would call instead, so it must not be mistaken for the builtin cast/abs; it falls through to the
-            # unsupported-call rejection below.
-            builtin_unshadowed = self._resolves_to_builtin(func.id)
-            if func.id == "abs" and not node.keywords and builtin_unshadowed:
-                operands = self._lower_args(node)
-                if len(operands) == 1:
-                    return Scalar(self._builder.operation(FloatAbs(), [self._float_operand(operands[0], node)]))
-            if func.id == "round" and not node.keywords and builtin_unshadowed:
-                # ``round(x)`` rounds to a whole-number float (ties to even); the format-aware hardware does the work.
-                # ``round(x, ndigits)`` (decimal rounding) is rejected rather than silently dropping the digit count.
-                operands = self._lower_args(node)
-                if len(operands) != 1:
+            glob = self._module_global(func.id)
+            if resolved is glob:
+                if isinstance(glob, types.FunctionType):
+                    return self._inline_call(glob, node)
+                if glob is not _ABSENT and not callable(glob):
+                    # A non-callable global shadows the builtin (Python raises TypeError on the call), so the name is
+                    # not the operator/cast it spells. The _ABSENT sentinel distinguishes a missing global from one
+                    # bound to None, which also shadows.
                     raise UnsupportedConstruct(
-                        "round() takes a single argument; round(x, ndigits) is not supported", self._loc(node)
+                        f"{func.id!r} is shadowed by a non-callable global; it cannot be called", self._loc(node)
                     )
-                return Scalar(self._builder.operation(FloatRound(), [self._float_operand(operands[0], node)]))
-            if func.id in ("min", "max") and not node.keywords and builtin_unshadowed:
-                # Binary min(a, b)/max(a, b) only; the variadic and iterable forms (and key=/default=) are not lowered.
-                operands = self._lower_args(node)
-                if len(operands) != 2:
-                    raise UnsupportedConstruct(
-                        f"{func.id}() is supported only with two scalar arguments", self._loc(node)
-                    )
-                operator = FloatMin() if func.id == "min" else FloatMax()
-                return Scalar(
-                    self._builder.operation(operator, [self._float_operand(operand, node) for operand in operands])
-                )
-            if func.id in ("list", "tuple") and not node.keywords and builtin_unshadowed:
-                # list(seq)/tuple(seq) produce a Python sequence (array=False) even from a numpy array; only the top
-                # level is rebuilt as a sequence, elements keep their own flavor (the rows of an array stay arrays).
-                operands = self._lower_args(node)
-                if len(operands) == 1 and isinstance(operands[0], Aggregate):
-                    return Aggregate(operands[0].items, array=False)
-            if func.id == "bool" and not node.keywords and builtin_unshadowed:
-                operands = self._lower_args(node)
-                if len(operands) != 1:
-                    raise UnsupportedConstruct("bool() takes a single scalar argument", self._loc(node))
-                operand = self._scalar(operands[0], node)  # an aggregate argument is rejected here
-                if isinstance(self._builder.type_of(operand), BoolType):
-                    return Scalar(operand)  # bool(<bool>) is identity
-                return Scalar(self._builder.operation(FloatToBool(), [operand]))
-            if func.id == "float" and not node.keywords and builtin_unshadowed:
-                operands = self._lower_args(node)
-                if len(operands) != 1:
-                    raise UnsupportedConstruct("float() takes a single scalar argument", self._loc(node))
-                operand = self._scalar(operands[0], node)  # an aggregate argument is rejected here
-                if isinstance(self._builder.type_of(operand), BoolType):
-                    return Scalar(self._builder.operation(BoolToFloat(), [operand]))
-                return Scalar(operand)  # float(<float>) is identity
-        name = func.id if isinstance(func, ast.Name) else func.attr if isinstance(func, ast.Attribute) else None
-        if name in _KNOWN_INTRINSICS:
-            raise MissingIntrinsic(f"implement this operator: {name}", self._loc(node))
-        raise UnsupportedConstruct(f"unsupported call to {name or '<expr>'!r}", self._loc(node))
+        if callable(resolved) and (
+            isinstance(resolved, np.ufunc) or any(resolved is member for member in vars(math).values())
+        ):
+            raise UnsupportedLibraryFunction(f"library function {name!r} is not implemented yet", self._loc(node))
+        raise UnsupportedConstruct(f"unsupported call to {name!r}", self._loc(node))
 
-    def _intrinsic_call(self, node: ast.Call) -> Value | None:
-        """Lower a ``math``/``numpy`` scalar intrinsic to its HIR operator, or None otherwise."""
-        name = self._intrinsic_name(node.func)
-        if name is None:
+    def _lower_cast_builtin(self, node: ast.Call, resolved: object) -> Value | None:
+        """
+        The type-dispatching builtins that are not operators: ``bool(x)``/``float(x)`` casts and ``list()``/``tuple()``
+        sequence rebuilds, matched by identity so an alias resolves and a shadow does not. Returns None when the callee
+        is not one of them (or is list/tuple on a non-sequence argument), so the caller keeps looking.
+        """
+        if node.keywords:
             return None
-        operator = _SCALAR_INTRINSICS[name]()
+        if resolved is list or resolved is tuple:
+            # list(seq)/tuple(seq) produce a Python sequence (array=False) even from a numpy array; only the top level
+            # is rebuilt as a sequence, elements keep their own flavor (the rows of an array stay arrays).
+            operands = self._lower_args(node)
+            if len(operands) == 1 and isinstance(operands[0], Aggregate):
+                return Aggregate(operands[0].items, array=False)
+            return None
+        if resolved is bool:
+            operands = self._lower_args(node)
+            if len(operands) != 1:
+                raise UnsupportedConstruct("bool() takes a single scalar argument", self._loc(node))
+            operand = self._scalar(operands[0], node)  # an aggregate argument is rejected here
+            if isinstance(self._builder.type_of(operand), BoolType):
+                return Scalar(operand)  # bool(<bool>) is identity
+            return Scalar(self._builder.operation(FloatToBool(), [operand]))
+        if resolved is float:
+            operands = self._lower_args(node)
+            if len(operands) != 1:
+                raise UnsupportedConstruct("float() takes a single scalar argument", self._loc(node))
+            operand = self._scalar(operands[0], node)  # an aggregate argument is rejected here
+            if isinstance(self._builder.type_of(operand), BoolType):
+                return Scalar(self._builder.operation(BoolToFloat(), [operand]))
+            return Scalar(operand)  # float(<float>) is identity
+        return None
+
+    def _lower_intrinsic(self, node: ast.Call, operator: Operator) -> Value:
+        name = _spelled_callee(node.func)
         arity = operator.signature.arity  # the operator's own signature is the single source of truth for arity
         if node.keywords:
             raise UnsupportedConstruct(f"{name}() takes no keyword arguments", self._loc(node))
@@ -1675,35 +1620,44 @@ class _Lowerer:
             raise UnsupportedConstruct(f"{name}() takes {arity} argument(s), got {len(operands)}", self._loc(node))
         return Scalar(self._builder.operation(operator, [self._float_operand(operand, node) for operand in operands]))
 
+    def _inline_library_stub(self, node: ast.Call, stub: types.FunctionType) -> Value:
+        """
+        Inline a composite library stub as an ordinary function, attributing any rejection inside its body to the
+        user's call site: the stub source is not the user's code, so a location pointing into it is not actionable.
+        A stub calling a sibling stub resolves it directly as a plain function, so only this outermost frame wraps.
+        """
+        name = _spelled_callee(node.func)
+        if node.keywords:
+            raise UnsupportedConstruct(f"{name}() takes no keyword arguments", self._loc(node))
+        args = self._lower_args(node)
+        loc = self._loc(node)
+        # Reject arity here, against the spelled name, so the error never surfaces the underscore-prefixed stub name
+        # that _inline would format from the callee's __name__.
+        arity = stub.__code__.co_argcount
+        if len(args) != arity:
+            raise UnsupportedConstruct(f"{name}() takes {arity} argument(s), got {len(args)}", loc)
+        try:
+            return self._inline(stub, args, loc)
+        except SynthesisError as exc:
+            # Re-attribute ANY synthesis error from the stub body (a rejection, or an unimplemented library function it
+            # itself calls) to the user's call site, preserving the concrete error type.
+            raise type(exc)(f"in {name}(): {exc.message}", loc) from exc
+
     def _resolved_callee(self, func: ast.expr) -> object:
         """
-        The module-global object a call targets -- an unshadowed ``<module>.<attr>`` attribute access or an unshadowed
-        bare name -- else None. The object is returned so callers decide dispatch by identity (never by spelling): a
-        shadowing local, a rebound global, or an absent attribute all fail the downstream identity check.
+        The object a call targets -- an unshadowed bare name completing Python's lookup order (enclosing freevar, else
+        module global, else builtin), or an attribute chain rooted in an unshadowed global and walked only through
+        module objects -- else None. The object is returned so callers decide dispatch by identity (never by spelling):
+        a shadowing local, a closure/global rebinding, or an absent attribute all fail the downstream identity check.
         """
-        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and not self._is_local(func.value.id):
-            return getattr(self._fn.__globals__.get(func.value.id), func.attr, None)
-        if isinstance(func, ast.Name) and not self._is_local(func.id):
-            return self._fn.__globals__.get(func.id)
-        return None
-
-    def _intrinsic_name(self, func: ast.expr) -> str | None:
-        """The canonical intrinsic name if ``func`` resolves to a supported ``math``/``numpy`` function, else None."""
-        return _intrinsic_of(self._resolved_callee(func))
-
-    def _is_np_matmul(self, func: ast.expr) -> bool:
-        """Dispatched apart from the scalar intrinsics because matmul is aggregate-valued."""
-        return self._resolved_callee(func) is np.matmul
-
-    def _numpy_function(self, func: ast.expr) -> str | None:
-        """
-        The function name if ``func`` is a ``<numpy>.<name>`` access (under any alias), else None. A locally bound name
-        shadows the global, mirroring Python scoping, so a local ``np`` is not mistaken for the numpy module.
-        """
-        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-            if not self._is_local(func.value.id) and self._fn.__globals__.get(func.value.id) is np:
-                return func.attr
-        return None
+        match func:
+            case ast.Name(id=name):
+                return self._resolve_name(name)
+            case ast.Attribute(value=base, attr=attr):
+                base_obj = self._resolved_callee(base)
+                return getattr(base_obj, attr, None) if isinstance(base_obj, types.ModuleType) else None
+            case _:
+                return None
 
     def _lower_args(self, node: ast.Call) -> list[Value]:
         """A ``*aggregate`` argument is spliced in place: its top-level items (a matrix's rows) inline, as in Python."""
@@ -1782,7 +1736,6 @@ class _Lowerer:
         outer = self._capture()
         self._inlining.add(callee)
         bindings = {param.arg: arg for param, arg in zip(params, args)}
-        # An instance method inherits the caller's scope as its state context; a pure function gets none.
         context = outer if bound_self else None
         self._install(Scope.fresh(callee, bindings, lines, start, filename, context=context, self_name=self_param))
         self._local_names[callee] = self._collect_local_names(fndef)
@@ -2310,6 +2263,36 @@ class _Lowerer:
         global) and apply their own type filter (the int/bool/float positions accept different subsets).
         """
         return self._fn.__globals__.get(name, _ABSENT)
+
+    def _freevar(self, name: str) -> object:
+        """
+        The value ``name`` is closed over from an enclosing scope (a freevar cell of the synthesized function), or
+        ``_ABSENT`` if it is not a freevar. Python resolves an enclosing binding before any global or builtin, so
+        callable dispatch MUST consult this: otherwise a closure that shadows ``pow``/``abs``/... would be miscompiled
+        to the stub/operator it merely spells instead of resolving to the captured object.
+        """
+        code = self._fn.__code__
+        if name in code.co_freevars and self._fn.__closure__ is not None:
+            cell = self._fn.__closure__[code.co_freevars.index(name)]
+            try:
+                return cell.cell_contents
+            except ValueError:  # an unbound cell (the enclosing binding never ran); treat as unresolved
+                return _ABSENT
+        return _ABSENT
+
+    def _resolve_name(self, name: str) -> object:
+        """
+        The object a bare ``name`` resolves to under Python's scoping order -- an enclosing-scope freevar, else a module
+        global, else a builtin -- for callable dispatch by identity. A function-local binding shadows all of these and
+        is a value rather than a callable, so it (and an unbound/unknown name) yields None.
+        """
+        if self._is_local(name):
+            return None
+        freevar = self._freevar(name)
+        if freevar is not _ABSENT:
+            return freevar
+        glob = self._module_global(name)
+        return getattr(builtins, name, None) if glob is _ABSENT else glob
 
     def _collect_written_attrs(self, fndef: ast.FunctionDef) -> None:
         """

--- a/holoso/_frontend/_lower.py
+++ b/holoso/_frontend/_lower.py
@@ -2,12 +2,13 @@
 
 import ast
 import builtins
+import contextlib
 import inspect
 import logging
 import math
 import types
 from collections.abc import Callable, Iterator
-from typing import Any, get_args, get_origin
+from typing import Any, NoReturn, get_args, get_origin
 
 import numpy as np
 
@@ -53,10 +54,41 @@ def _is_array_annotation(annotation: object) -> bool:
     return isinstance(annotation, type) and hasattr(annotation, "dims")
 
 
+def _exactly_a_float(value: object) -> bool:
+    """
+    Whether a real number survives the round trip through the float registers that hold persistent state. Only an
+    integer can fail: a reset the format cannot represent would read back rounded, so a later comparison against the
+    original literal would take the other branch. There is no integer type to fall back on.
+    """
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        return True
+    exact = int(value)
+    try:
+        return float(exact) == exact
+    except OverflowError:
+        return False
+
+
+def _reset_value_shape(value: object) -> tuple[int, ...] | None:
+    """``array_shape`` over a reset-state object: a nested sequence is shaped exactly like the aggregate it denotes."""
+    if isinstance(value, np.ndarray):
+        return tuple(value.shape)
+    if isinstance(value, (list, tuple)):
+        shapes = {_reset_value_shape(item) for item in value}
+        if len(shapes) != 1 or (inner := next(iter(shapes))) is None:
+            return None
+        return (len(value), *inner)
+    # An arbitrary stored object is not a shaped value, whatever attributes it happens to carry.
+    return () if isinstance(value, (bool, np.bool_)) or _real_or_none(value) is not None else None
+
+
 def _real_or_none(value: object) -> float | None:
     """The value as a float if it is a real number (a builtin or numpy int/float, never a boolean), else None."""
     if isinstance(value, (int, float, np.integer, np.floating)) and not isinstance(value, (bool, np.bool_)):
-        return float(value)
+        try:
+            return float(value)
+        except OverflowError:  # an integer beyond the float range; the exactness guard reports it
+            return None
     return None
 
 
@@ -143,6 +175,27 @@ def _hir_type_name(scalar_type: Type) -> str:
 _NUMPY_ARRAY_FACTORIES = (np.array, np.asarray, np.asanyarray)
 
 
+def _library_stub(callee: object) -> types.FunctionType:
+    """
+    The registered stub behind an operator the frontend lowers itself. Going through the registry rather than importing
+    the stub keeps it the single dispatch boundary, so ``a @ b`` and ``np.matmul(a, b)`` are one implementation.
+    """
+    match = resolve(callee)
+    assert isinstance(match, Library), callee
+    return match.stub
+
+
+# A shape query yields a compile-time integer, and there is no runtime integer type to carry it into a value position.
+_STATIC_ONLY = (
+    "{what} yields a compile-time integer, so it is usable only where one is expected: an index, a slice or range "
+    "bound, an exponent, or a branch condition"
+)
+
+# Under Python sequence semantics a numpy-only operation is undefined: list ``+`` concatenates, list ``-``/``@``/``.T``
+# and the ``.ndim``/``.shape`` attributes are errors. So it is rejected rather than silently reinterpreted.
+_SEQUENCE_REJECTION = "{what} on a Python list/tuple is not supported; build a numpy array with np.array([...])"
+
+
 def _spelled_callee(func: ast.expr) -> str:
     match func:
         case ast.Name(id=name):
@@ -200,6 +253,29 @@ class _Lowerer:
         self._readonly_scan_assigned_attrs: set[str] | None = None
         # The names each lowered function binds (parameters and assignment targets); shadow resolution consults these.
         self._local_names: dict[types.FunctionType, set[str]] = {}
+        # Nesting depth of the reachability scans. They run before (or ahead of) the code they describe, so the lowering
+        # environment they would see is not the one lowering will have -- ``_scanning`` is the single gate on that.
+        self._scan_depth = 0
+        # Generators live on the comprehension-expansion recursion stack right now (this comprehension plus every one
+        # it nests inside). Each generator is one frame, so bounding the running total bounds the recursion depth.
+        self._comprehension_frames = 0
+        # Instance attributes lowering actually read or wrote. The scans over-approximate the state set; this is the
+        # truth, and ``_prune_untouched_state`` trims to it. A while loop rewrites ``_state_env`` wholesale on exit, so
+        # membership there does NOT record whether an attribute was ever touched.
+        self._touched_attrs: set[str] = set()
+
+    @contextlib.contextmanager
+    def _scanning(self) -> Iterator[None]:
+        """
+        Mark a reachability scan as running. A scan walks statements it is not lowering, so the environment it would see
+        is not the one lowering will have there; static evaluation therefore resolves no name while a scan runs. Every
+        scan then folds strictly less than lowering, so it can only over-approximate, never miss.
+        """
+        self._scan_depth += 1
+        try:
+            yield
+        finally:
+            self._scan_depth -= 1
 
     def _loc(self, node: ast.AST) -> SourceLocation:
         lineno = getattr(node, "lineno", 1)
@@ -211,6 +287,8 @@ class _Lowerer:
         self._builder.block()  # the entry block (id 0); subsequent blocks are created by branch lowering
         self._bind_parameters(self._entry_fndef)
         self._lower_body(self._entry_fndef)
+        self._prune_untouched_state()
+        self._check_state_slot_names()  # after the prune: an attribute lowering never touched owns no slot to collide
         self._check_return_annotation(self._entry_fndef)
         self._register_state_slots()
         self._emit_outputs()
@@ -232,7 +310,6 @@ class _Lowerer:
             params = params[1:]
             self._assigned_attrs = self._syntactically_assigned_attrs(fndef)
             self._collect_written_attrs(fndef)
-            self._check_state_slot_names()
         # Positional then keyword-only parameters bind in declaration order; arrays decompose into per-element ports.
         for arg in [*params, *args.kwonlyargs]:
             self._env[arg.arg] = self._input(arg)
@@ -396,7 +473,7 @@ class _Lowerer:
                 return self._lower_for(name, iterable, body, self._loc(stmt))
             case ast.For():
                 raise UnsupportedConstruct(
-                    "only 'for <name> in range(...)' over a static count (with no else clause) is supported",
+                    "only 'for <name> in <range(...) or aggregate>' (with no else clause) is supported",
                     self._loc(stmt),
                 )
             case ast.While(test=test, body=body, orelse=[]):
@@ -410,8 +487,60 @@ class _Lowerer:
                 self._reject_nested_return(stmt)
                 self._return = self._lower_expr(value)
                 return True
+            case ast.Raise():
+                self._lower_raise(stmt)
             case _:
                 raise UnsupportedConstruct(f"unsupported statement {type(stmt).__name__}", self._loc(stmt))
+
+    def _lower_raise(self, stmt: ast.Raise) -> NoReturn:
+        """
+        Lowering descends only the arms the static fold selects, so a ``raise`` it reaches is taken unconditionally
+        within its own function: it becomes a located rejection carrying the exception's message. On a data-dependent
+        path it would have to be a runtime exception, which the hardware cannot signal, so it is rejected.
+        """
+        loc = self._loc(stmt)
+        if self._in_branch > 0:
+            raise UnsupportedConstruct(
+                "a 'raise' on a data-dependent path (a runtime branch arm or a loop body) cannot be lowered", loc
+            )
+        if stmt.exc is None or stmt.cause is not None:
+            raise UnsupportedConstruct("only 'raise <Exception>' or 'raise <Exception>(<message>)' is supported", loc)
+        if isinstance(stmt.exc, ast.Call):
+            if stmt.exc.keywords or len(stmt.exc.args) > 1:
+                raise UnsupportedConstruct("a raised exception takes at most one message argument", loc)
+            func = stmt.exc.func
+            message = self._static_str(stmt.exc.args[0]) if stmt.exc.args else _spelled_callee(func)
+        else:
+            func, message = stmt.exc, _spelled_callee(stmt.exc)
+        exception = self._resolved_callee(func)
+        if not (isinstance(exception, type) and issubclass(exception, BaseException)):
+            raise UnsupportedConstruct(f"{_spelled_callee(func)!r} does not name an exception type", loc)
+        raise UnsupportedConstruct(message, loc)
+
+    def _static_str(self, node: ast.expr) -> str:
+        """A compile-time string: a literal, or an f-string interpolating compile-time integers (shapes, counters)."""
+        match node:
+            case ast.Constant(value=str(text)):
+                return text
+            case ast.JoinedStr(values=values):
+                parts: list[str] = []
+                for piece in values:
+                    match piece:
+                        case ast.Constant(value=str(text)):
+                            parts.append(text)
+                        case ast.FormattedValue(value=interpolated, conversion=-1, format_spec=None):
+                            number = self._static_int(interpolated)
+                            if number is None:
+                                raise UnsupportedConstruct(
+                                    "an interpolated value must be a compile-time integer", self._loc(piece)
+                                )
+                            parts.append(str(number))
+                        case _:
+                            raise UnsupportedConstruct(
+                                "only plain '{...}' interpolation is supported", self._loc(piece)
+                            )
+                return "".join(parts)
+        raise UnsupportedConstruct("expected a string literal or an f-string of compile-time integers", self._loc(node))
 
     def _reject_nested_return(self, stmt: ast.stmt) -> None:
         # A return inside a branch arm would need the returns funneled to a single exit with an output phi; deferred.
@@ -419,31 +548,150 @@ class _Lowerer:
         if self._in_branch > 0 and not self._inlining:
             raise UnsupportedConstruct("a 'return' inside a branch or loop is not yet supported", self._loc(stmt))
 
+    def _unroll_sequence(self, iterable: ast.expr, loc: SourceLocation) -> range | tuple[Value, ...]:
+        """
+        The compile-time sequence a ``for`` or a comprehension iterates: a static ``range`` -- left lazy, so an
+        enormous bound is rejected before it is ever materialized -- or the top-level items of an aggregate (a matrix's
+        rows), as in Python. A ``range``-spelled call routes to ``_static_range`` whether or not the name is shadowed,
+        so a shadowed ``range`` is rejected as an unusable range rather than iterated as a value.
+        """
+        if isinstance(iterable, ast.Call) and isinstance(iterable.func, ast.Name) and iterable.func.id == "range":
+            trips = self._static_range(iterable, loc)
+            count = range_trip_count(trips)  # big-int count: reject without materializing, even for range(10**40)
+            self._reject_over_threshold(count, loc)
+            return trips
+        value = self._lower_expr(iterable)
+        if not isinstance(value, Aggregate):
+            raise UnsupportedConstruct("only a range(...) or an aggregate value can be iterated", loc)
+        self._reject_over_threshold(len(value.items), loc)
+        return value.items
+
+    @staticmethod
+    def _reject_over_threshold(count: int, loc: SourceLocation) -> None:
+        if count > UNROLL_THRESHOLD:
+            raise UnsupportedConstruct(
+                f"trip count {count} exceeds the unroll threshold {UNROLL_THRESHOLD}; a counted back-edge loop is "
+                "not supported (use a 'while' loop for a variable trip count)",
+                loc,
+            )
+
+    def _bind_iteration(self, name: str, item: int | Value, loc: SourceLocation) -> None:
+        """
+        Bind one ``for``/comprehension target. A ``range`` counter binds twice -- as a compile-time integer for
+        index/exponent positions and as a float constant for value positions -- while an aggregate item is just a value,
+        so it demotes any stale static-integer binding of the same name. A counter the float register cannot hold
+        exactly is rejected like any inexact integer, since its value-position use would silently round.
+        """
+        if isinstance(item, int):
+            self._reject_inexact_integer(item, loc)
+            self._static_ints[name] = item
+            self._env[name] = Scalar(self._builder.float_const(float(item)))
+        else:
+            self._invalidate_static_int(name)
+            self._env[name] = item
+
     def _lower_for(self, name: str, iterable: ast.expr, body: list[ast.stmt], loc: SourceLocation) -> bool:
         """
-        Lower a ``for <name> in range(...)`` by fully unrolling it: the loop counter is a compile-time integer, so each
-        trip lowers the body once with the counter bound (both as a static int for index/exponent positions and as a
-        float-constant local for value positions). A trip count above the unroll threshold is rejected (a counted
-        back-edge loop is not implemented; use a ``while`` for a variable count, lowered by ``_lower_while``). A
-        ``return`` inside the body is rejected (the single-exit invariant), as in a branch arm.
-        The counter leaks its final value after the loop, matching Python's ``for`` scoping (an empty range leaves any
+        Lower a ``for`` over a static ``range`` or an aggregate by fully unrolling it: each trip lowers the body once
+        with the target bound. A trip count above the unroll threshold is rejected (a counted back-edge loop is not
+        implemented; use a ``while`` for a variable count, lowered by ``_lower_while``). A ``return`` inside the body is
+        rejected (the single-exit invariant), as in a branch arm.
+        The target leaks its final value after the loop, matching Python's ``for`` scoping (an empty range leaves any
         pre-loop binding untouched); restoring it instead would silently miscompile a nested loop that reuses the name.
         """
         self._reject_self_rebinding(name, loc)  # ``for self in ...`` rebinds the instance parameter -- rejected
-        trips = self._static_range(iterable, loc)
-        count = range_trip_count(trips)  # big-int count: reject without materializing, even for range(10**40)
-        if count > UNROLL_THRESHOLD:
-            raise UnsupportedConstruct(
-                f"loop trip count {count} exceeds the unroll threshold {UNROLL_THRESHOLD}; a counted back-edge "
-                "for-loop is not supported (use a 'while' loop for a variable trip count)",
-                loc,
-            )
-        for index in trips:
-            self._static_ints[name] = index
-            self._env[name] = Scalar(self._builder.float_const(float(index)))
+        for item in self._unroll_sequence(iterable, loc):
+            self._bind_iteration(name, item, loc)
             if self._lower_stmts(body):
                 raise UnsupportedConstruct("a 'return' inside a loop is not yet supported", loc)
         return False
+
+    def _lower_listcomp(self, node: ast.ListComp) -> Value:
+        """
+        A list comprehension unrolls into a Python list aggregate, as the equivalent ``for`` loop would. It is its own
+        scope in Python: the targets do not leak, and while bound they shadow a same-named module global -- were they
+        not registered as locals, a static evaluator would resolve that global behind the binding.
+        """
+        if contains_walrus(node):
+            raise UnsupportedConstruct("a walrus inside a comprehension is not supported", self._loc(node))
+        # One expansion frame per generator, and a nested comprehension's frames sit atop this one's, so bound the
+        # running total (not just this comprehension's) to keep the recursion below the interpreter's limit.
+        self._comprehension_frames += len(node.generators)
+        if self._comprehension_frames > UNROLL_THRESHOLD:
+            self._comprehension_frames -= len(node.generators)
+            raise UnsupportedConstruct(
+                f"comprehension nesting expands more than {UNROLL_THRESHOLD} generators", self._loc(node)
+            )
+        # Python evaluates the OUTERMOST iterable in the ENCLOSING scope, before the comprehension's own scope exists,
+        # so ``[x for n in range(n)]`` reads the enclosing ``n`` as the bound. Everything after it sees the targets.
+        head = node.generators[0]
+        outermost = self._unroll_sequence(head.iter, self._loc(self._generator_target(head)))
+        env, static_ints = dict(self._env), dict(self._static_ints)
+        scope_locals = self._local_names[self._fn]
+        targets = {self._generator_target(gen).id for gen in node.generators}
+        added = targets - scope_locals
+        scope_locals |= added
+        for name in targets:  # a comprehension local is unbound until its own generator binds it, as in Python
+            self._env.pop(name, None)
+            self._invalidate_static_int(name)
+        items: list[Value] = []
+        try:
+            self._expand_comprehension(node.elt, node.generators, items, outermost)
+        finally:
+            self._comprehension_frames -= len(node.generators)
+            scope_locals -= added
+            self._env.clear()
+            self._env.update(env)
+            self._static_ints.clear()
+            self._static_ints.update(static_ints)
+        return Aggregate(tuple(items), array=False)
+
+    def _generator_target(self, generator: ast.comprehension) -> ast.Name:
+        loc = self._loc(generator.iter)
+        if generator.is_async:
+            raise UnsupportedConstruct("an async comprehension is not supported", loc)
+        if not isinstance(generator.target, ast.Name):
+            raise UnsupportedConstruct("a comprehension target must be a plain name", loc)
+        self._reject_self_rebinding(generator.target.id, loc)
+        return generator.target
+
+    def _expand_comprehension(
+        self,
+        elt: ast.expr,
+        generators: list[ast.comprehension],
+        items: list[Value],
+        sequence: range | tuple[Value, ...] | None = None,
+    ) -> None:
+        """
+        Unroll the leftmost generator, recursing on the rest; the innermost body lowers ``elt`` once per surviving
+        binding. Only the outermost iterable is pre-evaluated (``sequence``, in the enclosing scope); a nested one is
+        evaluated per outer trip, as in Python, so it may depend on the outer target.
+        """
+        if not generators:
+            items.append(self._lower_expr(elt))
+            return
+        head, *rest = generators
+        target = self._generator_target(head)
+        if sequence is None:
+            sequence = self._unroll_sequence(head.iter, self._loc(head.iter))
+        for item in sequence:
+            self._bind_iteration(target.id, item, self._loc(target))
+            if all(self._static_filter(condition) for condition in head.ifs):
+                self._expand_comprehension(elt, rest, items)
+
+    def _static_filter(self, condition: ast.expr) -> bool:
+        """
+        A comprehension's ``if`` selects which items exist, so it must be a compile-time condition, not a value. The
+        condition is lowered first -- as ``_lower_if`` does -- so its operands are type-checked and an unsupported one
+        is rejected rather than skipped over by a fold that never looks at it.
+        """
+        cond = self._scalar(self._lower_bool(condition), condition)
+        if not isinstance(self._builder.type_of(cond), BoolType):
+            raise UnsupportedConstruct("a comprehension filter must be a boolean value", self._loc(condition))
+        folded = self._static_condition(condition)
+        if folded is None:
+            raise UnsupportedConstruct("a comprehension filter must be a compile-time condition", self._loc(condition))
+        return folded
 
     def _lower_while(self, test: ast.expr, body: list[ast.stmt], loc: SourceLocation) -> bool:
         """
@@ -576,7 +824,9 @@ class _Lowerer:
         attrs: set[str] = set()
         outer_static = dict(self._static_ints)  # the fold-aware walk binds counters; do not perturb lowering's context
         try:
-            self._walk_reachable(stmts, on_attr=lambda node: attrs.add(node.attr), on_name=names.add)
+            with self._scanning():
+                carried = lambda node: attrs.add(node.attr) if node.attr in self._state_order else None
+                self._walk_reachable(stmts, on_attr=carried, on_name=names.add)
         finally:
             self._static_ints = outer_static
         return names, attrs
@@ -611,8 +861,8 @@ class _Lowerer:
                     on_name(name)
                 self._invalidate_static_int(name)  # mirror lowering: a reassigned name is no longer static
             match stmt:
-                case ast.Return():
-                    return True  # statements after a return are unreachable, exactly as lowering stops here
+                case ast.Return() | ast.Raise():
+                    return True  # statements after a return or a raise are unreachable, exactly as lowering stops here
                 case ast.If(test=test, body=body, orelse=orelse):
                     constant = self._static_condition(test)
                     if constant is not None:
@@ -681,31 +931,41 @@ class _Lowerer:
         self, counter: str, iterable: ast.expr, body: list[ast.stmt], recur: Callable[[list[ast.stmt]], bool]
     ) -> None:
         """
-        Unroll a static ``for`` exactly as ``_lower_for`` does -- bind the counter per trip and walk the body (via
-        ``recur``, the enclosing ``_walk_reachable`` continuation) once per trip so a counter-dependent inner range
-        resolves consistently; a non-static / over-threshold range is rejected at lowering, so walk the body once
-        (unbound) so a real write is not missed before that rejection.
+        Walk a ``for`` exactly as ``_lower_for`` does -- bind the counter per trip and walk the body (via ``recur``, the
+        enclosing ``_walk_reachable`` continuation) once per trip so a counter-dependent inner range resolves
+        consistently. Any other iterable is an aggregate (or a range lowering will reject) whose trip count the scan
+        cannot see: the target is demoted first -- so a branch on it cannot fold and hide a rebind while discovering
+        what the body rebinds -- then every name the body rebinds is demoted too, the body is walked once, and that
+        reduced context is restored, exactly as a ``while`` is walked. Letting the single walk's counters escape, or
+        discovering the rebinds while the target is still static, would fold a later branch on a value lowering never
+        produces (an empty aggregate runs the body zero times, an unrolled one runs it more) and miss the state write
+        in the arm it skipped.
         """
         try:
-            trips = self._static_range(iterable, self._loc(iterable))
+            trips: range | None = self._static_range(iterable, self._loc(iterable))
         except UnsupportedConstruct:
+            trips = None
+        if trips is None or range_trip_count(trips) > UNROLL_THRESHOLD:
+            self._static_ints = {n: v for n, v in self._static_ints.items() if n != counter}
+            _, _, demoted = self._loop_carried(body)
+            surviving = {n: v for n, v in self._static_ints.items() if n not in demoted}
+            self._static_ints = dict(surviving)
             recur(body)
-            return
-        if range_trip_count(trips) > UNROLL_THRESHOLD:
-            recur(body)
+            self._static_ints = surviving
             return
         for index in trips:
             self._static_ints[counter] = index
             recur(body)
 
-    def _is_builtin_range(self) -> bool:
+    def _is_builtin_name(self, name: str) -> bool:
         """
-        Whether bare ``range`` resolves to the builtin: not a local, and not shadowed by a module global (which Python
-        resolves before the builtin). A shadowed ``range`` is not the unrollable builtin and is rejected.
+        Whether a bare name still resolves to the builtin: not a local, and not shadowed by a module global (which
+        Python resolves before the builtin). A shadowed ``range``/``len`` is not the builtin and is not special-cased.
         """
-        if self._is_local("range"):
+        if self._is_local(name):
             return False
-        return self._fn.__globals__.get("range", builtins.range) is builtins.range
+        builtin = getattr(builtins, name)
+        return self._fn.__globals__.get(name, builtin) is builtin
 
     def _static_range(self, iterable: ast.expr, loc: SourceLocation) -> range:
         """
@@ -714,7 +974,7 @@ class _Lowerer:
         against the unroll threshold without ever building the sequence (``range(10**9)`` must not OOM the compiler).
         """
         match iterable:
-            case ast.Call(func=ast.Name(id="range"), args=args, keywords=[]) if self._is_builtin_range():
+            case ast.Call(func=ast.Name(id="range"), args=args, keywords=[]) if self._is_builtin_name("range"):
                 bounds = [self._static_int(arg) for arg in args]
                 if not 1 <= len(bounds) <= 3 or any(bound is None for bound in bounds):
                     raise UnsupportedConstruct("range(...) needs 1 to 3 static integer arguments", loc)
@@ -799,6 +1059,145 @@ class _Lowerer:
         value = self._static_ndarray_value(node)
         return value if value is not None and np.ndim(value) == 0 else None
 
+    def _static_shape(self, node: ast.expr) -> tuple[int, ...] | None:
+        """
+        The shape of a value-position expression, resolved without lowering it, or None when it is not a rectangular
+        shaped value the static evaluator can see. A shape it reports must equal ``array_shape`` of the value lowering
+        would produce. Names resolve through the lowering environment, hence the ``_scanning`` gate.
+        """
+        match node:
+            case ast.Name(id=name) if not self._scan_depth and (bound := self._env.get(name)) is not None:
+                return array_shape(bound)
+            case ast.Attribute(attr="T") if not self._is_self_attr(node):
+                self._reject_sequence_receiver(node.value, "transpose", self._loc(node))
+                inner = self._static_shape(node.value)
+                if inner == () and not self._scan_depth:  # the rejection the transpose stub makes
+                    raise UnsupportedConstruct("cannot transpose a scalar value", self._loc(node))
+                return None if inner is None else tuple(reversed(inner))
+            case ast.Attribute(attr=attr) if self._is_self_attr(node) and self._is_stored_attr(attr):
+                return self._snapshot_shape(attr)
+            case ast.Subscript() as sub if self._is_snapshot_rooted(sub):
+                # A subscript of reset state navigates the reset object itself, so a Python list obeys Python indexing
+                # (no numpy tuple key) while an ndarray obeys numpy's -- the probe below would give both numpy rules.
+                obj = self._snapshot_object(sub)
+                return None if obj is None else _reset_value_shape(obj)
+            case ast.Subscript(value=base, slice=index):
+                base_shape, key = self._static_shape(base), self._static_index_key(index)
+                if base_shape is None or key is None:
+                    return None
+                try:  # numpy owns the basic-indexing shape algebra; the probe is a zero-strided view, not a buffer
+                    shape = np.broadcast_to(np.False_, base_shape)[key].shape
+                except IndexError:  # an out-of-range index: unknown here, and rejected when the subscript lowers
+                    return None
+                # An empty slice yields no leaves, and an empty aggregate is not an array (see ``array_shape``), so the
+                # probe must agree rather than report a zero-length axis lowering cannot produce.
+                return None if 0 in shape else shape
+        array = self._static_ndarray_value(node)
+        return array.shape if isinstance(array, np.ndarray) else None
+
+    def _static_value(self, node: ast.expr) -> Value | None:
+        """
+        The already-lowered value an expression denotes, without emitting anything: a bound name, or a static subscript
+        of one. Structural navigation only, so it cannot introduce HIR.
+        """
+        if self._scan_depth:
+            return None
+        match node:
+            case ast.Name(id=name):
+                return self._env.get(name)
+            case ast.Subscript(value=base, slice=index) if (bound := self._static_value(base)) is not None:
+                return self._lower_subscript(bound, index, self._loc(node))
+        return None
+
+    def _static_len(self, node: ast.expr) -> int | None:
+        """
+        ``len()`` follows Python: it counts the top-level items of any aggregate, ragged or not, and rejects a scalar.
+        The rectangular shape is consulted only for a value the environment cannot produce (a module-level constant).
+        """
+        match self._static_value(node):
+            case Aggregate(items=items):
+                return len(items)
+            case Scalar():
+                raise UnsupportedConstruct("len() of a scalar value", self._loc(node))
+        if isinstance(stored := self._snapshot_object(node), (list, tuple)):
+            return len(stored)  # a ragged or empty reset sequence still has a length, as in Python
+        shape = self._static_shape(node)
+        if shape == ():
+            if self._scan_depth:
+                return None
+            raise UnsupportedConstruct("len() of a scalar value", self._loc(node))
+        return None if shape is None else shape[0]
+
+    def _snapshot_shape(self, attr: str) -> tuple[int, ...] | None:
+        """The reset value's own shape. Not ``_shape(attr)``, whose state decomposition admits only 1-D and 2-D."""
+        return _reset_value_shape(self._snapshot[attr])
+
+    def _is_snapshot_rooted(self, node: ast.expr) -> bool:
+        """Whether a subscript chain bottoms out at a stored ``self.<attr>``, so the reset object is authoritative."""
+        match node:
+            case ast.Attribute(attr=attr):
+                return self._is_self_attr(node) and self._is_stored_attr(attr)
+            case ast.Subscript(value=base):
+                return self._is_snapshot_rooted(base)
+        return False
+
+    def _snapshot_object(self, node: ast.expr) -> object | None:
+        """The reset-state object a ``self.<attr>`` chain of static subscripts denotes, or None if it denotes none."""
+        match node:
+            case ast.Attribute(attr=attr) if self._is_self_attr(node) and self._is_stored_attr(attr):
+                return self._snapshot[attr]
+            # An arbitrary stored object is not navigable, whatever `__getitem__` it happens to carry.
+            case ast.Subscript(value=base, slice=index) if isinstance(
+                obj := self._snapshot_object(base), (np.ndarray, list, tuple)
+            ):
+                key = self._static_index_key(index)
+                if key is None:
+                    return None
+                element: object
+                try:
+                    if isinstance(obj, np.ndarray):
+                        element = obj[key]
+                    elif len(key) == 1 and not isinstance(index, ast.Tuple):
+                        element = obj[key[0]]  # a Python sequence takes one int or slice, never a tuple key
+                    else:
+                        return None
+                except IndexError:
+                    return None
+                return element
+        return None
+
+    def _reject_sequence_receiver(self, receiver: ast.expr, what: str, loc: SourceLocation) -> None:
+        """
+        Reject a numpy-only shape query or transpose on a Python list/tuple, however the receiver is spelled. A shape
+        query never lowers its receiver, so ``_reject_sequence_operand`` would only ever see a bare name. A scan walks
+        arms lowering folds away, so it stays silent and lets the rejection happen where lowering reaches it.
+        """
+        if self._scan_depth:
+            return
+        bound = self._static_value(receiver)  # indexing a list of arrays yields an array, not a sequence
+        if bound is not None:
+            self._reject_sequence_operand(bound, what, loc)
+            return
+        match receiver:
+            case ast.Attribute(attr="T") if not self._is_self_attr(receiver):
+                self._reject_sequence_receiver(receiver.value, what, loc)
+            case _ if isinstance(self._snapshot_object(receiver), (list, tuple)):
+                raise UnsupportedConstruct(_SEQUENCE_REJECTION.format(what=what), loc)
+            case ast.Subscript(value=base) if self._snapshot_object(receiver) is None:
+                self._reject_sequence_receiver(base, what, loc)
+
+    def _numpy_property_shape(self, receiver: ast.expr, prop: str, loc: SourceLocation) -> tuple[int, ...] | None:
+        """The shape behind a numpy-only ``.ndim``/``.shape`` query, rejecting a Python sequence receiver as Python does."""
+        self._reject_sequence_receiver(receiver, prop, loc)
+        shape = self._static_shape(receiver)
+        if self._scan_depth:
+            return shape
+        if shape is None and isinstance(self._static_value(receiver), Aggregate):
+            # An aggregate the shape probe cannot describe is ragged or empty; say so rather than let the query surface
+            # as a bare "not a compile-time integer" from wherever it happened to be spelled.
+            raise UnsupportedConstruct(f"{prop} requires a rectangular vector or matrix", loc)
+        return shape
+
     def _static_int(self, node: ast.expr) -> int | None:
         """Evaluate an expression to a compile-time integer (counter, index, or exponent), or None if it is not one."""
         element = self._static_ndarray_element(node)
@@ -807,6 +1206,22 @@ class _Lowerer:
         match node:
             case ast.Constant(value=int(literal)) if not isinstance(literal, bool):
                 return literal
+            case ast.Call(func=ast.Name(id="len"), args=[arg], keywords=[]) if self._is_builtin_name("len"):
+                return self._static_len(arg)
+            case ast.Attribute(attr="ndim") if not self._is_self_attr(node):
+                shape = self._numpy_property_shape(node.value, "ndim", self._loc(node))
+                return None if shape is None else len(shape)
+            case ast.Subscript(value=ast.Attribute(attr="shape") as prop, slice=axis) if not self._is_self_attr(prop):
+                assert isinstance(prop, ast.Attribute)
+                shape = self._numpy_property_shape(prop.value, "shape", self._loc(node))
+                index = self._static_int(axis)
+                if shape is None or index is None:
+                    return None
+                if not -len(shape) <= index < len(shape):
+                    if self._scan_depth:
+                        return None
+                    raise UnsupportedConstruct(f"axis {index} is out of range for {shape_name(shape)}", self._loc(node))
+                return shape[index]
             case ast.Name(id=name) if name in self._static_ints:
                 return self._static_ints[name]
             case ast.Name(id=name) if not self._is_local(name):
@@ -1071,7 +1486,8 @@ class _Lowerer:
             while True:
                 self._readonly_scan_assigned_attrs = current
                 following: set[str] = set()
-                self._collect_assigned(fndef.body, following)
+                with self._scanning():
+                    self._collect_assigned(fndef.body, following)
                 if following == current:
                     return current
                 current = following
@@ -1089,8 +1505,8 @@ class _Lowerer:
         """
         for stmt in stmts:
             match stmt:
-                case ast.Return():
-                    return True  # statements after a return are unreachable, exactly as lowering stops here
+                case ast.Return() | ast.Raise():
+                    return True  # statements after a return or a raise are unreachable, exactly as lowering stops here
                 case ast.If(test=test, body=body, orelse=orelse):
                     # Fold a statically-known guard to its live arm, as lowering does, so a write in the dead arm is not
                     # counted as an assignment (which would wrongly mark a read-only attribute as written and suppress a
@@ -1246,12 +1662,16 @@ class _Lowerer:
     ) -> dict[str, Value]:
         """
         Merge persistent state across the arms: an attribute an arm did not touch carries its live-in there, so a
-        write on only one path becomes a phi against the carried-over value.
+        write on only one path becomes a phi against the carried-over value. An attribute NEITHER arm touched is left
+        alone -- both arms start from the same pre-branch state, so it has no live-in yet, and loading one here would
+        conjure a register out of a branch that never mentions the attribute, defeating ``_prune_untouched_state``.
         """
         merged: dict[str, Value] = {}
         for attr in self._state_order:
             a = then_state.get(attr)
             b = else_state.get(attr)
+            if a is None and b is None:
+                continue
             a = self._live_in(attr) if a is None else a
             b = self._live_in(attr) if b is None else b
             merged[attr] = self._merge_values(a, b, pred_then, pred_else, loc)
@@ -1389,6 +1809,7 @@ class _Lowerer:
                 if isinstance(value, bool):  # checked before int: bool is an int subclass
                     return Scalar(self._builder.bool_const(value))
                 if isinstance(value, (int, float)):
+                    self._reject_inexact_integer(value, self._loc(node))
                     return Scalar(self._builder.float_const(float(value)))
                 raise UnsupportedConstruct(f"unsupported constant {value!r}", self._loc(node))
             case ast.Name(id=name):
@@ -1404,6 +1825,7 @@ class _Lowerer:
                     if isinstance(glob, bool):
                         return Scalar(self._builder.bool_const(glob))
                     if isinstance(glob, (int, float)):
+                        self._reject_inexact_integer(glob, self._loc(node))
                         return Scalar(self._builder.float_const(float(glob)))
                     if isinstance(glob, np.ndarray):
                         return self._constant_array(name, glob, self._loc(node))
@@ -1416,11 +1838,14 @@ class _Lowerer:
                 # A list/tuple literal has Python sequence semantics (array=False): numpy-only operations on it are
                 # rejected; wrapping it in np.array(...) converts it to an array.
                 return Aggregate(tuple(self._lower_elements(elts)), array=False)
+            case ast.ListComp():
+                return self._lower_listcomp(node)
             case ast.Subscript(value=value, slice=index):
                 return self._lower_subscript(self._lower_expr(value), index, self._loc(node))
             case ast.UnaryOp(op=ast.USub(), operand=ast.Constant(value=(int() | float()) as value)) if not isinstance(
                 value, bool
             ):
+                self._reject_inexact_integer(value, self._loc(node))  # a negative literal rounds like a positive one
                 return Scalar(self._builder.float_const(-float(value)))
             case ast.UnaryOp(op=ast.USub(), operand=operand):
                 return self._negate(self._lower_expr(operand), self._loc(node))
@@ -1429,6 +1854,7 @@ class _Lowerer:
                 # arithmetic position (Python's ``+True`` is int 1, which has no runtime representation here).
                 operand_value = self._lower_expr(operand)
                 self._reject_sequence_operand(operand_value, "arithmetic", self._loc(node))
+                self._reject_empty_aggregate(operand_value, "arithmetic", self._loc(node))
                 self._require_float_leaves(
                     operand_value, "arithmetic operands must be floating-point, not boolean", self._loc(node)
                 )
@@ -1450,7 +1876,10 @@ class _Lowerer:
             case ast.Attribute(attr="T") if not self._is_self_attr(node):
                 # ``value.T`` is numpy transpose unless the receiver is the instance itself (an attribute named ``T``
                 # keeps Python's own resolution priority: ``self.T`` is a state read, ``self.P.T`` a transpose).
-                return self._transpose(self._lower_expr(node.value), self._loc(node))
+                receiver = [self._lower_expr(node.value)]
+                return self._inline_library_stub(_library_stub(np.transpose), receiver, self._loc(node), "transpose")
+            case ast.Attribute(attr="ndim" | "shape" as prop) if not self._is_self_attr(node):
+                raise UnsupportedConstruct(_STATIC_ONLY.format(what=f".{prop}"), self._loc(node))
             case ast.Attribute():
                 return self._read_attr(node)
             case ast.NamedExpr(target=ast.Name(id=name), value=value):
@@ -1478,11 +1907,19 @@ class _Lowerer:
 
     def _lower_subscript(self, value: Value, index: ast.expr, loc: SourceLocation) -> Value:
         if isinstance(index, ast.Tuple):
-            # Multi-axis ``m[i, j]`` is a numpy-array op with no meaning on a Python list/tuple (list ``[i, j]`` is a
-            # tuple key -- a TypeError), so it is rejected on a sequence; single-axis indexing works on any aggregate,
-            # matching plain list indexing. A numpy array is always rectangular by construction.
+            # Multi-axis ``m[i, j]`` is a numpy-array op with no meaning on a Python list/tuple, where ``[i, j]`` is a
+            # tuple key. Single-axis indexing works on any aggregate, as plain list indexing does.
             self._reject_sequence_operand(value, "multi-axis indexing", loc)
-            assert not isinstance(value, Aggregate) or array_shape(value) is not None
+            shape = array_shape(value)
+            if shape is None:
+                raise UnsupportedConstruct("multi-axis indexing requires a rectangular vector or matrix", loc)
+            key = self._static_index_key(index)
+            if key is not None:
+                # An axis whose leading slice is empty selects no item, so per-item bounds never fire; probe up front.
+                try:
+                    np.broadcast_to(np.False_, shape)[key]
+                except IndexError as exc:
+                    raise UnsupportedConstruct(f"invalid index: {exc}", loc) from exc
             return self._subscript_axes(value, index.elts, loc)
         return self._subscript_axes(value, [index], loc)
 
@@ -1535,22 +1972,19 @@ class _Lowerer:
         # its unhashable-shadow guard; the aggregate factories and casts below are the non-operator builtins.
         resolved = self._resolved_callee(func)
         name = _spelled_callee(func)
+        if resolved is builtins.len:
+            raise UnsupportedConstruct(_STATIC_ONLY.format(what="len()"), self._loc(node))
         if any(resolved is factory for factory in _NUMPY_ARRAY_FACTORIES):
             if node.keywords or len(node.args) != 1 or isinstance(node.args[0], ast.Starred):
                 raise UnsupportedConstruct(f"{name}() takes a single array-like argument", self._loc(node))
             return self._as_array(self._lower_expr(node.args[0]), name, self._loc(node))
-        if resolved is np.matmul:
-            if node.keywords:
-                raise UnsupportedConstruct("matmul() takes no keyword arguments", self._loc(node))
-            operands = self._lower_args(node)
-            if len(operands) != 2:
-                raise UnsupportedConstruct(f"matmul() takes 2 arguments, got {len(operands)}", self._loc(node))
-            return self._lower_matmul(operands[0], operands[1], self._loc(node))
         match resolve(resolved):
             case Intrinsic(operator=operator):
                 return self._lower_intrinsic(node, operator)
             case Library(stub=stub):
-                return self._inline_library_stub(node, stub)
+                if node.keywords:
+                    raise UnsupportedConstruct(f"{name}() takes no keyword arguments", self._loc(node))
+                return self._inline_library_stub(stub, self._lower_args(node), self._loc(node), name)
         cast = self._lower_cast_builtin(node, resolved)  # bool/float casts and list/tuple sequence rebuilds
         if cast is not None:
             return cast
@@ -1620,19 +2054,17 @@ class _Lowerer:
             raise UnsupportedConstruct(f"{name}() takes {arity} argument(s), got {len(operands)}", self._loc(node))
         return Scalar(self._builder.operation(operator, [self._float_operand(operand, node) for operand in operands]))
 
-    def _inline_library_stub(self, node: ast.Call, stub: types.FunctionType) -> Value:
+    def _inline_library_stub(
+        self, stub: types.FunctionType, args: list[Value], loc: SourceLocation, name: str
+    ) -> Value:
         """
         Inline a composite library stub as an ordinary function, attributing any rejection inside its body to the
         user's call site: the stub source is not the user's code, so a location pointing into it is not actionable.
         A stub calling a sibling stub resolves it directly as a plain function, so only this outermost frame wraps.
+        Also the whole lowering of the operators that ARE library functions -- ``@`` is ``np.matmul`` and ``.T`` is
+        ``np.transpose`` -- so an operator and its spelled call cannot drift apart. ``name`` is the user's spelling,
+        never the underscore-suffixed stub name, which is meaningless to them.
         """
-        name = _spelled_callee(node.func)
-        if node.keywords:
-            raise UnsupportedConstruct(f"{name}() takes no keyword arguments", self._loc(node))
-        args = self._lower_args(node)
-        loc = self._loc(node)
-        # Reject arity here, against the spelled name, so the error never surfaces the underscore-prefixed stub name
-        # that _inline would format from the callee's __name__.
         arity = stub.__code__.co_argcount
         if len(args) != arity:
             raise UnsupportedConstruct(f"{name}() takes {arity} argument(s), got {len(args)}", loc)
@@ -1641,7 +2073,7 @@ class _Lowerer:
         except SynthesisError as exc:
             # Re-attribute ANY synthesis error from the stub body (a rejection, or an unimplemented library function it
             # itself calls) to the user's call site, preserving the concrete error type.
-            raise type(exc)(f"in {name}(): {exc.message}", loc) from exc
+            raise type(exc)(f"in {name}(): {exc.message}", loc) from None  # a cause would point into the stub
 
     def _resolved_callee(self, func: ast.expr) -> object:
         """
@@ -1738,7 +2170,10 @@ class _Lowerer:
         bindings = {param.arg: arg for param, arg in zip(params, args)}
         context = outer if bound_self else None
         self._install(Scope.fresh(callee, bindings, lines, start, filename, context=context, self_name=self_param))
-        self._local_names[callee] = self._collect_local_names(fndef)
+        if (
+            callee not in self._local_names
+        ):  # a pure function of the callee's source, and matmul inlines its dot n*m times
+            self._local_names[callee] = self._collect_local_names(fndef)
         try:
             if bound_self and self._all_assigned_attrs(fndef.body):
                 # A state-mutating helper would have to fold its writes into the entry method's state-slot analysis,
@@ -1762,6 +2197,7 @@ class _Lowerer:
             env=self._env,
             static_ints=self._static_ints,
             return_=self._return,
+            in_branch=self._in_branch,
             instance=self._instance,
             self_name=self._self_name,
             snapshot=self._snapshot,
@@ -1777,6 +2213,7 @@ class _Lowerer:
         self._env = scope.env
         self._static_ints = scope.static_ints
         self._return = scope.return_
+        self._in_branch = scope.in_branch
         self._instance = scope.instance
         self._self_name = scope.self_name
         self._snapshot = scope.snapshot
@@ -1874,19 +2311,13 @@ class _Lowerer:
         raise TypeError(f"unexpected value {value!r}")
 
     def _reject_sequence_operand(self, value: Value, what: str, loc: SourceLocation) -> None:
-        """
-        Reject a numpy-only operation applied to a plain Python list/tuple aggregate. Under Python sequence semantics
-        the operation is undefined (list ``+`` concatenates, list ``-``/``@``/``.T``/``.flatten()`` are errors), so the
-        user must build a numpy array; a scalar or an array operand passes.
-        """
+        """Reject a numpy-only operation applied to a plain Python list/tuple; a scalar or an array operand passes."""
         if isinstance(value, Aggregate) and not value.array:
-            raise UnsupportedConstruct(
-                f"{what} on a Python list/tuple is not supported; build a numpy array with np.array([...])", loc
-            )
+            raise UnsupportedConstruct(_SEQUENCE_REJECTION.format(what=what), loc)
 
     def _apply_binop(self, op: ast.operator, a: Value, b: Value, loc: SourceLocation) -> Value:
         if isinstance(op, ast.MatMult):
-            return self._lower_matmul(a, b, loc)
+            return self._inline_library_stub(_library_stub(np.matmul), [a, b], loc, "matmul")
         if isinstance(a, Aggregate) or isinstance(b, Aggregate):
             # Elementwise arithmetic is a numpy operation; a Python list/tuple operand (including a scalar broadcast
             # like ``list * s``) is rejected. The recursion below only ever revisits array-internal or scalar values.
@@ -1918,6 +2349,8 @@ class _Lowerer:
         # Name an unsupported operator before checking shapes, so its diagnostic wins over a mismatched-shape one.
         if not isinstance(op, (ast.Mult, ast.Add, ast.Sub, ast.Div)):
             raise UnsupportedConstruct(f"unsupported binary operator {type(op).__name__}", loc)
+        self._reject_empty_aggregate(a, "arithmetic", loc)
+        self._reject_empty_aggregate(b, "arithmetic", loc)
         if isinstance(a, Aggregate) and isinstance(b, Aggregate):
             return self._zip_elementwise(op, a, b, loc)
         match (a, b):
@@ -1943,53 +2376,15 @@ class _Lowerer:
                     loc,
                 )
 
-    def _lower_matmul(self, a: Value, b: Value, loc: SourceLocation) -> Value:
-        """
-        Expand ``a @ b`` into scalar multiply/add chains, following numpy's shape rules exactly: operands are 1-D or
-        2-D rectangular arrays with an agreeing inner dimension; a 1-D left operand is promoted to a row, a 1-D right
-        operand to a column, and each promoted axis is dropped from the result -- so vector @ vector is a scalar dot
-        product. There is no batching (ndim > 2) and no hardware aggregate: the result is an ordinary compile-time
-        aggregate of scalar dot products.
-        """
-        self._reject_sequence_operand(a, "the matrix product", loc)
-        self._reject_sequence_operand(b, "the matrix product", loc)
-        shape_a, shape_b = array_shape(a), array_shape(b)
-        if shape_a is None or shape_b is None:
-            raise UnsupportedConstruct("matmul operands must be rectangular vectors or matrices", loc)
-        if shape_a == () or shape_b == ():
-            raise UnsupportedConstruct("matmul does not accept scalar operands", loc)
-        if len(shape_a) > 2 or len(shape_b) > 2:
-            raise UnsupportedConstruct(
-                f"matmul operands must be 1-D or 2-D, got {len(shape_a)}-D @ {len(shape_b)}-D", loc
-            )
-        if shape_a[-1] != shape_b[0]:
-            raise UnsupportedConstruct(f"matmul dimension mismatch: {shape_name(shape_a)} @ {shape_name(shape_b)}", loc)
-        self._require_float_leaves(a, "matmul operands must be floating-point", loc)
-        self._require_float_leaves(b, "matmul operands must be floating-point", loc)
-        rows = [a] if len(shape_a) == 1 else list(self._row_items(a))
-        cols = [b] if len(shape_b) == 1 else list(self._row_items(self._transpose(b, loc)))
-        leaves = [self._dot(self._row_items(row), self._row_items(col), loc) for row in rows for col in cols]
-        return array_of((*shape_a[:-1], *shape_b[1:]), leaves, array=True)
-
-    @staticmethod
-    def _row_items(value: Value) -> tuple[Value, ...]:
-        assert isinstance(value, Aggregate)
-        return value.items
+    def _reject_empty_aggregate(self, value: Value, what: str, loc: SourceLocation) -> None:
+        """An empty aggregate has no leaves, so a check over them proves nothing; it is not an array either."""
+        if isinstance(value, Aggregate) and not value.leaves():
+            raise UnsupportedConstruct(f"{what} on an empty aggregate is not supported", loc)
 
     def _require_float_leaves(self, value: Value, message: str, loc: SourceLocation) -> None:
         for vid in value.leaves():
             if not isinstance(self._builder.type_of(vid), FloatType):
                 raise UnsupportedConstruct(message, loc)
-
-    def _dot(self, xs: tuple[Value, ...], ys: tuple[Value, ...], loc: SourceLocation) -> Scalar:
-        # A left fold rather than a balanced tree: it keeps every product single-use with an add of the running sum,
-        # which is exactly the shape MIR's FMA contraction fuses into one fmul plus a chain of ffma when configured.
-        acc: ValueId | None = None
-        for x, y in zip(xs, ys, strict=True):
-            term = self._builder.operation(FloatMul(), [self._scalar(x, loc), self._scalar(y, loc)])
-            acc = term if acc is None else self._builder.operation(FloatAdd(), [acc, term])
-        assert acc is not None
-        return Scalar(acc)
 
     _RELATIONAL_OPS: dict[type[ast.cmpop], RelationalOp] = {
         ast.Lt: RelationalOp.LT,
@@ -2143,27 +2538,9 @@ class _Lowerer:
         self._builder.position_at(merge_block)
         return self._merge_values(then, else_, then_end, else_end, loc)
 
-    def _transpose(self, value: Value, loc: SourceLocation) -> Value:
-        """
-        ``.T`` with numpy semantics over the supported shapes: identity on a 1-D vector, row/column swap on a 2-D
-        matrix; a scalar, a ragged aggregate, or a deeper nesting is rejected.
-        """
-        self._reject_sequence_operand(value, "transpose", loc)
-        match array_shape(value):
-            case None:
-                raise UnsupportedConstruct("only a rectangular vector or matrix can be transposed", loc)
-            case ():
-                raise UnsupportedConstruct("cannot transpose a scalar value", loc)
-            case (_,):
-                return value
-            case (_, _):
-                columns = zip(*[self._row_items(row) for row in self._row_items(value)])
-                return Aggregate(tuple(Aggregate(column, array=True) for column in columns), array=True)
-            case shape:
-                raise UnsupportedConstruct(f"transpose of a {len(shape)}-D value is not supported", loc)
-
     def _negate(self, value: Value, loc: SourceLocation) -> Value:
         self._reject_sequence_operand(value, "arithmetic", loc)
+        self._reject_empty_aggregate(value, "arithmetic", loc)
         match value:
             case Scalar():
                 return Scalar(self._builder.operation(FloatNeg(), [self._float_operand(value, loc)]))
@@ -2251,6 +2628,13 @@ class _Lowerer:
     def _is_local(self, name: str) -> bool:
         return name in self._local_names[self._fn]
 
+    def _is_stored_attr(self, attr: str) -> bool:
+        """
+        Whether ``self.<attr>`` is a plain snapshotted instance attribute, so its shape may be read off the reset
+        snapshot. A class data descriptor shadows the ``__dict__`` entry for reads, making that entry dead state.
+        """
+        return attr in self._snapshot and not self._is_class_data_descriptor(attr)
+
     def _constant_array(self, name: str, value: np.ndarray, loc: SourceLocation) -> Value:
         """A module-level ndarray constant folds into an aggregate of interned float constants, like a literal."""
         shape, reals = _ndarray_reals(value, f"module constant {name!r}", loc)
@@ -2297,24 +2681,37 @@ class _Lowerer:
     def _collect_written_attrs(self, fndef: ast.FunctionDef) -> None:
         """
         Find the instance attributes the method assigns on any reachable path; these become persistent state, the rest
-        stay constant. Scanning must mirror lowering's static reachability exactly: it descends into both arms of a
-        DYNAMIC ``if`` (an attribute written on only one path is still state, carrying its live-in on the other) but
-        only the taken arm of a literal-constant ``if``, and the body of a ``for`` once per unrolled trip with the
-        counter bound (so a counter-dependent inner range that is empty on every trip -- e.g. ``for i in range(1): for
-        j in range(i): self.s = ...`` -- is never scanned). A write that lowering never reaches must not be classified
-        as state: it would crash slot registration or silently add a spurious state port. Stops at the first top-level
-        return, like ``_lower_stmts``.
+        stay constant. Scanning tracks lowering's static reachability: it descends into both arms of a DYNAMIC ``if``
+        (an attribute written on only one path is still state, carrying its live-in on the other) but only the taken arm
+        of a literal-constant ``if``, and the body of a ``for`` once per unrolled trip with the counter bound (so a
+        counter-dependent inner range that is empty on every trip -- e.g. ``for i in range(1): for j in range(i):
+        self.s = ...`` -- is never scanned). Stops at the first top-level return, like ``_lower_stmts``.
+
+        The scan runs before the body is lowered, so it cannot always fold what lowering folds -- a branch on the shape
+        of a local, or an aggregate ``for`` whose trip count is unknown here. The contract is therefore one-sided: the
+        result is a conservative SUPERSET, trimmed back to the truth by ``_prune_untouched_state`` once lowering has
+        run. The other direction is forbidden and asserted in ``_assign_attr``, since a write lowering reaches but the
+        scan missed would be dropped from the slot set and vanish silently.
+
+        Because the superset covers paths lowering folds away, the scan validates nothing: a write it cannot make state
+        is passed over, and ``_assign_attr`` rejects it if and when lowering reaches it.
         """
-        self._walk_reachable(fndef.body, on_attr=self._register_state_attr)
+        with self._scanning():
+            self._walk_reachable(fndef.body, on_attr=self._register_state_attr)
         self._static_ints.clear()  # the scan binds loop counters to mirror the unroll; lowering re-binds from scratch
 
     def _register_state_attr(self, target: ast.Attribute) -> None:
         """
-        Register a reachable ``self.<attr>`` write target as a persistent state slot, in first-write order. A write
-        through a class data descriptor (e.g. a property setter) or to an attribute with no instance snapshot is
-        rejected with the same diagnostic ``_lower_stmts`` raises -- the state set must be discovered here exactly as
-        lowering will treat it.
+        Register a ``self.<attr>`` write target as a persistent state slot, in first-write order. The scan walks paths
+        lowering may fold away, so a target it cannot make state -- a class data descriptor, or a name the instance
+        snapshot does not hold -- is passed over rather than rejected here: only a write lowering actually reaches is a
+        real write, and ``_reject_unwritable_attr`` rejects it there.
         """
+        if self._is_stored_attr(target.attr) and target.attr not in self._state_order:
+            self._state_order.append(target.attr)
+
+    def _reject_unwritable_attr(self, target: ast.Attribute) -> None:
+        """The two instance attributes a reachable ``self.<attr> = ...`` may not target."""
         attr = target.attr
         if self._is_class_data_descriptor(attr):
             # Python routes ``self.<name> = ...`` through a class data descriptor (e.g. a property setter) even when
@@ -2331,8 +2728,6 @@ class _Lowerer:
                 "(all persistent state must have an initial value)",
                 self._loc(target),
             )
-        if attr not in self._state_order:
-            self._state_order.append(attr)
 
     def _is_self_attr(self, node: ast.expr) -> bool:
         return (
@@ -2444,6 +2839,7 @@ class _Lowerer:
         header phi for an attribute first written in the loop -- sees the value carried over from the previous call.
         """
         if attr in self._state_order and attr not in self._state_env:
+            self._touched_attrs.add(attr)
             shape = self._shape(attr)
             reads = tuple(Scalar(self._read_slot(shape, slot)) for slot in shape.slots)
             self._state_env[attr] = shape.compose(reads)
@@ -2475,6 +2871,8 @@ class _Lowerer:
         return shape.compose(consts)
 
     def _assign_attr(self, target: ast.Attribute, value: Value) -> None:
+        if self._is_self_attr(target):
+            self._reject_unwritable_attr(target)  # deferred from the scan, which also walks paths lowering folds away
         attr = self._attr_of(target)
         shape = self._shape(attr)
         if not shape.accepts(value):
@@ -2498,6 +2896,10 @@ class _Lowerer:
                     f"self.{attr} holds {_hir_type_name(expected)} values; the assigned value has an incompatible type",
                     self._loc(target),
                 )
+        # A write lowering reaches that the scan classified as unreachable would be dropped from the slot set here and
+        # vanish without a trace, so the scan is allowed to over-approximate the state set but never to under-approximate.
+        assert attr in self._state_order, attr
+        self._touched_attrs.add(attr)
         self._state_env[attr] = value
 
     def _shape(self, attr: str) -> StateAttr:
@@ -2551,6 +2953,8 @@ class _Lowerer:
 
     def _coerce_real(self, attr: str, value: object) -> float:
         real = _real_or_none(value)
+        if real is None and isinstance(value, (int, np.integer)) and not isinstance(value, (bool, np.bool_)):
+            self._reject_inexact_integer_element(attr, value)  # float() overflowed: beyond the format entirely
         if real is None:
             raise UnsupportedConstruct(
                 f"instance attribute self.{attr} must hold real numbers (a matrix reset must be a 2-D numpy array, "
@@ -2579,8 +2983,44 @@ class _Lowerer:
         """A public attribute (no leading underscore) drives state_<attr> ports; an underscored one stays internal."""
         return not attr.startswith("_")
 
+    def _prune_untouched_state(self) -> None:
+        """
+        Drop the attributes the scan classified as state but lowering never touched: they keep their reset value, as a
+        read-only attribute does, so nothing in HIR refers to them. An attribute lowering only READ stays a slot whose
+        live-out is its live-in; its live-in is re-materialized here because a ``while`` restores the pre-loop state
+        environment on exit, dropping whatever its body loaded.
+        """
+        for attr in [attr for attr in self._state_order if attr not in self._touched_attrs]:
+            _logger.debug("state attribute %r is written only on paths lowering folded away; not a state slot", attr)
+            self._state_order.remove(attr)
+        for attr in self._state_order:
+            self._ensure_state_loaded(attr)
+
+    def _reject_inexact_integer(self, value: object, loc: SourceLocation) -> None:
+        if not _exactly_a_float(value):
+            raise UnsupportedConstruct(
+                f"the integer {value} has no exact float representation, so it cannot enter the datapath", loc
+            )
+
+    def _reject_inexact_integer_element(self, attr: str, element: object) -> NoReturn:
+        raise UnsupportedConstruct(
+            f"instance attribute self.{attr} resets to the integer {element}, which a float state register cannot "
+            "hold exactly; persistent state has no integer type"
+        )
+
+    def _reject_inexact_integer_reset(self, attr: str) -> None:
+        """A state register holds floats, so an integer reset it cannot represent would read back as another number."""
+        value = self._snapshot[attr]
+        elements = (
+            value.flatten() if isinstance(value, np.ndarray) else value if isinstance(value, (list, tuple)) else [value]
+        )
+        for element in elements:
+            if not _exactly_a_float(element):
+                self._reject_inexact_integer_element(attr, element)
+
     def _register_state_slots(self) -> None:
         for attr in self._state_order:
+            self._reject_inexact_integer_reset(attr)
             shape = self._shape(attr)
             for slot, reset, live_out in zip(shape.slots, shape.resets, self._state_env[attr].leaves()):
                 self._builder.state_slot(slot, reset, live_out)

--- a/holoso/_frontend/_scope.py
+++ b/holoso/_frontend/_scope.py
@@ -1,6 +1,7 @@
 """The per-function lowering scope, its branch-arm result, and source-to-AST parsing for the front-end lowerer."""
 
 import ast
+import functools
 import inspect
 import textwrap
 import types
@@ -26,6 +27,7 @@ class Scope:
     env: dict[str, Value]
     static_ints: dict[str, int]
     return_: Value | None
+    in_branch: int
     instance: object | None
     self_name: str | None
     snapshot: dict[str, object]
@@ -52,12 +54,15 @@ class Scope:
         inherited loop-counter bindings. A pure function gets NO state context (``context`` is None). An instance method
         passes the caller's scope as ``context`` to inherit its instance/snapshot/state -- so the method's
         ``self.<attr>`` reads resolve against the same module -- with ``self_name`` bound to the method's own receiver.
+        The branch depth also restarts: whether the callee's own body guards a statement behind a data-dependent test is
+        a property of the callee, not of the call site that happens to sit inside a branch arm.
         """
         return cls(
             fn=fn,
             env=env,
             static_ints={},
             return_=None,
+            in_branch=0,
             instance=context.instance if context is not None else None,
             self_name=self_name,
             snapshot=context.snapshot if context is not None else {},
@@ -69,7 +74,13 @@ class Scope:
         )
 
 
+@functools.lru_cache(maxsize=1024)  # bounded: a long-lived process must not pin every kernel it ever lowered
 def parse_fndef(fn: types.FunctionType) -> tuple[ast.FunctionDef, list[str], int, str]:
+    """
+    Memoized because inlining reparses: one matrix product inlines its dot-product helper once per output element,
+    so an unmemoized getsourcelines+parse would make lowering quadratic in the operand shapes. The result is treated
+    as immutable by every caller. A raised SourceUnavailable is not cached, so a fixed source is picked up.
+    """
     try:
         lines, start = inspect.getsourcelines(fn)
     except (OSError, TypeError) as exc:

--- a/tests/test_cosim.py
+++ b/tests/test_cosim.py
@@ -712,3 +712,33 @@ def test_cosim_sincos_in_back_edge_loop(sim: str) -> None:
         return acc
 
     run_cosim(sim, kernel, FloatFormat(8, 24), "cs_sincos_loop")
+
+
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_cosim_library_composites(sim: str) -> None:
+    # Composite library stubs end-to-end: cbrt's sign/exp2/log2 expansion behind its zero guard, tan's sincos+div,
+    # the pow rung ladder under a static exponent, sinh's exp difference, and tanh's stable sigmoid form -- all
+    # bit-exact against the model backend.
+    def kernel(x: float, y: float) -> tuple[float, float, float, float, float]:
+        return math.cbrt(x), math.tan(y), pow(x, 3.0), math.sinh(x), math.tanh(y)
+
+    run_cosim(sim, kernel, FloatFormat(8, 24), "cs_lib_composites")
+
+
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_cosim_tan_pole_latches_no_error(sim: str) -> None:
+    # At the format-nearest pi/2, cos rounds to exactly zero. tan's c==0 guard is a real branch (the divide is
+    # unspeculatable, so if-conversion cannot fold it into an always-executed select), which skips the divide at the
+    # pole -- so no divide-by-zero error is latched. The bench asserts err_pc==0 on every vector, so an unguarded
+    # sin/cos would fail here; a normal input in the same run confirms the divide path still works.
+    def kernel(x: float) -> float:
+        return math.tan(x)
+
+    fmt = FloatFormat(8, 24)
+    pole = float(np.float32(math.pi / 2))
+    vectors: list[Mapping[str, int]] = [
+        {"x": fmt.encode(pole)},
+        {"x": fmt.encode(-pole)},
+        {"x": fmt.encode(0.5)},
+    ]
+    run_cosim(sim, kernel, fmt, "cs_tan_pole", vectors=vectors)

--- a/tests/test_extended_operators.py
+++ b/tests/test_extended_operators.py
@@ -36,6 +36,7 @@ from math import ceil, floor, log2, trunc
 # Aliased imports: the local name is NOT the canonical spelling, so dispatch must resolve by callee-object identity.
 from math import floor as aliased_floor
 from math import fma as aliased_fma
+from math import tan as aliased_tan
 
 FMT = FloatFormat(8, 24)  # binary32: a float64 decode of any in-format value is exact, so math/round is an exact oracle
 _POS_INF = float("inf")
@@ -895,3 +896,229 @@ def test_atan2_fold_normalizes_signed_zero() -> None:
     fold_bits = _bits(_sim(folded, "atan2_fold_neg_zero").run(0.0)[0])
     runtime_bits = _bits(_sim(runtime, "atan2_runtime_zero").run(0.0, 0.0)[0])
     assert fold_bits == runtime_bits, "folded signed-zero atan2 must match the datapath's atan2(0, 0)"
+
+
+# --- Composite library stubs: black-box value checks against the substituted math/numpy references. The stubs lower
+# --- through the ordinary operator set, so tolerances cover binary32 rounding plus the identity's error amplification.
+
+
+def test_sign_values() -> None:
+    def kernel(x: float) -> float:
+        return np.sign(x)  # type: ignore[no-any-return]
+
+    sim = _sim(kernel, "lib_sign")
+    for x, want in ((3.5, 1.0), (-1e-30, -1.0), (0.0, 0.0), (_POS_INF, 1.0), (_NEG_INF, -1.0)):
+        assert float(sim.run(x)[0]) == want, f"sign({x})"
+
+
+def test_cbrt_matches_reference() -> None:
+    def kernel(x: float) -> float:
+        return math.cbrt(x)
+
+    sim = _sim(kernel, "lib_cbrt")
+    for x in (8.0, -27.0, 0.5, -1e-6, 1e18, 3.7, -0.125):
+        assert float(sim.run(x)[0]) == pytest.approx(math.cbrt(x), rel=4e-6), f"cbrt({x})"
+    assert float(sim.run(0.0)[0]) == 0.0
+
+
+def test_tan_matches_reference() -> None:
+    def kernel(x: float) -> float:
+        return math.tan(x)
+
+    sim = _sim(kernel, "lib_tan")
+    for x in (0.0, 0.3, 1.0, -1.2, 2.0):
+        assert float(sim.run(x)[0]) == pytest.approx(math.tan(x), rel=1e-5, abs=1e-6), f"tan({x})"
+
+
+def test_tan_pole_returns_signed_infinity() -> None:
+    # At the format-nearest pi/2, cos rounds to exactly zero; the c==0 guard returns a signed infinity (by sin's sign)
+    # rather than dividing. Only the value is asserted here; that the divide is skipped (no div-by-zero error) is a
+    # real-branch property the cosim exercises via its err_pc check.
+    def kernel(x: float) -> float:
+        return math.tan(x)
+
+    sim = _sim(kernel, "lib_tan_pole")
+    pole = float(np.float32(math.pi / 2))
+    assert float(sim.run(pole)[0]) == _POS_INF
+    assert float(sim.run(-pole)[0]) == _NEG_INF
+    assert float(sim.run(0.5)[0]) == pytest.approx(math.tan(0.5), rel=1e-5)  # a normal input still divides
+
+
+def test_atan_asin_acos_match_references() -> None:
+    def kernel(x: float) -> tuple[float, float, float]:
+        return (math.atan(x), math.asin(x), math.acos(x))
+
+    sim = _sim(kernel, "lib_arcs")
+    for x in (0.0, 0.5, -0.5, 0.9, -0.999, 1.0, -1.0):
+        out = sim.run(x)
+        assert float(out[0]) == pytest.approx(math.atan(x), abs=1e-5), f"atan({x})"
+        assert float(out[1]) == pytest.approx(math.asin(x), abs=1e-4), f"asin({x})"
+        assert float(out[2]) == pytest.approx(math.acos(x), abs=1e-4), f"acos({x})"
+
+
+def test_exp_log_log10_match_references() -> None:
+    def kernel(x: float) -> tuple[float, float, float]:
+        return (math.exp(x), math.log(x), math.log10(x))
+
+    sim = _sim(kernel, "lib_exp_log")
+    for x in (0.001, 0.5, 2.0, math.e, 100.0, 1e30):
+        out = sim.run(x)
+        assert float(out[0]) == pytest.approx(math.exp(min(x, 80.0)), rel=2e-5) or x > 80.0, f"exp({x})"
+        assert float(out[1]) == pytest.approx(math.log(x), rel=1e-5, abs=1e-6), f"log({x})"
+        assert float(out[2]) == pytest.approx(math.log10(x), rel=1e-5, abs=1e-6), f"log10({x})"
+
+
+def test_composite_dispatch_numpy_spellings() -> None:
+    def kernel(x: float) -> tuple[float, float, float, float]:
+        return (np.cbrt(x), np.tan(x), np.arcsin(x), np.exp(x))
+
+    sim = _sim(kernel, "lib_np_spellings")
+    for x in (0.25, -0.5):
+        out = sim.run(x)
+        assert float(out[0]) == pytest.approx(math.cbrt(x), rel=4e-6)
+        assert float(out[1]) == pytest.approx(math.tan(x), rel=1e-5)
+        assert float(out[2]) == pytest.approx(math.asin(x), abs=1e-5)
+        assert float(out[3]) == pytest.approx(math.exp(x), rel=1e-5)
+
+
+def test_composite_dispatch_aliased_import() -> None:
+    def kernel(x: float) -> float:
+        return aliased_tan(x)
+
+    sim = _sim(kernel, "lib_tan_aliased")
+    assert float(sim.run(0.7)[0]) == pytest.approx(math.tan(0.7), rel=1e-5)
+
+
+def test_composite_unconfigured_operator_is_rejected() -> None:
+    # cbrt expands through exp2/log2; without them configured the synthesis must fail, proving the expansion is real.
+    def kernel(x: float) -> float:
+        return math.cbrt(x)
+
+    with pytest.raises(UnsupportedConstruct):
+        holoso.synthesize(kernel, _ops(with_exp2=False), name="lib_cbrt_unconfigured")
+
+
+def test_pow_needs_transcendentals_even_for_a_constant_exponent() -> None:
+    # The rung ladder never prunes the general exp2/log2 path, so even a compile-time exponent requires both
+    # configured -- unlike ** which is a bare multiply chain. Guards the DESIGN.md claim.
+    def kernel(x: float) -> float:
+        return pow(x, 3.0)  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct):
+        holoso.synthesize(kernel, _ops(with_exp2=False), name="lib_pow_needs_exp2")
+    with pytest.raises(UnsupportedConstruct):
+        holoso.synthesize(kernel, _ops(with_log2=False), name="lib_pow_needs_log2")
+
+
+def test_pow_static_exponent_matches_star_star_bit_exactly() -> None:
+    def with_pow(x: float) -> float:
+        return pow(x, 3.0)  # type: ignore[no-any-return]
+
+    def with_star(x: float) -> float:
+        return x**3
+
+    sim_pow, sim_star = _sim(with_pow, "lib_pow_static"), _sim(with_star, "lib_pow_star")
+    for x in (2.0, -2.0, 0.5, -1.5, 100.0):
+        assert _bits(sim_pow.run(x)[0]) == _bits(sim_star.run(x)[0]), f"pow(x,3) vs x**3 x={x}"
+    assert float(sim_pow.run(-2.0)[0]) == -8.0
+
+
+def test_pow_runtime_exponent_rungs_and_general_path() -> None:
+    def kernel(b: float, e: float) -> float:
+        return math.pow(b, e)
+
+    sim = _sim(kernel, "lib_pow_runtime")
+    for b in (2.0, -2.0, 0.5, -1.5):  # a rung-hit runtime exponent is exact even for a negative base
+        for e in (0.0, 1.0, 2.0, 3.0, 4.0, 5.0):
+            assert float(sim.run(b, e)[0]) == pytest.approx(math.pow(b, e), rel=1e-6), f"rung b={b} e={e}"
+    for b, e in ((2.0, 0.5), (3.0, 2.5), (10.0, -1.5), (0.5, 8.5)):  # general path: the a>0 exp2/log2 identity
+        assert float(sim.run(b, e)[0]) == pytest.approx(math.pow(b, e), rel=1e-5), f"general b={b} e={e}"
+
+
+def test_pow_dispatch_builtin_and_numpy_spellings() -> None:
+    def kernel(b: float, e: float) -> tuple[float, float, float]:
+        return (pow(b, e), np.power(b, e), np.float_power(b, e))
+
+    sim = _sim(kernel, "lib_pow_spellings")
+    out = sim.run(3.0, 2.0)
+    assert float(out[0]) == 9.0 and float(out[1]) == 9.0 and float(out[2]) == 9.0
+
+
+def test_pow_zero_base_returns_correct_value() -> None:
+    # The b==0 short-circuit keeps the value correct (0**0 == 1, 0**positive == 0); only the datapath value is asserted
+    # here, not the pole error signal (unmodeled by the numerical backend; the RTL cosim is where signals are checked).
+    def kernel(b: float, e: float) -> float:
+        return math.pow(b, e)
+
+    sim = _sim(kernel, "lib_pow_zero_base")
+    assert float(sim.run(0.0, 0.0)[0]) == 1.0
+    for e in (0.5, 1.0, 2.0, 7.0, 20.0):
+        assert float(sim.run(0.0, e)[0]) == 0.0, f"pow(0, {e})"
+
+
+def test_pow_unit_base_returns_one_including_infinite_exponent() -> None:
+    # The b==1 short-circuit gives pow(1, e) == 1 for every representable e, avoiding the exp2(inf*0)=nan the general
+    # path hits at a non-finite exponent. (A NaN exponent is not ZKF-representable, so only +-inf is exercised here.)
+    def kernel(b: float, e: float) -> float:
+        return math.pow(b, e)
+
+    sim = _sim(kernel, "lib_pow_unit_base")
+    for e in (0.0, 2.5, 7.0, _POS_INF, _NEG_INF):
+        assert float(sim.run(1.0, e)[0]) == 1.0, f"pow(1, {e})"
+
+
+def test_hyperbolic_match_references() -> None:
+    def kernel(x: float) -> tuple[float, float, float]:
+        return (math.sinh(x), math.cosh(x), math.tanh(x))
+
+    sim = _sim(kernel, "lib_hyperbolic")
+    # 88, 89 are inside binary32's exp-overflow band [88.7, 89.4]: sinh/cosh are ~2e38 (representable), so folding the
+    # /2 into the exponent must keep them finite instead of overflowing exp before the halving.
+    for x in (0.0, 0.5, -0.5, 2.0, -2.0, 5.0, -5.0, 88.0, 89.0, -89.0):
+        out = sim.run(x)
+        assert float(out[0]) == pytest.approx(math.sinh(x), rel=1e-5, abs=1e-5), f"sinh({x})"
+        assert float(out[1]) == pytest.approx(math.cosh(x), rel=1e-5), f"cosh({x})"
+        assert float(out[2]) == pytest.approx(math.tanh(x), rel=1e-5, abs=1e-5), f"tanh({x})"
+
+
+def test_inverse_hyperbolic_match_references() -> None:
+    # Independent inputs: asinh spans all reals, acosh needs w>=1, atanh needs |u|<1.
+    def kernel(x: float, w: float, u: float) -> tuple[float, float, float]:
+        return (math.asinh(x), math.acosh(w), math.atanh(u))
+
+    sim = _sim(kernel, "lib_inverse_hyperbolic")
+    # The large-|x| cases (>= 1e19) are the regression: binary32 x*x overflows to inf there, so without the branch
+    # asinh/acosh returned inf across the whole band up to FLT_MAX, where the true values (~44..89) are representable.
+    cases = [(0.0, 1.0, 0.0), (2.0, 1.5, 0.5), (-2.0, 2.0, -0.5), (100.0, 100.0, 0.9), (-100.0, 4.0, -0.9)]
+    cases += [(1e19, 1e19, 0.5), (1e30, 1e38, -0.5), (-1e30, 3e38, 0.9)]
+    for x, w, u in cases:
+        out = sim.run(x, w, u)
+        assert float(out[0]) == pytest.approx(math.asinh(x), rel=1e-5, abs=1e-4), f"asinh({x})"
+        assert float(out[1]) == pytest.approx(math.acosh(w), rel=1e-5, abs=1e-4), f"acosh({w})"
+        assert float(out[2]) == pytest.approx(math.atanh(u), rel=1e-5, abs=1e-5), f"atanh({u})"
+
+
+def test_expm1_log1p_degrees_radians_match_references() -> None:
+    def kernel(x: float) -> tuple[float, float, float, float]:
+        return (math.expm1(x), math.log1p(x * x), math.degrees(x), math.radians(x))
+
+    sim = _sim(kernel, "lib_expm1_log1p_angles")
+    for x in (0.0, 0.5, -0.5, 2.0, -2.0):
+        out = sim.run(x)
+        assert float(out[0]) == pytest.approx(math.expm1(x), rel=1e-5, abs=1e-5), f"expm1({x})"
+        assert float(out[1]) == pytest.approx(math.log1p(x * x), rel=1e-5, abs=1e-5), f"log1p({x * x})"
+        assert float(out[2]) == pytest.approx(math.degrees(x), rel=1e-5, abs=1e-5), f"degrees({x})"
+        assert float(out[3]) == pytest.approx(math.radians(x), rel=1e-5, abs=1e-5), f"radians({x})"
+
+
+def test_new_composite_and_binary_numpy_spellings() -> None:
+    def kernel(x: float, y: float) -> tuple[float, float, float, float, float]:
+        return (np.sinh(x), np.arcsinh(x), np.fmin(x, y), np.fmax(x, y), np.fix(x))  # type: ignore[return-value]
+
+    sim = _sim(kernel, "lib_new_spellings")
+    for x, y in ((1.5, -2.0), (-0.5, 3.0)):
+        out = sim.run(x, y)
+        assert float(out[0]) == pytest.approx(math.sinh(x), rel=1e-5, abs=1e-5)
+        assert float(out[1]) == pytest.approx(math.asinh(x), rel=1e-5, abs=1e-5)
+        assert float(out[2]) == min(x, y) and float(out[3]) == max(x, y)
+        assert float(out[4]) == math.trunc(x)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -13,7 +13,8 @@ from typing import cast
 import numpy as np
 import pytest
 
-from holoso import UnsupportedConstruct, UnsupportedLibraryFunction
+import holoso
+from holoso import FloatFormat, UnsupportedConstruct, UnsupportedLibraryFunction
 from holoso._frontend import lower
 from holoso._frontend._ast_support import port_name
 from holoso._hir import (
@@ -47,7 +48,7 @@ from holoso._hir import (
     StateRead,
 )
 
-from ._modelref import arith_count as _arith_count, flatten_value, output_names
+from ._modelref import arith_count as _arith_count, default_ops, flatten_value, output_names
 
 
 def test_scalar_is_output_zero() -> None:
@@ -387,6 +388,45 @@ def test_globally_shadowed_range_is_rejected(tmp_path: Path) -> None:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     with pytest.raises(UnsupportedConstruct, match="for-loop must iterate over range"):
+        lower(module.kernel)
+
+
+def _lower_generated_kernel(tmp_path: Path, name: str, source: str):  # type: ignore[no-untyped-def]
+    import importlib.util
+
+    module_path = tmp_path / f"_{name}.py"
+    module_path.write_text(source)
+    spec = importlib.util.spec_from_file_location(f"_{name}", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_comprehension_with_too_many_generators_is_a_located_rejection(tmp_path: Path) -> None:
+    # Regression (Codex): each generator adds one `_expand_comprehension` frame, so a comprehension with hundreds of
+    # generators used to leak a bare RecursionError. It now rejects with a located error; CPython runs it normally.
+    clauses = " ".join(f"for a{i} in [{float(i)!r}]" for i in range(200))
+    module = _lower_generated_kernel(
+        tmp_path, "many_generators", f"def kernel(x: float) -> float:\n    return [x {clauses}][0]\n"
+    )
+    assert module.kernel(6.5) == 6.5  # valid, runnable Python
+    with pytest.raises(UnsupportedConstruct, match="comprehension nesting expands"):
+        lower(module.kernel)
+
+
+def test_deeply_nested_comprehensions_are_a_located_rejection(tmp_path: Path) -> None:
+    # Regression (Codex): a single comprehension's generators are bounded, but nested comprehensions accumulate
+    # expansion frames across levels, so deep nesting used to leak a bare RecursionError; it is now a located error.
+    inner = "x"
+    for depth in range(15):
+        clauses = " ".join(f"for a{depth}_{i} in [0.0]" for i in range(64))
+        inner = f"[{inner} {clauses}][0]"
+    module = _lower_generated_kernel(
+        tmp_path, "nested_comprehensions", f"def kernel(x: float) -> float:\n    return {inner}\n"
+    )
+    assert module.kernel(3.25) == 3.25  # valid, runnable Python (below CPython's own compiler limit)
+    with pytest.raises(UnsupportedConstruct, match="comprehension nesting expands"):
         lower(module.kernel)
 
 
@@ -2574,3 +2614,1282 @@ def test_explicit_return_none_is_accepted_for_stateful_method() -> None:
             return None
 
     lower(Acc().update)
+
+
+# ---------------------------------------------------------------- compile-time shape queries
+
+
+def test_static_shape_queries_in_index_range_and_branch_positions() -> None:
+    from jaxtyping import Float64
+
+    def kernel(v: Float64[np.ndarray, "3"], m: Float64[np.ndarray, "2 3"]) -> float:
+        acc = v[0]
+        for i in range(1, len(v)):  # len() bounds an unrolled range
+            acc = acc + v[i]
+        acc = acc + m[m.ndim - 2][m.shape[-1] - 3]  # .ndim and .shape[k] are compile-time integers
+        if v.ndim == 1:  # a shape comparison folds, so only the taken arm is lowered
+            acc = acc * 2.0
+        return acc
+
+    hir = lower(kernel)
+    assert [o.name for o in hir.outputs] == ["out_0"]
+    assert _arith_count(hir, FloatAdd) == 3  # v[0]+v[1]+v[2] then +m[0][0]; the ndim branch adds no add
+    assert _arith_count(hir, FloatMul) == 1
+
+
+def test_len_follows_python_and_accepts_a_ragged_list() -> None:
+    # len() is a Python builtin, not a numpy one, so it counts the items of any aggregate; only .ndim/.shape are
+    # numpy-only and rejected on a sequence.
+    def ragged(a: float, b: float) -> float:
+        rows = [[a, b], [a]]
+        acc = 0.0
+        for i in range(len(rows)):
+            for j in range(len(rows[i])):
+                acc = acc + rows[i][j]
+        return acc
+
+    assert _arith_count(lower(ragged), FloatAdd) == 3
+
+
+def test_shape_queries_are_rejected_outside_a_static_position() -> None:
+    from jaxtyping import Float64
+
+    def ndim_as_value(v: Float64[np.ndarray, "3"]) -> float:
+        return float(v.ndim)
+
+    def shape_as_value(v: Float64[np.ndarray, "3"]) -> float:
+        return float(v.shape[0])
+
+    def len_as_value(v: Float64[np.ndarray, "3"]) -> float:
+        return float(len(v))
+
+    for kernel in (ndim_as_value, shape_as_value, len_as_value):
+        with pytest.raises(UnsupportedConstruct, match="compile-time integer"):
+            lower(kernel)
+
+    def ndim_of_list(a: float, b: float) -> float:
+        rows = [a, b]
+        return a if rows.ndim == 1 else b  # type: ignore[attr-defined]
+
+    with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+        lower(ndim_of_list)
+
+    def len_of_scalar(a: float) -> float:
+        acc = 0.0
+        for _ in range(len(a)):  # type: ignore[arg-type]
+            acc = acc + a
+        return acc
+
+    with pytest.raises(UnsupportedConstruct, match="len\\(\\) of a scalar"):
+        lower(len_of_scalar)
+
+    def bad_axis(v: Float64[np.ndarray, "3"]) -> float:
+        return v[v.shape[2]]
+
+    with pytest.raises(UnsupportedConstruct, match="axis 2 is out of range"):
+        lower(bad_axis)
+
+
+def test_numpy_only_shape_queries_are_rejected_on_a_sequence_however_it_is_spelled() -> None:
+    # A shape query never lowers its receiver, so the list/tuple rejection has to walk the receiver expression itself.
+    # Reaching a list through a subscript, a transpose, or a state attribute must not hand it .ndim/.shape/.T, none of
+    # which Python gives a list -- otherwise Holoso would accept a kernel that is not runnable Python.
+    def ndim_through_a_subscript(a: float, b: float) -> float:
+        rows = [[a, b], [b, a]]
+        return a if rows[0].ndim == 1 else b  # type: ignore[attr-defined]
+
+    with pytest.raises(UnsupportedConstruct, match="ndim on a Python list/tuple"):
+        lower(ndim_through_a_subscript)
+
+    def transpose_of_a_sequence_in_a_static_position(a: float, b: float) -> float:
+        rows = [a, b]
+        acc = 0.0
+        for i in range(len(rows.T)):  # type: ignore[attr-defined]
+            acc = acc + rows[i]
+        return acc
+
+    with pytest.raises(UnsupportedConstruct, match="transpose on a Python list/tuple"):
+        lower(transpose_of_a_sequence_in_a_static_position)
+
+    class ListState:
+        def __init__(self) -> None:
+            self.vec = [1.0, 2.0]
+
+        def __call__(self, a: float) -> float:
+            return a if self.vec.ndim == 1 else -a  # type: ignore[attr-defined]
+
+    with pytest.raises(UnsupportedConstruct, match="ndim on a Python list/tuple"):
+        lower(ListState().__call__)
+
+
+def test_empty_slice_has_no_shape_but_still_has_a_length() -> None:
+    # An empty aggregate is not an array (array_shape says so), so the static shape probe must not report a zero-length
+    # axis that lowering can never produce. Iteration and len() still follow Python, which give an empty slice a length.
+    from jaxtyping import Float64
+
+    def iterate_an_empty_slice(v: Float64[np.ndarray, "5"]) -> float:
+        acc = v[0]
+        for x in v[2:2]:
+            acc = acc + x
+        return acc
+
+    assert iterate_an_empty_slice(np.arange(5.0)) == 0.0  # the kernel is runnable Python, and the loop is empty
+    assert _arith_count(lower(iterate_an_empty_slice), FloatAdd) == 0
+
+    def ndim_of_an_empty_slice(v: Float64[np.ndarray, "5"]) -> float:
+        return v[0] if v[2:2].ndim == 1 else v[1]
+
+    with pytest.raises(UnsupportedConstruct, match="rectangular"):
+        lower(ndim_of_an_empty_slice)
+
+    def matmul_of_an_empty_slice(v: Float64[np.ndarray, "5"], w: Float64[np.ndarray, "5"]) -> float:
+        return v[2:2] @ w  # type: ignore[no-any-return]
+
+    # The stub's own shape guard surfaces the same diagnostic through the operator, at the user's call site.
+    with pytest.raises(UnsupportedConstruct, match="rectangular"):
+        lower(matmul_of_an_empty_slice)
+
+
+def test_shape_queries_still_reach_arrays_through_the_same_spellings() -> None:
+    # The complement of the rejection above: an array receiver keeps .ndim/.shape/.T through a subscript or a state
+    # attribute, and len() keeps working on a list attribute, where Python does give it a length.
+    class Mixed:
+        def __init__(self) -> None:
+            self.m = np.array([[1.0, 2.0], [3.0, 4.0]])
+            self.v = [1.0, 2.0]
+
+        def __call__(self, a: float) -> float:
+            acc = a
+            for i in range(len(self.v)):
+                acc = acc + self.v[i]
+            for i in range(self.m.ndim):
+                acc = acc + self.m[i][i]
+            return acc + self.m.T[0][1]
+
+    assert [o.name for o in lower(Mixed().__call__).outputs] == ["out_0"]
+
+    from jaxtyping import Float64
+
+    def array_row_has_ndim(m: Float64[np.ndarray, "2 3"]) -> float:
+        return m[0][0] if m[0].ndim == 1 else m[1][0]
+
+    assert [o.name for o in lower(array_row_has_ndim).outputs] == ["out_0"]
+
+
+# ---------------------------------------------------------------- comprehensions and aggregate iteration
+
+
+def test_list_comprehension_unrolls_and_scopes_its_target() -> None:
+    from jaxtyping import Float64
+
+    def scaled(v: Float64[np.ndarray, "3"], s: float) -> Float64[np.ndarray, "3"]:
+        return np.array([v[i] * s for i in range(len(v))])  # type: ignore[no-any-return]
+
+    hir = lower(scaled)
+    assert [o.name for o in hir.outputs] == ["out_0", "out_1", "out_2"]
+    assert _arith_count(hir, FloatMul) == 3
+
+    def nested(m: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "3 2"]:
+        return np.array([[m[i][j] for i in range(2)] for j in range(3)])  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(nested).outputs] == [f"out_{i}_{j}" for i in range(3) for j in range(2)]
+
+    def filtered(m: Float64[np.ndarray, "3 3"]) -> Float64[np.ndarray, "3"]:
+        return np.array([m[i][j] for i in range(3) for j in range(3) if i < j])  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(filtered).outputs] == ["out_0", "out_1", "out_2"]
+
+    def target_does_not_leak(v: Float64[np.ndarray, "3"]) -> float:
+        rows = [v[k] for k in range(3)]
+        return rows[0] + k  # type: ignore[name-defined]  # noqa: F821
+
+    # Unlike a ``for`` counter, a comprehension target is confined to the comprehension, exactly as in Python.
+    with pytest.raises(UnsupportedConstruct, match="unknown name 'k'"):
+        lower(target_does_not_leak)
+
+
+def test_comprehension_yields_a_python_list_not_an_array() -> None:
+    from jaxtyping import Float64
+
+    def arithmetic_on_a_comprehension(v: Float64[np.ndarray, "2"]) -> float:
+        rows = [v[i] for i in range(2)]
+        return (rows * 2.0)[0]  # type: ignore[operator]
+
+    # A comprehension is a Python list, so numpy-only operations need np.array(...) around it, as in Python.
+    with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
+        lower(arithmetic_on_a_comprehension)
+
+
+def test_comprehension_rejections() -> None:
+    from jaxtyping import Float64
+
+    def dynamic_filter(v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "3"]:
+        return np.array([v[i] for i in range(3) if v[i] > 0.0])  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="compile-time condition"):
+        lower(dynamic_filter)
+
+    def walrus_inside(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return np.array([(t := v[i]) + t for i in range(2)])  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="walrus"):
+        lower(walrus_inside)
+
+    def tuple_target(v: Float64[np.ndarray, "2"]) -> float:
+        pairs = [[v[0], v[1]]]
+        return [a + b for a, b in pairs][0]
+
+    with pytest.raises(UnsupportedConstruct, match="comprehension target must be a plain name"):
+        lower(tuple_target)
+
+    def over_threshold(a: float) -> float:
+        return [a for _ in range(1000)][0]
+
+    with pytest.raises(UnsupportedConstruct, match="unroll threshold"):
+        lower(over_threshold)
+
+
+def test_for_loop_iterates_an_aggregate() -> None:
+    from jaxtyping import Float64
+
+    def sum_rows(m: Float64[np.ndarray, "2 3"]) -> float:
+        acc = 0.0
+        for row in m:
+            for x in row:
+                acc = acc + x
+        return acc
+
+    hir = lower(sum_rows)
+    assert _arith_count(hir, FloatAdd) == 6  # the 0.0 seed folds away only later, in the optimizer
+    assert [o.name for o in hir.outputs] == ["out_0"]
+
+    def iterate_a_scalar(a: float) -> float:
+        acc = 0.0
+        for x in a:  # type: ignore[attr-defined]
+            acc = acc + x
+        return acc
+
+    with pytest.raises(UnsupportedConstruct, match="range|aggregate"):
+        lower(iterate_a_scalar)
+
+
+# ---------------------------------------------------------------- statically reachable raise
+
+
+def test_raise_on_a_statically_taken_path_is_a_located_synthesis_error() -> None:
+    from jaxtyping import Float64
+
+    def rejects(m: Float64[np.ndarray, "2 3"]) -> float:
+        if m.ndim != 1:
+            raise ValueError(f"expected 1-D, got {m.ndim}-D with {len(m)} rows")
+        return m[0]
+
+    with pytest.raises(UnsupportedConstruct, match="expected 1-D, got 2-D with 2 rows") as excinfo:
+        lower(rejects)
+    assert excinfo.value.location is not None and "raise ValueError" in (excinfo.value.location.line or "")
+
+    def accepts(v: Float64[np.ndarray, "3"]) -> float:
+        if v.ndim != 1:
+            raise ValueError("expected 1-D")  # the fold never takes this arm, so it never lowers
+        return v[0]
+
+    assert [o.name for o in lower(accepts).outputs] == ["out_0"]
+
+
+def test_raise_rejections() -> None:
+    def data_dependent(a: float) -> float:
+        if a > 0.0:
+            raise ValueError("positive")
+        return a
+
+    # Hardware cannot signal a runtime exception, so a raise whose reachability depends on data is rejected as such.
+    with pytest.raises(UnsupportedConstruct, match="data-dependent"):
+        lower(data_dependent)
+
+    def bare(a: float) -> float:
+        raise  # noqa: PLE0704
+
+    with pytest.raises(UnsupportedConstruct, match="only 'raise"):
+        lower(bare)
+
+    def not_an_exception(a: float) -> float:
+        raise a  # type: ignore[misc]
+
+    with pytest.raises(UnsupportedConstruct, match="does not name an exception type"):
+        lower(not_an_exception)
+
+    def runtime_interpolation(a: float) -> float:
+        raise ValueError(f"bad {a}")
+
+    with pytest.raises(UnsupportedConstruct, match="interpolated value must be a compile-time integer"):
+        lower(runtime_interpolation)
+
+
+def _raises_under_a_dynamic_guard(a: float) -> float:
+    if a > 0.0:
+        raise ValueError("positive")
+    return a
+
+
+def test_branch_depth_restarts_per_inlined_function() -> None:
+    # Whether a raise is data-dependent is a property of the function that WRITES it, not of a call site that happens to
+    # sit in a branch arm. So a callee's own dynamic guard is rejected even from a straight-line caller, and a stub's
+    # static guard is still a compile-time rejection even when the call site is inside a dynamic arm.
+    from jaxtyping import Float64
+
+    def dynamic_guard_in_callee(a: float, b: float) -> float:
+        r = b
+        if b > 0.0:
+            r = _raises_under_a_dynamic_guard(a)
+        return r
+
+    with pytest.raises(UnsupportedConstruct, match="data-dependent"):
+        lower(dynamic_guard_in_callee)
+
+    def static_guard_in_stub(c: bool, m: Float64[np.ndarray, "2 3"], v: Float64[np.ndarray, "2"]) -> float:
+        r = 0.0
+        if c:
+            r = (m @ v)[0]  # a shape error, though the arm it sits in is data-dependent
+        return r
+
+    with pytest.raises(UnsupportedConstruct, match=r"in matmul\(\).*mismatch"):
+        lower(static_guard_in_stub)
+
+
+# ---------------------------------------------------------------- reachability scan vs lowering
+
+
+def test_state_write_only_on_a_folded_away_shape_branch_is_not_state() -> None:
+    # The scan runs before the body is lowered, so it cannot fold a shape query and descends both arms, registering the
+    # write. Lowering folds the branch away and never touches the attribute, which therefore keeps its reset value for
+    # good and is not state. Before ``_prune_untouched_state`` this crashed with a raw KeyError from slot registration.
+    from jaxtyping import Float64
+
+    class DeadShapeBranch:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, x: Float64[np.ndarray, "3"]) -> float:
+            if len(x) == 4:  # statically false for a declared 3-vector
+                self.s = x[0]
+            return x[0]
+
+    hir = lower(DeadShapeBranch().step)
+    assert [slot.name for slot in hir.state_slots] == []
+    assert [o.name for o in hir.outputs] == ["out_0"]
+
+    class DeadAggregateLoop:
+        def __init__(self) -> None:
+            self.a = 0.0
+
+        def step(self, x: float) -> float:
+            for _ in []:  # zero trips, so the write is unreachable
+                self.a = x
+            return x
+
+    assert [slot.name for slot in lower(DeadAggregateLoop().step).state_slots] == []
+
+    class AlsoRead:
+        # When the attribute is also READ on a live path, lowering must emit the read before it can know the write is
+        # unreachable, so the conservative classification stands and the slot survives as a register that holds its
+        # reset value. Correct -- reads see the reset, as in Python -- at the cost of one register and one port.
+        def __init__(self) -> None:
+            self.s = 0.25
+
+        def step(self, x: Float64[np.ndarray, "3"]) -> float:
+            if len(x) == 4:
+                self.s = x[0]
+            return self.s + x[0]
+
+    hir = lower(AlsoRead().step)
+    assert [slot.name for slot in hir.state_slots] == ["s"]
+    sim = holoso.synthesize(AlsoRead().step, default_ops(FloatFormat(11, 52)), name="alsoread").numerical_model
+    simulator = sim.elaborate()
+    reference = AlsoRead()
+    inputs = np.array([1.5, 0.0, 0.0])
+    for _ in range(3):
+        returned, state = simulator.run(*inputs.tolist())
+        assert float(returned) == pytest.approx(reference.step(inputs))
+        assert float(state) == pytest.approx(0.25)  # never written, so the register holds its reset forever
+
+
+def test_state_write_under_an_aggregate_for_is_not_dropped_by_a_stale_counter() -> None:
+    # ``for i in <aggregate>`` binds a runtime value, so the target's compile-time binding must be demoted in the
+    # reachability scan exactly as lowering demotes it. Otherwise the scan folds ``i == 2.0`` on the leaked counter of
+    # the preceding range loop, walks only one arm, misses the write, and the state slot silently disappears -- the
+    # module would return the reset constant forever. ``_assign_attr`` now asserts against that direction outright.
+    from jaxtyping import Float64
+
+    class StaleCounter:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, x: Float64[np.ndarray, "2"]) -> float:
+            for i in range(3):
+                pass
+            for i in x:  # i is demoted here; the scan must not keep the leaked value 2
+                if i == 2.0:
+                    pass
+                else:
+                    self.s = i
+            return self.s
+
+    hir = lower(StaleCounter().step)
+    assert [slot.name for slot in hir.state_slots] == ["s"]
+
+    sim = holoso.synthesize(StaleCounter().step, default_ops(FloatFormat(11, 52)), name="stale").numerical_model
+    simulator = sim.elaborate()
+    inputs = np.array([5.0, 7.0])
+    assert float(simulator.run(*inputs.tolist())[0]) == pytest.approx(StaleCounter().step(inputs))
+
+
+_COMPREHENSION_SHADOW = 1  # a module-level integer constant a comprehension target below deliberately shadows
+
+
+def test_comprehension_target_shadows_a_same_named_module_constant() -> None:
+    # A comprehension is its own scope in Python, so its target shadows a same-named global while it is bound. If the
+    # target were not registered as a local for its extent, the static evaluators would resolve the global integer
+    # behind the binding and fold the comparison to a compile-time answer -- a silent miscompile: the kernel would
+    # return all ones instead of a one-hot vector.
+    from jaxtyping import Float64
+
+    def one_hot(v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "3"]:
+        return np.array([1.0 if _COMPREHENSION_SHADOW == 1 else 0.0 for _COMPREHENSION_SHADOW in v])
+
+    hir = lower(one_hot)
+    assert _arith_count(hir, FloatRelational) == 3  # three runtime comparisons, not a folded constant
+
+    inputs = np.array([5.0, 1.0, 9.0])
+    sim = holoso.synthesize(one_hot, default_ops(FloatFormat(11, 52)), name="onehot").numerical_model.elaborate()
+    assert [float(x) for x in sim.run(*inputs.tolist())] == pytest.approx(list(np.asarray(one_hot(inputs))))
+
+    def indexed(v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "3"]:
+        # The complement: a range-bound target IS a compile-time integer, so its comparison still folds away.
+        return np.array([v[i] * 2.0 if i == 1 else v[i] for i in range(3)])
+
+    assert _arith_count(lower(indexed), FloatRelational) == 0 and _arith_count(lower(indexed), FloatMul) == 1
+
+
+_COMPREHENSION_BOUND = 2  # a module-level integer the outermost generator below reads from the enclosing scope
+
+
+def test_comprehension_scoping_follows_python_exactly() -> None:
+    # Python evaluates the OUTERMOST iterable in the enclosing scope, before the comprehension's scope exists, so the
+    # range bound below is the module constant, not the (as yet unbound) target that shadows it.
+    from jaxtyping import Float64
+
+    def outermost_iterable_reads_the_enclosing_scope(x: float) -> Float64[np.ndarray, "2"]:
+        return np.array([x for _COMPREHENSION_BOUND in range(_COMPREHENSION_BOUND)])
+
+    assert [o.name for o in lower(outermost_iterable_reads_the_enclosing_scope).outputs] == ["out_0", "out_1"]
+    assert len(outermost_iterable_reads_the_enclosing_scope(1.0)) == 2  # and it is runnable Python
+
+    def inner_generator_sees_the_unbound_comprehension_local(v: Float64[np.ndarray, "2"]) -> float:
+        y = v
+        return [y for x in range(1) for y in y][0]  # type: ignore[misc]  # Python: UnboundLocalError on the inner y
+
+    with pytest.raises(UnboundLocalError):
+        inner_generator_sees_the_unbound_comprehension_local(np.array([1.0, 2.0]))
+    with pytest.raises(UnsupportedConstruct, match="unknown name 'y'"):
+        lower(inner_generator_sees_the_unbound_comprehension_local)
+
+
+def test_comprehension_filter_is_lowered_before_it_is_folded() -> None:
+    # The filter decides which items exist, so it must fold -- but it is lowered first, exactly as an ``if`` test is,
+    # so its operands are type-checked. A fold that never looked at the condition would wave an unsupported operand
+    # through whenever the other side of an ``or`` happened to be statically true.
+    from jaxtyping import Float64
+
+    def unsupported_operand(v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "1"]:
+        return np.array([v[i] for i in range(1) if _returns_a_dict(v) or True])  # type: ignore[misc]
+
+    with pytest.raises(UnsupportedConstruct, match="Dict"):
+        lower(unsupported_operand)
+
+
+def _returns_a_dict(v: object) -> object:
+    return {"not": v}
+
+
+def test_state_write_after_a_raise_does_not_poison_the_read_only_scan() -> None:
+    # A raise ends the block, so the assignment below it is unreachable and must not mark ``flag`` as written --
+    # otherwise ``flag`` stops being a read-only constant, the guard becomes a runtime branch, and the raise in the
+    # statically-dead else arm is misreported as sitting on a data-dependent path.
+    class GuardedByAReadOnlyFlag:
+        def __init__(self) -> None:
+            self.flag = True
+            self.y = 0.0
+
+        def step(self, a: float) -> float:
+            if self.flag:
+                self.y = a
+            else:
+                raise ValueError("flag must be set")
+                self.flag = False  # noqa: F841  # unreachable: the raise ends the block
+
+            return self.y
+
+    hir = lower(GuardedByAReadOnlyFlag().step)
+    assert [slot.name for slot in hir.state_slots] == ["y"]  # flag stays a read-only constant
+
+
+def test_an_untouched_state_attribute_is_not_resurrected_by_an_unrelated_branch() -> None:
+    # _merge_state must not load the live-in of an attribute NEITHER arm touched: both arms start from the same
+    # pre-branch state, so doing so would conjure a register (and a public port) out of a branch that never
+    # mentions the attribute, undoing _prune_untouched_state.
+    from jaxtyping import Float64
+
+    class DeadWritePlusUnrelatedBranch:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, x: Float64[np.ndarray, "3"]) -> float:
+            if len(x) == 4:  # dead: the write never happens
+                self.s = x[0]
+            r = x[0]
+            if x[1] > 0.0:  # an unrelated dynamic branch, which merges state
+                r = x[2]
+            return r
+
+    hir = lower(DeadWritePlusUnrelatedBranch().step)
+    assert [slot.name for slot in hir.state_slots] == []
+    assert [o.name for o in hir.outputs] == ["out_0"]
+
+
+def test_a_scan_never_folds_a_shape_query_against_an_environment_lowering_will_not_have() -> None:
+    # The loop-carried scan walks a while body BEFORE its phis exist, so the environment it sees is the preheader's.
+    # Were it allowed to resolve a name there, it would fold ``i.ndim == 1`` against the scalar ``i`` bound before the
+    # loop, miss the state write in the arm it skipped, open no loop phi, and discard the accumulation entirely --
+    # a silent miscompile returning the reset value forever.
+    from jaxtyping import Float64
+
+    class AccumulateOverRows:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, c: bool, m: Float64[np.ndarray, "2 3"]) -> float:
+            i = 0.0
+            while c:
+                for i in m:
+                    if i.ndim == 1:
+                        self.s = self.s + i[0]
+                i = 0.0
+                c = False
+            return self.s
+
+    rows = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    assert AccumulateOverRows().step(True, rows) == 5.0  # the kernel is runnable Python
+    assert [slot.name for slot in lower(AccumulateOverRows().step).state_slots] == ["s"]
+
+    sim = holoso.synthesize(
+        AccumulateOverRows().step, default_ops(FloatFormat(11, 52)), name="accumulate_rows"
+    ).numerical_model
+    assert float(sim.elaborate().run(True, *rows.flatten().tolist())[0]) == pytest.approx(5.0)
+
+
+def test_a_state_attribute_read_only_inside_a_while_loop_keeps_its_slot() -> None:
+    # A while loop restores the pre-loop state environment on exit, dropping whatever its body loaded, so membership
+    # there cannot decide whether an attribute was touched. Pruning on it would drop a slot whose StateRead is still
+    # in the HIR, leaving the register allocator to trip over an undeclared slot.
+    class ReadOnlyInsideLoop:
+        def __init__(self) -> None:
+            self.gain = 2.0
+
+        def update(self, x: float) -> float:
+            v = [1.0, 2.0]
+            if len(v) == 3:  # dead: the scan cannot fold it, so ``gain`` is over-registered as state
+                self.gain = x
+            acc = 0.0
+            while acc < x:
+                acc = acc + self.gain
+            return acc
+
+    assert ReadOnlyInsideLoop().update(5.0) == 6.0
+    hir = lower(ReadOnlyInsideLoop().update)
+    slots = {slot.name for slot in hir.state_slots}
+    reads = {node.slot for node in hir.nodes.values() if isinstance(node, StateRead)}
+    assert reads <= slots  # every StateRead names a declared slot
+
+    sim = holoso.synthesize(
+        ReadOnlyInsideLoop().update, default_ops(FloatFormat(11, 52)), name="read_only_in_loop"
+    ).numerical_model
+    assert float(sim.elaborate().run(5.0)[0]) == pytest.approx(6.0)
+
+
+def test_a_shape_query_cannot_slip_past_a_rejection_the_stub_makes() -> None:
+    # ``.T`` is rejected on a scalar, so asking for the shape of one must be rejected identically -- otherwise a
+    # static position would quietly accept an expression a value position rejects, and neither is runnable Python.
+    def transpose_of_a_scalar_as_a_value(a: float) -> float:
+        return a.T  # type: ignore[attr-defined, no-any-return]
+
+    def transpose_of_a_scalar_in_a_shape_query(a: float) -> float:
+        return a if a.T.ndim == 0 else -a  # type: ignore[attr-defined]
+
+    for kernel in (transpose_of_a_scalar_as_a_value, transpose_of_a_scalar_in_a_shape_query):
+        with pytest.raises(UnsupportedConstruct, match="transpose a scalar"):
+            lower(kernel)
+
+
+def test_only_a_write_lowering_reaches_is_validated() -> None:
+    # The scan walks paths lowering folds away, so it validates nothing: a write it cannot turn into state is passed
+    # over, and the rejection happens at the write itself, if and when lowering gets there. A dead branch assigning an
+    # attribute the instance never had is dead code, exactly as it is in Python.
+    from jaxtyping import Float64
+
+    class DeadWriteToAnUninitializedAttribute:
+        def __init__(self) -> None:
+            self.ok = 0.0
+
+        def step(self, v: Float64[np.ndarray, "2"]) -> float:
+            if v.ndim == 2:  # statically false for a vector
+                self.never_initialized = 1.0
+            return v[0]
+
+    assert DeadWriteToAnUninitializedAttribute().step(np.array([3.0, 4.0])) == 3.0  # runnable Python
+    assert [slot.name for slot in lower(DeadWriteToAnUninitializedAttribute().step).state_slots] == []
+
+    class ReachableWriteToAnUninitializedAttribute:
+        def __init__(self) -> None:
+            self.ok = 0.0
+
+        def step(self, x: float) -> float:
+            if x > 0.0:  # a runtime arm is lowered, so the write is reached
+                self.never_initialized = x
+            return x
+
+    with pytest.raises(UnsupportedConstruct, match="assigned but not initialized"):
+        lower(ReachableWriteToAnUninitializedAttribute().step)
+
+
+def test_an_integer_state_reset_the_float_registers_cannot_hold_is_rejected() -> None:
+    # Persistent state lives in float registers and there is no integer type, so an integer reset the format cannot
+    # represent would read back rounded and a comparison against the original literal would take the other branch.
+    # Rejecting is the only honest option: silently rounding it miscompiles the guard below.
+    inexact = 2**53 + 1  # the first integer float64 cannot represent
+
+    class Selector:
+        def __init__(self) -> None:
+            self.selector = inexact
+            self.total = 0.0
+
+        def step(self, x: float) -> float:
+            if x > 100.0:  # a runtime guard, so `selector` really is persistent state
+                self.selector = 0
+            if self.selector == 2**53:  # False in Python; True once the reset rounds down
+                self.total = self.total + 100.0 * x
+            else:
+                self.total = self.total + x
+            return self.total
+
+    assert Selector().step(1.0) == 1.0  # Python compares the integer exactly
+    with pytest.raises(UnsupportedConstruct, match="hold exactly"):
+        lower(Selector().step)
+
+    class ExactVector:
+        # The guard is about exactness, not about integers: 2**53 itself round-trips, and so does any small integer.
+        def __init__(self) -> None:
+            self.taps = [1, 2**53, -3]
+            self.y = 0.0
+
+        def step(self, x: float) -> float:
+            self.taps = [self.taps[0], self.taps[1], self.taps[2]]  # written, so the vector really is state
+            self.y = self.y + self.taps[1] * x
+            return self.y
+
+    assert [slot.name for slot in lower(ExactVector().step).state_slots] == ["taps_0", "taps_1", "taps_2", "y"]
+
+
+def test_state_slot_names_only_collide_among_the_attributes_lowering_keeps() -> None:
+    # The scan over-registers `v_0` from a write lowering folds away, and `v_0` is also the first slot of the vector
+    # `v`. Checking for the collision before the prune would reject a kernel whose colliding attribute is dead code.
+    from jaxtyping import Float64
+
+    class DeadCollider:
+        def __init__(self) -> None:
+            self.v = np.array([1.0, 2.0])
+            self.v_0 = 100.0
+
+        def step(self, x: Float64[np.ndarray, "1"]) -> float:
+            if x.ndim == 2:  # dead: the scan cannot fold it, so `v_0` is over-registered
+                self.v_0 = x[0]
+            self.v = self.v + x[0]
+            return self.v[0]
+
+    assert [slot.name for slot in lower(DeadCollider().step).state_slots] == ["v_0", "v_1"]
+
+    class LiveCollider:
+        def __init__(self) -> None:
+            self.v = np.array([1.0, 2.0])
+            self.v_0 = 100.0
+
+        def step(self, x: float) -> float:
+            self.v_0 = x  # reached, so both attributes really do claim the slot name `v_0`
+            self.v = self.v + x
+            return self.v[0]
+
+    with pytest.raises(UnsupportedConstruct, match="aliasing collision"):
+        lower(LiveCollider().step)
+
+
+def test_iteration_and_shape_queries_reach_every_aggregate_spelling() -> None:
+    # A `for` iterates whatever Python iterates: a slice, a transpose, a flattened matrix, a comprehension. The shape
+    # queries reach the same values. Each kernel is runnable Python, so a construct Holoso accepts but Python rejects
+    # would fail here rather than pass as a spurious positive.
+    from jaxtyping import Float64
+
+    def over_a_slice(m: Float64[np.ndarray, "2 3"]) -> float:
+        acc = 0.0
+        for e in m[0][1:]:
+            acc = acc + e
+        return acc
+
+    def over_a_transpose(m: Float64[np.ndarray, "2 3"]) -> float:
+        acc = 0.0
+        for row in m.T:
+            acc = acc + row[0]
+        return acc
+
+    def over_a_flatten(m: Float64[np.ndarray, "2 2"]) -> float:
+        acc = 0.0
+        for e in m.flatten():
+            acc = acc + e
+        return acc
+
+    def over_a_comprehension(v: Float64[np.ndarray, "3"]) -> float:
+        acc = 0.0
+        for e in [v[i] * 2.0 for i in range(3)]:
+            acc = acc + e
+        return acc
+
+    def negative_axis_on_a_vector(v: Float64[np.ndarray, "3"]) -> float:
+        return v[v.shape[-1] - 1]
+
+    m23, m22, v3 = np.arange(6.0).reshape(2, 3), np.arange(4.0).reshape(2, 2), np.arange(3.0)
+    for kernel, args in (
+        (over_a_slice, (m23,)),
+        (over_a_transpose, (m23,)),
+        (over_a_flatten, (m22,)),
+        (over_a_comprehension, (v3,)),
+        (negative_axis_on_a_vector, (v3,)),
+    ):
+        assert [o.name for o in lower(kernel).outputs] == ["out_0"]
+        kernel(*args)  # runnable Python
+
+
+def test_a_raise_message_may_interpolate_a_shape_and_a_counter() -> None:
+    from jaxtyping import Float64
+
+    def guard(m: Float64[np.ndarray, "2 3"]) -> float:
+        if m.shape[1] == 3:
+            raise ValueError(f"width {m.shape[1]} of a {m.ndim}-D value is not allowed")
+        return m[0][0]
+
+    with pytest.raises(UnsupportedConstruct, match="width 3 of a 2-D value is not allowed"):
+        lower(guard)
+
+    def dead_elif_chain(v: Float64[np.ndarray, "3"]) -> float:
+        if v.ndim == 3:
+            raise ValueError("three")
+        elif v.ndim == 2:
+            raise ValueError("two")
+        return v[0]
+
+    assert dead_elif_chain(np.arange(3.0)) == 0.0  # runnable Python: neither arm is taken
+    assert [o.name for o in lower(dead_elif_chain).outputs] == ["out_0"]
+
+
+def test_a_loop_carries_only_attributes_that_are_really_state() -> None:
+    # The scan collects self-attribute writes syntactically, so a write it cannot turn into state must not open a
+    # loop-header phi for it; otherwise the phi's live-in lookup fails with a bare KeyError.
+    from jaxtyping import Float64
+
+    class DeadWriteInLoop:
+        def __init__(self) -> None:
+            self.ok = 0.0
+
+        def step(self, run: bool, v: Float64[np.ndarray, "3"]) -> float:
+            while run:
+                if v.ndim == 2:  # dead
+                    self.never_initialized = v[1]
+                run = False
+            return v[0]
+
+    assert DeadWriteInLoop().step(True, np.array([2.0, 3.0, 5.0])) == 2.0
+    assert [slot.name for slot in lower(DeadWriteInLoop().step).state_slots] == []
+
+
+def test_a_shape_query_reads_the_reset_value_not_the_state_decomposition() -> None:
+    # `.ndim` of a read-only 3-D array attribute is a compile-time integer; only STATE is restricted to 1-D and 2-D.
+    from jaxtyping import Float64
+
+    class Cube:
+        def __init__(self) -> None:
+            self.cube = np.zeros((2, 2, 2))
+
+        def step(self, v: Float64[np.ndarray, "2"]) -> float:
+            if v.ndim == 2:
+                if self.cube.ndim == 3:
+                    return v[1]
+            return v[0]
+
+    assert Cube().step(np.array([2.0, 9.0])) == 2.0
+    assert [o.name for o in lower(Cube().step).outputs] == ["out_0"]
+
+
+def test_multi_axis_indexing_validates_its_axes_against_the_shape() -> None:
+    from jaxtyping import Float64
+
+    def out_of_range_behind_an_empty_slice(m: Float64[np.ndarray, "2 2"]) -> float:
+        if len(m[:0, 99]) == 0:  # Python: IndexError, axis 1 has size 2
+            return 17.0
+        return -17.0
+
+    with pytest.raises(IndexError):
+        out_of_range_behind_an_empty_slice(np.array([[1.0, 2.0], [3.0, 4.0]]))
+
+    # An empty leading slice selects no item, so a per-item bounds check never fires: the axes need an up-front probe.
+    with pytest.raises(UnsupportedConstruct, match="invalid index"):
+        lower(out_of_range_behind_an_empty_slice)
+
+    def too_many_axes_behind_an_empty_slice(m: Float64[np.ndarray, "2 2"]) -> float:
+        if len(m[:0, 0, 0]) == 0:  # Python: IndexError, too many indices
+            return 17.0
+        return -17.0
+
+    with pytest.raises(IndexError):
+        too_many_axes_behind_an_empty_slice(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    with pytest.raises(UnsupportedConstruct, match="too many indices"):
+        lower(too_many_axes_behind_an_empty_slice)
+
+    def multi_axis_on_an_empty_slice(m: Float64[np.ndarray, "2 2"]) -> float:
+        acc = 2.0
+        for x in m[0:0, :][:, 0]:
+            acc = acc + x
+        return acc
+
+    # An empty aggregate is not an array, so it has no axes to index; this must be a located error, not an assertion.
+    with pytest.raises(UnsupportedConstruct, match="rectangular"):
+        lower(multi_axis_on_an_empty_slice)
+
+
+def test_a_sequence_stays_a_sequence_through_a_subscript() -> None:
+    class ListState:
+        def __init__(self) -> None:
+            self.values = [1.0, 2.0]
+
+        def step(self, x: float) -> float:
+            return x if self.values[0:1].ndim == 1 else -x  # type: ignore[attr-defined]
+
+    with pytest.raises(AttributeError):
+        ListState().step(3.0)  # a Python list slice has no .ndim
+    with pytest.raises(UnsupportedConstruct, match="ndim on a Python list/tuple"):
+        lower(ListState().step)
+
+
+def test_a_write_is_validated_only_where_lowering_reaches_it() -> None:
+    # The scan walks paths lowering folds away, so it cannot validate. Each attribute below is unrepresentable as
+    # state; a dead write to it is dead code, a reachable one is an error. Both halves must hold, in a loop body too.
+    from jaxtyping import Float64
+
+    class Descriptor:
+        def __init__(self) -> None:
+            self.__dict__["p"] = 1.0
+            self.y = 0.0
+
+        @property
+        def p(self) -> float:
+            return 2.0
+
+        @p.setter
+        def p(self, value: float) -> None:
+            pass
+
+    class DeadDescriptorWriteInLoop(Descriptor):
+        def step(self, run: bool, v: Float64[np.ndarray, "2"]) -> float:
+            while run:
+                if v.ndim == 2:  # dead
+                    self.p = v[0]
+                run = False
+            return v[0]
+
+    class LiveDescriptorWriteInLoop(Descriptor):
+        def step(self, run: bool, v: Float64[np.ndarray, "2"]) -> float:
+            while run:
+                self.p = v[0]
+                run = False
+            return v[0]
+
+    class DeadCubeWrite:
+        def __init__(self) -> None:
+            self.cube = np.zeros((2, 2, 2))
+            self.ok = 0.0
+
+        def step(self, v: Float64[np.ndarray, "2"]) -> float:
+            if v.ndim == 2:  # dead: a 3-D attribute cannot be state
+                self.cube = v
+            return v[0]
+
+    v = np.array([1.0, 2.0])
+    assert DeadDescriptorWriteInLoop().step(True, v) == 1.0
+    assert [slot.name for slot in lower(DeadDescriptorWriteInLoop().step).state_slots] == []
+    assert [slot.name for slot in lower(DeadCubeWrite().step).state_slots] == []
+
+    with pytest.raises(UnsupportedConstruct, match="descriptor"):
+        lower(LiveDescriptorWriteInLoop().step)
+
+
+def test_an_integer_the_float_datapath_cannot_hold_never_enters_it() -> None:
+    # An integer that rounds would read back as another number, so a comparison against the source literal flips.
+    # The guard is on the value entering the datapath, not on the spelling: a reset, a literal, or a module constant.
+    inexact, colliding = 2**53 + 1, 2**53
+
+    class WrittenFromAModuleConstant:
+        def __init__(self) -> None:
+            self.selector = 0
+            self.total = 0.0
+
+        def step(self, x: float) -> float:
+            if x > 100.0:
+                self.selector = _INEXACT_INTEGER
+            self.total = self.total + (100.0 * x if self.selector == colliding else x)
+            return self.total
+
+    reference = WrittenFromAModuleConstant()
+    assert [reference.step(v) for v in (1.0, 101.0)] == [1.0, 102.0]  # the integer never equals 2**53 in Python
+    with pytest.raises(UnsupportedConstruct, match="no exact float representation"):
+        lower(WrittenFromAModuleConstant().step)
+
+    class HugeReset:
+        def __init__(self) -> None:
+            self.counter = 10**400  # beyond the float range entirely
+
+        def step(self, x: float) -> float:
+            if x > 0.0:
+                self.counter = 0
+            return x
+
+    with pytest.raises(UnsupportedConstruct, match="hold exactly"):
+        lower(HugeReset().step)  # a located rejection, not a bare OverflowError
+
+    class ReadOnlyInexact:
+        # Never written, so it is a folded constant. Python's own `int + float` rounds it the same way: no divergence.
+        def __init__(self) -> None:
+            self.offset = inexact
+
+        def step(self, x: float) -> float:
+            return self.offset + x
+
+    assert [o.name for o in lower(ReadOnlyInexact().step).outputs] == ["out_0"]
+
+
+_INEXACT_INTEGER = 2**53 + 1
+
+
+def test_only_a_shaped_value_answers_a_shape_query() -> None:
+    # An arbitrary stored object is not a shaped value, whatever attributes it happens to carry.
+    class Config:
+        ndim = 1
+
+    class Kernel:
+        def __init__(self) -> None:
+            self.config = Config()
+
+        def step(self, x: float) -> float:
+            return x if self.config.ndim == 0 else -x  # Python: -x, because Config.ndim is 1
+
+    assert Kernel().step(3.0) == -3.0
+    with pytest.raises(UnsupportedConstruct, match="compile-time integer"):
+        lower(Kernel().step)
+
+
+def test_an_empty_aggregate_makes_no_check_vacuous() -> None:
+    # An empty aggregate has no leaves, so a per-leaf type check and a per-item shape check both prove nothing.
+    from jaxtyping import Float64
+
+    def negate_an_empty_boolean_slice(c: bool) -> float:
+        flags = np.array([c])
+        invalid = -flags[:0]  # Python: TypeError, numpy cannot negate booleans
+        return 17.0 if len(invalid) == 0 else -17.0
+
+    with pytest.raises(TypeError):
+        negate_an_empty_boolean_slice(True)
+    with pytest.raises(UnsupportedConstruct, match="empty aggregate"):
+        lower(negate_an_empty_boolean_slice)
+
+    def add_empty_slices_of_different_widths(a: Float64[np.ndarray, "2 3"], b: Float64[np.ndarray, "2 2"]) -> float:
+        invalid = a[:0, :] + b[:0, :]  # Python: ValueError, shapes (0,3) and (0,2)
+        return 17.0 if len(invalid) == 0 else -17.0
+
+    with pytest.raises(ValueError):
+        add_empty_slices_of_different_widths(np.zeros((2, 3)), np.zeros((2, 2)))
+    with pytest.raises(UnsupportedConstruct, match="empty aggregate"):
+        lower(add_empty_slices_of_different_widths)
+
+
+def test_indexing_a_sequence_of_arrays_yields_an_array() -> None:
+    from jaxtyping import Float64
+
+    def row_of_a_list(a: Float64[np.ndarray, "2"], x: float) -> float:
+        rows = [a]
+        return x if rows[0].ndim == 1 else -x  # the element is the ndarray, not a list
+
+    assert row_of_a_list(np.zeros(2), 3.0) == 3.0
+    assert [o.name for o in lower(row_of_a_list).outputs] == ["out_0"]
+
+
+def test_a_scan_never_rejects_an_arm_lowering_folds_away() -> None:
+    # The scan descends both arms of a shape-dependent branch, so it must not validate what it finds there.
+    from jaxtyping import Float64
+
+    class DeadInvalidShapeQuery:
+        def __init__(self) -> None:
+            self.values = [1.0, 2.0]
+            self.total = 0.0
+
+        def step(self, v: Float64[np.ndarray, "2"], x: float) -> float:
+            if v.ndim == 2:  # dead
+                if self.values.ndim == 1:  # type: ignore[attr-defined]  # a list has no .ndim
+                    self.total = x
+            return self.total
+
+    assert DeadInvalidShapeQuery().step(np.zeros(2), 1.0) == 0.0
+    # `total` is read on a live path, so it keeps a register holding its reset; the point is that it LOWERS at all.
+    assert [slot.name for slot in lower(DeadInvalidShapeQuery().step).state_slots] == ["total"]
+
+
+def _assert_shape_kernel_matches_python(fn: Callable[..., float], v: np.ndarray) -> None:
+    sim = holoso.synthesize(fn, default_ops(FloatFormat(11, 52)), name=fn.__qualname__.split(".")[0]).numerical_model
+    assert [float(x) for x in sim.elaborate().run(*v.tolist())] == pytest.approx([fn(v)])
+
+
+def test_a_nested_reset_sequence_is_shaped_like_the_aggregate_it_denotes() -> None:
+    # `len(self.nested[0])` is 3 in Python, so the snapshot's shape must describe every axis, not just the outermost.
+    from jaxtyping import Float64
+
+    class NestedRows:
+        def __init__(self) -> None:
+            self.nested = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+
+        def step(self, v: Float64[np.ndarray, "3"]) -> float:
+            acc = 0.0
+            for i in range(len(self.nested[0])):
+                acc = acc + v[i]
+            return acc
+
+    v = np.array([10.0, 20.0, 30.0])
+    assert NestedRows().step(v) == 60.0
+    _assert_shape_kernel_matches_python(NestedRows().step, v)
+
+
+def test_a_ragged_or_empty_reset_sequence_still_has_a_length() -> None:
+    from jaxtyping import Float64
+
+    class RaggedRows:
+        def __init__(self) -> None:
+            self.ragged = [[1.0], [2.0, 3.0]]
+            self.empty: list[float] = []
+
+        def step(self, v: Float64[np.ndarray, "3"]) -> float:
+            return v[len(self.ragged)] + v[len(self.ragged[1])] + v[len(self.empty)]
+
+    v = np.array([10.0, 20.0, 30.0])
+    assert RaggedRows().step(v) == 70.0
+    _assert_shape_kernel_matches_python(RaggedRows().step, v)
+
+
+def test_indexing_a_reset_sequence_of_arrays_yields_an_array() -> None:
+    from jaxtyping import Float64
+
+    class ArrayRows:
+        def __init__(self) -> None:
+            self.rows = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+
+        def step(self, v: Float64[np.ndarray, "3"]) -> float:
+            return v[self.rows[0].ndim]  # the element is the ndarray, not a list
+
+    v = np.array([10.0, 20.0, 30.0])
+    assert ArrayRows().step(v) == 20.0
+    _assert_shape_kernel_matches_python(ArrayRows().step, v)
+
+
+def test_a_shape_query_on_a_nested_reset_sequence_element_is_rejected() -> None:
+    from jaxtyping import Float64
+
+    class NestedNdim:
+        def __init__(self) -> None:
+            self.nested = [[1.0, 2.0]]
+
+        def step(self, v: Float64[np.ndarray, "3"]) -> float:
+            return v[self.nested[0].ndim]  # type: ignore[attr-defined]  # a list has no .ndim
+
+    with pytest.raises(UnsupportedConstruct, match="ndim on a Python list/tuple"):
+        lower(NestedNdim().step)
+
+
+def test_subscripting_a_non_container_reset_attribute_is_a_located_rejection() -> None:
+    # Navigating the reset snapshot must not index whatever `__getitem__` a stored object happens to carry.
+    from jaxtyping import Float64
+
+    class ForeignAttr:
+        def __init__(self) -> None:
+            self.lookup = {"a": 1}
+
+        def step(self, v: Float64[np.ndarray, "3"]) -> float:
+            return v[len(self.lookup[0])]  # type: ignore[index]  # a KeyError in Python
+
+    with pytest.raises(UnsupportedConstruct):
+        lower(ForeignAttr().step)
+
+
+def test_a_scan_must_not_fold_a_counter_an_empty_aggregate_never_rebinds() -> None:
+    # Lowering runs an empty aggregate's body zero times, so `i` keeps its outer value. A scan that walks the body once
+    # and adopts the inner counter would fold `i == 1` away and never see the state write it guards.
+    class EmptyAggregateCounter:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, a: float) -> float:
+            for i in range(2):
+                pass
+            for _unused in []:
+                for i in range(5):  # noqa: B007  # never runs; must not leak i == 4 into the scan
+                    pass
+            if i == 1:
+                self.s = a
+            return self.s
+
+    reference = EmptyAggregateCounter()
+    assert reference.step(7.0) == 7.0 and reference.s == 7.0
+    assert [slot.name for slot in lower(EmptyAggregateCounter().step).state_slots] == ["s"]
+    sim = holoso.synthesize(
+        EmptyAggregateCounter().step, default_ops(FloatFormat(11, 52)), name="empty_aggregate_counter"
+    ).numerical_model.elaborate()
+    assert dict(zip([p.name for p in sim.outputs], [float(x) for x in sim.run(7.0)], strict=True))["state_s"] == 7.0
+
+
+def test_a_scan_must_not_fold_a_branch_on_a_counter_the_loop_body_rebinds() -> None:
+    # The aggregate loop's first trip rebinds `i` to a runtime value, so lowering takes the else arm on the second
+    # trip. A scan that keeps `i == 0` static walks only the then arm and misses `self.s`, whose write then has
+    # nowhere to land.
+    from jaxtyping import Float64
+
+    class RebindingCounter:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, v: Float64[np.ndarray, "2"]) -> float:
+            for i in range(1):
+                pass
+            for x in v:
+                if i == 0:
+                    i = x  # noqa: PLW2901
+                else:
+                    self.s = x
+            return self.s
+
+    reference = RebindingCounter()
+    assert reference.step(np.array([5.0, 7.0])) == 7.0
+    sim = holoso.synthesize(
+        RebindingCounter().step, default_ops(FloatFormat(11, 52)), name="rebinding_counter"
+    ).numerical_model.elaborate()
+    assert (
+        dict(zip([p.name for p in sim.outputs], [float(x) for x in sim.run(5.0, 7.0)], strict=True))["state_s"] == 7.0
+    )
+
+
+def test_a_scan_demotes_the_aggregate_target_before_discovering_body_rebinds() -> None:
+    # The aggregate loop's target `x` leaks a stale value from an earlier same-named range loop. Discovering what the
+    # body rebinds must happen with `x` already demoted, or the fold of `if x != 0` hides the `j = x` rebind, `j` is
+    # restored stale, and the guarded state write is missed -- tripping `assert attr in self._state_order`.
+    class LeakedAggregateTarget:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, a: float) -> float:
+            for x in range(1):  # noqa: B007  # leaks x == 0
+                pass
+            for j in range(1):  # noqa: B007  # leaks j == 0
+                pass
+            for x in [a]:  # noqa: B007  # aggregate: target demoted, body rebinds j
+                if x != 0:
+                    j = x  # noqa: PLW2901
+            if j != 0:
+                self.s = j
+            return self.s
+
+    reference = LeakedAggregateTarget()
+    assert reference.step(5.0) == 5.0 and reference.s == 5.0
+    sim = holoso.synthesize(
+        LeakedAggregateTarget().step, default_ops(FloatFormat(11, 52)), name="leaked_aggregate_target"
+    ).numerical_model.elaborate()
+    assert dict(zip([p.name for p in sim.outputs], [float(x) for x in sim.run(5.0)], strict=True))["state_s"] == 5.0
+
+
+def test_a_tuple_index_of_a_list_reset_attribute_is_a_located_rejection() -> None:
+    # `self.rows[0,]` indexes a Python list with a one-tuple, which CPython rejects; the reset-state navigator must
+    # not silently reinterpret it as the numpy-style `self.rows[0]`.
+    from jaxtyping import Float64
+
+    class TupleIndexedRows:
+        def __init__(self) -> None:
+            self.rows = [[1.0, 2.0]]
+
+        def step(self, v: Float64[np.ndarray, "3"]) -> float:
+            return v[len(self.rows[0,])]  # type: ignore[index]  # a TypeError in Python
+
+    with pytest.raises(UnsupportedConstruct):
+        lower(TupleIndexedRows().step)
+
+
+_INEXACT_COUNTER_START = 2**53 + 1  # a compile-time range bound whose counter no float holds exactly
+
+
+def test_an_inexact_integer_loop_counter_is_rejected_not_silently_rounded() -> None:
+    # A counter the float register cannot hold exactly would round in value position, flipping a comparison against a
+    # runtime float. The range binds the single counter 2**53+1, which rounds to 2**53.
+    def counter_rounds(x: float) -> float:
+        return (
+            x
+            + np.array(
+                [1.0 if i == float(2**53) else 0.0 for i in range(_INEXACT_COUNTER_START, _INEXACT_COUNTER_START + 1)]
+            )[0]
+        )
+
+    assert counter_rounds(0.0) == 0.0  # (2**53+1) == 2.0**53 is False in Python, so the element is 0.0
+    with pytest.raises(UnsupportedConstruct, match="no exact float"):
+        lower(counter_rounds)
+
+
+def test_a_scalar_takes_an_empty_tuple_key_as_identity_like_a_numpy_scalar() -> None:
+    # A Holoso scalar is rank zero, as a numpy scalar is, so `x[()]` yields the scalar itself -- while `x[0]` and a
+    # slice, which a numpy scalar also rejects, stay rejected.
+    from jaxtyping import Float64
+
+    def element_full_index(v: Float64[np.ndarray, "3"]) -> float:
+        return v[0][()]  # numpy: v[0], a 0-D identity
+
+    assert element_full_index(np.array([2.0, 4.0, 6.0])) == 2.0
+    _assert_shape_kernel_matches_python(element_full_index, np.array([2.0, 4.0, 6.0]))
+
+    def index_a_scalar(v: Float64[np.ndarray, "3"]) -> float:
+        return v[0][0]  # numpy: IndexError, too many indices for a scalar
+
+    with pytest.raises(IndexError):
+        index_a_scalar(np.array([2.0, 4.0, 6.0]))
+    with pytest.raises(UnsupportedConstruct, match="cannot index or slice a scalar"):
+        lower(index_a_scalar)
+
+
+def test_a_negative_inexact_integer_literal_is_rejected_not_rounded() -> None:
+    # The negated-constant fold path (a spelled `-<literal>`, not a module global) must apply the same exactness check
+    # as a positive literal, or an aggregate over `[-(2**53+1)]` rounds the counter to -2**53 and a comparison flips.
+    def negative_counter_rounds(x: float) -> float:
+        result = 0.0
+        for i in [-9007199254740993]:  # -(2**53+1), which no float holds exactly
+            if i == x:
+                result = 1.0
+        return result
+
+    assert negative_counter_rounds(float(-(2**53))) == 0.0  # -(2**53+1) != -2.0**53 in Python
+    with pytest.raises(UnsupportedConstruct, match="no exact float"):
+        lower(negative_counter_rounds)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -13,7 +13,7 @@ from typing import cast
 import numpy as np
 import pytest
 
-from holoso import MissingIntrinsic, UnsupportedConstruct
+from holoso import UnsupportedConstruct, UnsupportedLibraryFunction
 from holoso._frontend import lower
 from holoso._frontend._ast_support import port_name
 from holoso._hir import (
@@ -27,11 +27,13 @@ from holoso._hir import (
     FloatAbs,
     FloatAdd,
     FloatConst,
+    FloatCos,
     FloatDiv,
     FloatExp2,
     FloatMul,
     FloatNeg,
     FloatRelational,
+    FloatSin,
     FloatToBool,
     FloatType,
     Hir,
@@ -826,11 +828,39 @@ def test_unknown_global_is_unsupported() -> None:
         lower(f)
 
 
-def test_missing_intrinsic_message() -> None:
+def test_tan_lowers_to_sin_cos_division() -> None:
     def f(a: float) -> float:
         return math.tan(a)
 
-    with pytest.raises(MissingIntrinsic, match="tan"):
+    hir = lower(f)
+    assert _arith_count(hir, FloatSin) == 1
+    assert _arith_count(hir, FloatCos) == 1
+    assert _arith_count(hir, FloatDiv) == 1
+
+
+def test_unsupported_library_function_message() -> None:
+    def f(a: float) -> float:
+        return math.erf(a)
+
+    with pytest.raises(UnsupportedLibraryFunction, match="erf"):
+        lower(f)
+
+
+def test_unsupported_library_function_covers_unregistered_ufuncs() -> None:
+    # np.spacing is a ufunc with no fast-math float equivalent (it reads the format's ULP), so it stays unregistered
+    # and reports an unimplemented library function rather than a generic unsupported-call.
+    def f(a: float) -> float:
+        return np.spacing(a)  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedLibraryFunction, match="spacing"):
+        lower(f)
+
+
+def test_non_operator_numpy_call_stays_unsupported() -> None:
+    def f(a: float) -> float:
+        return np.sum(a)  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="unsupported call to 'sum'"):
         lower(f)
 
 
@@ -1184,7 +1214,7 @@ def test_user_global_function_shadows_intrinsic_name() -> None:
     def f(a: float) -> float:
         return cbrt(a)
 
-    assert _arith_count(lower(f), FloatMul) == 1  # the inlined x * x, not a MissingIntrinsic rejection
+    assert _arith_count(lower(f), FloatMul) == 1  # the inlined x * x, not an UnsupportedLibraryFunction rejection
 
 
 def test_local_name_shadows_global_callable() -> None:
@@ -1290,6 +1320,129 @@ def test_callable_global_shadowing_abs_is_inlined_not_floatabs() -> None:
 
     hir = lower(_rebind_globals(use_abs, abs=cbrt))
     assert _arith_count(hir, FloatAbs) == 0 and _arith_count(hir, FloatMul) == 1
+
+
+def test_unhashable_global_shadowing_registered_name_is_rejected() -> None:
+    # A registry lookup on an unhashable shadow must not crash the compiler; the shadow simply misses and gets the
+    # standard non-callable diagnostic instead. Various unhashable shapes are covered.
+    def use_abs(a: float) -> float:
+        return abs(a)
+
+    for shadow in (np.zeros(3), (1.0, [2.0]), {1: 2}, {1, 2}):
+        with pytest.raises(UnsupportedConstruct, match="non-callable"):
+            lower(_rebind_globals(use_abs, abs=shadow))
+
+
+def test_closure_freevar_shadowing_a_registered_name_is_rejected() -> None:
+    # A freevar (enclosing-scope binding) shadows the name Python would call, so holoso must resolve it to the captured
+    # object -- never dispatch to the stub/operator it merely spells. Regression: a freevar 'pow' bound to a user
+    # function was silently lowered to the pow stub (256 instead of the user function's value), and a non-callable
+    # freevar 'abs' to FloatAbs where Python raises.
+    def make_pow(pow: Callable[[float, float], float]) -> Callable[[float], float]:  # noqa: A002 -- closure shadow
+        def kernel(x: float) -> float:
+            return pow(x, x)
+
+        return kernel
+
+    def user_pow(a: float, b: float) -> float:
+        return a - b
+
+    with pytest.raises(UnsupportedConstruct, match="pow"):
+        lower(make_pow(user_pow))
+
+    def make_abs(abs: float) -> Callable[[float], float]:  # noqa: A002 -- a non-callable closure shadow
+        def kernel(x: float) -> float:
+            return abs(x)  # type: ignore[operator, no-any-return]
+
+        return kernel
+
+    with pytest.raises(UnsupportedConstruct, match="abs"):
+        lower(make_abs(3.0))
+
+
+def test_closure_freevar_bound_to_a_library_function_still_dispatches() -> None:
+    # The fix must not over-reject: a freevar capturing an actual library function dispatches by identity as usual.
+    def make() -> Callable[[float], float]:
+        s = math.sin
+
+        def kernel(x: float) -> float:
+            return s(x)
+
+        return kernel
+
+    assert _arith_count(lower(make()), FloatSin) == 1
+
+
+def test_call_dispatch_is_by_identity_not_spelling() -> None:
+    # Dispatch resolves the callee object, so an aliased import lowers exactly like the canonical spelling -- the numpy
+    # array factories and the cast/sequence builtins are matched by identity, not by the name written at the call.
+    def use_asarray(a: float, b: float) -> list[float]:
+        return aa([a, b])  # type: ignore[name-defined, no-any-return]  # noqa: F821 -- 'aa' is np.asarray, injected
+
+    assert [o.name for o in lower(_rebind_globals(use_asarray, aa=np.asarray)).outputs] == ["out_0", "out_1"]
+
+    def use_float(a: bool) -> float:
+        return f(a)  # type: ignore[name-defined, no-any-return]  # noqa: F821 -- 'f' is the builtin float, injected
+
+    assert _arith_count(lower(_rebind_globals(use_float, f=float)), BoolToFloat) == 1
+
+
+def _module_scoped_helper(a: float) -> float:  # a module global used by the freevar-shadowing test below
+    return a + 100.0
+
+
+def test_freevar_shadowing_a_global_function_is_not_inlined_as_the_global() -> None:
+    # A freevar shadows the same-named module global Python would otherwise call. Dispatch is freevar-aware (resolved),
+    # so the inline path must not lower the module global in its place -- the captured user function is a closure
+    # callable, which is rejected, never silently swapped for the wrong global.
+    def outer(helper: Callable[[float], float]) -> Callable[[float], float]:  # noqa: A002 -- shadows the global name
+        def kernel(x: float) -> float:
+            return helper(x)  # 'helper' is the freevar
+
+        return kernel
+
+    def captured(a: float) -> float:
+        return a * 3.0
+
+    kernel = _rebind_globals(outer(captured), helper=_module_scoped_helper)  # freevar helper + a same-named global
+    with pytest.raises(UnsupportedConstruct, match="helper"):
+        lower(kernel)
+
+
+def test_library_stub_error_is_attributed_to_the_call_site() -> None:
+    def f(a: float) -> float:
+        return math.tan((a, a))  # type: ignore[arg-type]
+
+    with pytest.raises(UnsupportedConstruct, match=r"in tan\(\):") as excinfo:
+        lower(f)
+    location = excinfo.value.location
+    assert location is not None
+    assert location.filename == __file__
+    assert location.line is not None and "math.tan((a, a))" in location.line
+
+
+def test_stub_calling_an_unimplemented_library_function_is_reattributed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A stub body can itself call an unimplemented library function, raising UnsupportedLibraryFunction -- a sibling of
+    # UnsupportedConstruct under SynthesisError. Re-attribution must catch it too (not just UnsupportedConstruct), so
+    # the error points at the user's call site with the concrete type preserved, never the stub-internal location.
+    from holoso._frontend._lib import Library
+    from holoso._frontend._lib._registry import _REGISTRY
+
+    def sentinel(x: float) -> float:  # a stand-in external callable, mapped into the registry for this test
+        return x
+
+    def bad_stub(x: float) -> float:  # a composite whose body calls an unimplemented library function
+        return math.erf(x)
+
+    monkeypatch.setitem(_REGISTRY, sentinel, Library(bad_stub))  # type: ignore[arg-type]
+
+    def kernel(x: float) -> float:
+        return sentinel(x)
+
+    with pytest.raises(UnsupportedLibraryFunction, match="erf") as excinfo:
+        lower(kernel)
+    assert excinfo.value.message.startswith("in sentinel():")
+    assert excinfo.value.location is not None and excinfo.value.location.filename == __file__
 
 
 def test_numpy_array_state_decomposes_like_a_list() -> None:

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -2629,7 +2629,7 @@ def test_static_shape_queries_in_index_range_and_branch_positions() -> None:
         acc = acc + m[m.ndim - 2][m.shape[-1] - 3]  # .ndim and .shape[k] are compile-time integers
         if v.ndim == 1:  # a shape comparison folds, so only the taken arm is lowered
             acc = acc * 2.0
-        return acc
+        return acc  # type: ignore[no-any-return]
 
     hir = lower(kernel)
     assert [o.name for o in hir.outputs] == ["out_0"]
@@ -2684,7 +2684,7 @@ def test_shape_queries_are_rejected_outside_a_static_position() -> None:
         lower(len_of_scalar)
 
     def bad_axis(v: Float64[np.ndarray, "3"]) -> float:
-        return v[v.shape[2]]
+        return v[v.shape[2]]  # type: ignore[return-value]
 
     with pytest.raises(UnsupportedConstruct, match="axis 2 is out of range"):
         lower(bad_axis)
@@ -2731,13 +2731,13 @@ def test_empty_slice_has_no_shape_but_still_has_a_length() -> None:
         acc = v[0]
         for x in v[2:2]:
             acc = acc + x
-        return acc
+        return acc  # type: ignore[no-any-return]
 
     assert iterate_an_empty_slice(np.arange(5.0)) == 0.0  # the kernel is runnable Python, and the loop is empty
     assert _arith_count(lower(iterate_an_empty_slice), FloatAdd) == 0
 
     def ndim_of_an_empty_slice(v: Float64[np.ndarray, "5"]) -> float:
-        return v[0] if v[2:2].ndim == 1 else v[1]
+        return v[0] if v[2:2].ndim == 1 else v[1]  # type: ignore[no-any-return]
 
     with pytest.raises(UnsupportedConstruct, match="rectangular"):
         lower(ndim_of_an_empty_slice)
@@ -2764,14 +2764,14 @@ def test_shape_queries_still_reach_arrays_through_the_same_spellings() -> None:
                 acc = acc + self.v[i]
             for i in range(self.m.ndim):
                 acc = acc + self.m[i][i]
-            return acc + self.m.T[0][1]
+            return acc + self.m.T[0][1]  # type: ignore[no-any-return]
 
     assert [o.name for o in lower(Mixed().__call__).outputs] == ["out_0"]
 
     from jaxtyping import Float64
 
     def array_row_has_ndim(m: Float64[np.ndarray, "2 3"]) -> float:
-        return m[0][0] if m[0].ndim == 1 else m[1][0]
+        return m[0][0] if m[0].ndim == 1 else m[1][0]  # type: ignore[no-any-return]
 
     assert [o.name for o in lower(array_row_has_ndim).outputs] == ["out_0"]
 
@@ -2783,25 +2783,25 @@ def test_list_comprehension_unrolls_and_scopes_its_target() -> None:
     from jaxtyping import Float64
 
     def scaled(v: Float64[np.ndarray, "3"], s: float) -> Float64[np.ndarray, "3"]:
-        return np.array([v[i] * s for i in range(len(v))])  # type: ignore[no-any-return]
+        return np.array([v[i] * s for i in range(len(v))])
 
     hir = lower(scaled)
     assert [o.name for o in hir.outputs] == ["out_0", "out_1", "out_2"]
     assert _arith_count(hir, FloatMul) == 3
 
     def nested(m: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "3 2"]:
-        return np.array([[m[i][j] for i in range(2)] for j in range(3)])  # type: ignore[no-any-return]
+        return np.array([[m[i][j] for i in range(2)] for j in range(3)])
 
     assert [o.name for o in lower(nested).outputs] == [f"out_{i}_{j}" for i in range(3) for j in range(2)]
 
     def filtered(m: Float64[np.ndarray, "3 3"]) -> Float64[np.ndarray, "3"]:
-        return np.array([m[i][j] for i in range(3) for j in range(3) if i < j])  # type: ignore[no-any-return]
+        return np.array([m[i][j] for i in range(3) for j in range(3) if i < j])
 
     assert [o.name for o in lower(filtered).outputs] == ["out_0", "out_1", "out_2"]
 
     def target_does_not_leak(v: Float64[np.ndarray, "3"]) -> float:
         rows = [v[k] for k in range(3)]
-        return rows[0] + k  # type: ignore[name-defined]  # noqa: F821
+        return rows[0] + k  # type: ignore[name-defined, no-any-return]  # noqa: F821
 
     # Unlike a ``for`` counter, a comprehension target is confined to the comprehension, exactly as in Python.
     with pytest.raises(UnsupportedConstruct, match="unknown name 'k'"):
@@ -2813,7 +2813,7 @@ def test_comprehension_yields_a_python_list_not_an_array() -> None:
 
     def arithmetic_on_a_comprehension(v: Float64[np.ndarray, "2"]) -> float:
         rows = [v[i] for i in range(2)]
-        return (rows * 2.0)[0]  # type: ignore[operator]
+        return (rows * 2.0)[0]  # type: ignore[no-any-return, operator]
 
     # A comprehension is a Python list, so numpy-only operations need np.array(...) around it, as in Python.
     with pytest.raises(UnsupportedConstruct, match="Python list/tuple"):
@@ -2824,20 +2824,20 @@ def test_comprehension_rejections() -> None:
     from jaxtyping import Float64
 
     def dynamic_filter(v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "3"]:
-        return np.array([v[i] for i in range(3) if v[i] > 0.0])  # type: ignore[no-any-return]
+        return np.array([v[i] for i in range(3) if v[i] > 0.0])
 
     with pytest.raises(UnsupportedConstruct, match="compile-time condition"):
         lower(dynamic_filter)
 
     def walrus_inside(v: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
-        return np.array([(t := v[i]) + t for i in range(2)])  # type: ignore[no-any-return]
+        return np.array([(t := v[i]) + t for i in range(2)])
 
     with pytest.raises(UnsupportedConstruct, match="walrus"):
         lower(walrus_inside)
 
     def tuple_target(v: Float64[np.ndarray, "2"]) -> float:
         pairs = [[v[0], v[1]]]
-        return [a + b for a, b in pairs][0]
+        return [a + b for a, b in pairs][0]  # type: ignore[no-any-return]
 
     with pytest.raises(UnsupportedConstruct, match="comprehension target must be a plain name"):
         lower(tuple_target)
@@ -2882,7 +2882,7 @@ def test_raise_on_a_statically_taken_path_is_a_located_synthesis_error() -> None
     def rejects(m: Float64[np.ndarray, "2 3"]) -> float:
         if m.ndim != 1:
             raise ValueError(f"expected 1-D, got {m.ndim}-D with {len(m)} rows")
-        return m[0]
+        return m[0]  # type: ignore[no-any-return]
 
     with pytest.raises(UnsupportedConstruct, match="expected 1-D, got 2-D with 2 rows") as excinfo:
         lower(rejects)
@@ -2891,7 +2891,7 @@ def test_raise_on_a_statically_taken_path_is_a_located_synthesis_error() -> None
     def accepts(v: Float64[np.ndarray, "3"]) -> float:
         if v.ndim != 1:
             raise ValueError("expected 1-D")  # the fold never takes this arm, so it never lowers
-        return v[0]
+        return v[0]  # type: ignore[no-any-return]
 
     assert [o.name for o in lower(accepts).outputs] == ["out_0"]
 
@@ -2972,7 +2972,7 @@ def test_state_write_only_on_a_folded_away_shape_branch_is_not_state() -> None:
         def step(self, x: Float64[np.ndarray, "3"]) -> float:
             if len(x) == 4:  # statically false for a declared 3-vector
                 self.s = x[0]
-            return x[0]
+            return x[0]  # type: ignore[no-any-return]
 
     hir = lower(DeadShapeBranch().step)
     assert [slot.name for slot in hir.state_slots] == []
@@ -2999,7 +2999,7 @@ def test_state_write_only_on_a_folded_away_shape_branch_is_not_state() -> None:
         def step(self, x: Float64[np.ndarray, "3"]) -> float:
             if len(x) == 4:
                 self.s = x[0]
-            return self.s + x[0]
+            return self.s + x[0]  # type: ignore[no-any-return]
 
     hir = lower(AlsoRead().step)
     assert [slot.name for slot in hir.state_slots] == ["s"]
@@ -3086,7 +3086,7 @@ def test_comprehension_scoping_follows_python_exactly() -> None:
 
     def inner_generator_sees_the_unbound_comprehension_local(v: Float64[np.ndarray, "2"]) -> float:
         y = v
-        return [y for x in range(1) for y in y][0]  # type: ignore[misc]  # Python: UnboundLocalError on the inner y
+        return [y for x in range(1) for y in y][0]  # type: ignore[no-any-return]  # Python: UnboundLocalError on the inner y
 
     with pytest.raises(UnboundLocalError):
         inner_generator_sees_the_unbound_comprehension_local(np.array([1.0, 2.0]))
@@ -3101,7 +3101,7 @@ def test_comprehension_filter_is_lowered_before_it_is_folded() -> None:
     from jaxtyping import Float64
 
     def unsupported_operand(v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "1"]:
-        return np.array([v[i] for i in range(1) if _returns_a_dict(v) or True])  # type: ignore[misc]
+        return np.array([v[i] for i in range(1) if _returns_a_dict(v) or True])
 
     with pytest.raises(UnsupportedConstruct, match="Dict"):
         lower(unsupported_operand)
@@ -3149,7 +3149,7 @@ def test_an_untouched_state_attribute_is_not_resurrected_by_an_unrelated_branch(
             r = x[0]
             if x[1] > 0.0:  # an unrelated dynamic branch, which merges state
                 r = x[2]
-            return r
+            return r  # type: ignore[no-any-return]
 
     hir = lower(DeadWritePlusUnrelatedBranch().step)
     assert [slot.name for slot in hir.state_slots] == []
@@ -3243,7 +3243,7 @@ def test_only_a_write_lowering_reaches_is_validated() -> None:
         def step(self, v: Float64[np.ndarray, "2"]) -> float:
             if v.ndim == 2:  # statically false for a vector
                 self.never_initialized = 1.0
-            return v[0]
+            return v[0]  # type: ignore[no-any-return]
 
     assert DeadWriteToAnUninitializedAttribute().step(np.array([3.0, 4.0])) == 3.0  # runnable Python
     assert [slot.name for slot in lower(DeadWriteToAnUninitializedAttribute().step).state_slots] == []
@@ -3313,7 +3313,7 @@ def test_state_slot_names_only_collide_among_the_attributes_lowering_keeps() -> 
             if x.ndim == 2:  # dead: the scan cannot fold it, so `v_0` is over-registered
                 self.v_0 = x[0]
             self.v = self.v + x[0]
-            return self.v[0]
+            return self.v[0]  # type: ignore[no-any-return]
 
     assert [slot.name for slot in lower(DeadCollider().step).state_slots] == ["v_0", "v_1"]
 
@@ -3325,7 +3325,7 @@ def test_state_slot_names_only_collide_among_the_attributes_lowering_keeps() -> 
         def step(self, x: float) -> float:
             self.v_0 = x  # reached, so both attributes really do claim the slot name `v_0`
             self.v = self.v + x
-            return self.v[0]
+            return self.v[0]  # type: ignore[no-any-return]
 
     with pytest.raises(UnsupportedConstruct, match="aliasing collision"):
         lower(LiveCollider().step)
@@ -3362,7 +3362,7 @@ def test_iteration_and_shape_queries_reach_every_aggregate_spelling() -> None:
         return acc
 
     def negative_axis_on_a_vector(v: Float64[np.ndarray, "3"]) -> float:
-        return v[v.shape[-1] - 1]
+        return v[v.shape[-1] - 1]  # type: ignore[no-any-return]
 
     m23, m22, v3 = np.arange(6.0).reshape(2, 3), np.arange(4.0).reshape(2, 2), np.arange(3.0)
     for kernel, args in (
@@ -3382,7 +3382,7 @@ def test_a_raise_message_may_interpolate_a_shape_and_a_counter() -> None:
     def guard(m: Float64[np.ndarray, "2 3"]) -> float:
         if m.shape[1] == 3:
             raise ValueError(f"width {m.shape[1]} of a {m.ndim}-D value is not allowed")
-        return m[0][0]
+        return m[0][0]  # type: ignore[no-any-return]
 
     with pytest.raises(UnsupportedConstruct, match="width 3 of a 2-D value is not allowed"):
         lower(guard)
@@ -3392,7 +3392,7 @@ def test_a_raise_message_may_interpolate_a_shape_and_a_counter() -> None:
             raise ValueError("three")
         elif v.ndim == 2:
             raise ValueError("two")
-        return v[0]
+        return v[0]  # type: ignore[no-any-return]
 
     assert dead_elif_chain(np.arange(3.0)) == 0.0  # runnable Python: neither arm is taken
     assert [o.name for o in lower(dead_elif_chain).outputs] == ["out_0"]
@@ -3412,7 +3412,7 @@ def test_a_loop_carries_only_attributes_that_are_really_state() -> None:
                 if v.ndim == 2:  # dead
                     self.never_initialized = v[1]
                 run = False
-            return v[0]
+            return v[0]  # type: ignore[no-any-return]
 
     assert DeadWriteInLoop().step(True, np.array([2.0, 3.0, 5.0])) == 2.0
     assert [slot.name for slot in lower(DeadWriteInLoop().step).state_slots] == []
@@ -3429,8 +3429,8 @@ def test_a_shape_query_reads_the_reset_value_not_the_state_decomposition() -> No
         def step(self, v: Float64[np.ndarray, "2"]) -> float:
             if v.ndim == 2:
                 if self.cube.ndim == 3:
-                    return v[1]
-            return v[0]
+                    return v[1]  # type: ignore[no-any-return]
+            return v[0]  # type: ignore[no-any-return]
 
     assert Cube().step(np.array([2.0, 9.0])) == 2.0
     assert [o.name for o in lower(Cube().step).outputs] == ["out_0"]
@@ -3510,14 +3510,14 @@ def test_a_write_is_validated_only_where_lowering_reaches_it() -> None:
                 if v.ndim == 2:  # dead
                     self.p = v[0]
                 run = False
-            return v[0]
+            return v[0]  # type: ignore[no-any-return]
 
     class LiveDescriptorWriteInLoop(Descriptor):
         def step(self, run: bool, v: Float64[np.ndarray, "2"]) -> float:
             while run:
                 self.p = v[0]
                 run = False
-            return v[0]
+            return v[0]  # type: ignore[no-any-return]
 
     class DeadCubeWrite:
         def __init__(self) -> None:
@@ -3527,7 +3527,7 @@ def test_a_write_is_validated_only_where_lowering_reaches_it() -> None:
         def step(self, v: Float64[np.ndarray, "2"]) -> float:
             if v.ndim == 2:  # dead: a 3-D attribute cannot be state
                 self.cube = v
-            return v[0]
+            return v[0]  # type: ignore[no-any-return]
 
     v = np.array([1.0, 2.0])
     assert DeadDescriptorWriteInLoop().step(True, v) == 1.0
@@ -3690,7 +3690,7 @@ def test_a_ragged_or_empty_reset_sequence_still_has_a_length() -> None:
             self.empty: list[float] = []
 
         def step(self, v: Float64[np.ndarray, "3"]) -> float:
-            return v[len(self.ragged)] + v[len(self.ragged[1])] + v[len(self.empty)]
+            return v[len(self.ragged)] + v[len(self.ragged[1])] + v[len(self.empty)]  # type: ignore[no-any-return]
 
     v = np.array([10.0, 20.0, 30.0])
     assert RaggedRows().step(v) == 70.0
@@ -3705,7 +3705,7 @@ def test_indexing_a_reset_sequence_of_arrays_yields_an_array() -> None:
             self.rows = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
 
         def step(self, v: Float64[np.ndarray, "3"]) -> float:
-            return v[self.rows[0].ndim]  # the element is the ndarray, not a list
+            return v[self.rows[0].ndim]  # type: ignore[no-any-return]  # the element is the ndarray, not a list
 
     v = np.array([10.0, 20.0, 30.0])
     assert ArrayRows().step(v) == 20.0
@@ -3720,7 +3720,7 @@ def test_a_shape_query_on_a_nested_reset_sequence_element_is_rejected() -> None:
             self.nested = [[1.0, 2.0]]
 
         def step(self, v: Float64[np.ndarray, "3"]) -> float:
-            return v[self.nested[0].ndim]  # type: ignore[attr-defined]  # a list has no .ndim
+            return v[self.nested[0].ndim]  # type: ignore[attr-defined, return-value]  # a list has no .ndim
 
     with pytest.raises(UnsupportedConstruct, match="ndim on a Python list/tuple"):
         lower(NestedNdim().step)
@@ -3735,7 +3735,7 @@ def test_subscripting_a_non_container_reset_attribute_is_a_located_rejection() -
             self.lookup = {"a": 1}
 
         def step(self, v: Float64[np.ndarray, "3"]) -> float:
-            return v[len(self.lookup[0])]  # type: ignore[index]  # a KeyError in Python
+            return v[len(self.lookup[0])]  # type: ignore[arg-type, index, no-any-return]  # a KeyError in Python
 
     with pytest.raises(UnsupportedConstruct):
         lower(ForeignAttr().step)
@@ -3751,7 +3751,7 @@ def test_a_scan_must_not_fold_a_counter_an_empty_aggregate_never_rebinds() -> No
         def step(self, a: float) -> float:
             for i in range(2):
                 pass
-            for _unused in []:
+            for _unused in []:  # type: ignore[var-annotated]
                 for i in range(5):  # noqa: B007  # never runs; must not leak i == 4 into the scan
                     pass
             if i == 1:
@@ -3810,7 +3810,7 @@ def test_a_scan_demotes_the_aggregate_target_before_discovering_body_rebinds() -
                 pass
             for j in range(1):  # noqa: B007  # leaks j == 0
                 pass
-            for x in [a]:  # noqa: B007  # aggregate: target demoted, body rebinds j
+            for x in [a]:  # type: ignore[assignment]  # noqa: B007  # aggregate: target demoted, body rebinds j
                 if x != 0:
                     j = x  # noqa: PLW2901
             if j != 0:
@@ -3835,7 +3835,7 @@ def test_a_tuple_index_of_a_list_reset_attribute_is_a_located_rejection() -> Non
             self.rows = [[1.0, 2.0]]
 
         def step(self, v: Float64[np.ndarray, "3"]) -> float:
-            return v[len(self.rows[0,])]  # type: ignore[index]  # a TypeError in Python
+            return v[len(self.rows[0,])]  # type: ignore[call-overload,no-any-return]  # a TypeError in Python
 
     with pytest.raises(UnsupportedConstruct):
         lower(TupleIndexedRows().step)
@@ -3848,7 +3848,7 @@ def test_an_inexact_integer_loop_counter_is_rejected_not_silently_rounded() -> N
     # A counter the float register cannot hold exactly would round in value position, flipping a comparison against a
     # runtime float. The range binds the single counter 2**53+1, which rounds to 2**53.
     def counter_rounds(x: float) -> float:
-        return (
+        return (  # type: ignore[no-any-return]
             x
             + np.array(
                 [1.0 if i == float(2**53) else 0.0 for i in range(_INEXACT_COUNTER_START, _INEXACT_COUNTER_START + 1)]
@@ -3866,13 +3866,13 @@ def test_a_scalar_takes_an_empty_tuple_key_as_identity_like_a_numpy_scalar() -> 
     from jaxtyping import Float64
 
     def element_full_index(v: Float64[np.ndarray, "3"]) -> float:
-        return v[0][()]  # numpy: v[0], a 0-D identity
+        return v[0][()]  # type: ignore[no-any-return]  # numpy: v[0], a 0-D identity
 
     assert element_full_index(np.array([2.0, 4.0, 6.0])) == 2.0
     _assert_shape_kernel_matches_python(element_full_index, np.array([2.0, 4.0, 6.0]))
 
     def index_a_scalar(v: Float64[np.ndarray, "3"]) -> float:
-        return v[0][0]  # numpy: IndexError, too many indices for a scalar
+        return v[0][0]  # type: ignore[no-any-return]  # numpy: IndexError, too many indices for a scalar
 
     with pytest.raises(IndexError):
         index_a_scalar(np.array([2.0, 4.0, 6.0]))

--- a/tests/test_library_stubs.py
+++ b/tests/test_library_stubs.py
@@ -1,0 +1,196 @@
+"""
+Plain-Python numerical verification of the library stubs: each composite stub is executed directly (no compiler
+involved) and compared against the math/numpy function it substitutes. This checks the ALGORITHM (the identity the
+stub encodes); the lowering of the same stubs is checked end-to-end in test_extended_operators / test_cosim.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from holoso._frontend._lib import Intrinsic, Library, resolve
+from holoso._frontend._lib._intrinsics import (
+    abs_,
+    atan2_,
+    ceil_,
+    cos_,
+    exp2_,
+    floor_,
+    fma_,
+    hypot_,
+    isfinite_,
+    isinf_,
+    isneginf_,
+    isposinf_,
+    log2_,
+    max_,
+    min_,
+    round_,
+    sin_,
+    sqrt_,
+    trunc_,
+)
+from holoso._frontend._lib._numpy import (
+    acos_,
+    acosh_,
+    asin_,
+    asinh_,
+    atan_,
+    atanh_,
+    cbrt_,
+    cosh_,
+    degrees_,
+    exp_,
+    expm1_,
+    log10_,
+    log1p_,
+    log_,
+    pow_,
+    radians_,
+    sign_,
+    sinh_,
+    tan_,
+    tanh_,
+)
+
+_INF = float("inf")
+
+
+def test_registry_resolves_the_expected_externals() -> None:
+    intrinsic_externals: list[object] = [math.sqrt, np.sqrt, math.sin, np.cos, math.atan2, np.arctan2]
+    intrinsic_externals += [abs, min, max, round, math.fma, np.fmin, np.fmax, np.fix, np.rint, np.around]
+    for external in intrinsic_externals:
+        assert isinstance(resolve(external), Intrinsic), external
+    library_externals: list[object] = [math.cbrt, np.cbrt, math.tan, np.sign, math.exp, np.log10]
+    library_externals += [pow, math.pow, np.power, np.float_power]
+    library_externals += [math.sinh, np.cosh, math.tanh, math.asinh, np.arcsinh, math.acosh, math.atanh]
+    library_externals += [math.expm1, np.log1p, math.degrees, np.rad2deg, math.radians, np.deg2rad]
+    for external in library_externals:
+        assert isinstance(resolve(external), Library), external
+    # An unregistered callable resolves to nothing; an unhashable shadow does not crash the lookup.
+    assert resolve(math.erf) is None and resolve(np.zeros(3)) is None
+
+
+def test_intrinsic_stubs_match_their_references() -> None:
+    for x in (0.0, -0.0, 0.75, -2.5, 3.0, 100.0, -1e-30):
+        assert exp2_(x) == math.exp2(x)
+        assert sin_(x) == math.sin(x)
+        assert cos_(x) == math.cos(x)
+        assert floor_(x) == np.floor(x) and ceil_(x) == np.ceil(x) and trunc_(x) == np.trunc(x)
+        assert abs_(x) == abs(x)
+        assert round_(x) == np.round(x)
+        assert isfinite_(x) and not isinf_(x) and not isposinf_(x) and not isneginf_(x)
+    for x in (0.25, 1.0, 4.0, 1e30):
+        assert log2_(x) == math.log2(x)
+        assert sqrt_(x) == math.sqrt(x)
+    assert atan2_(3.0, -4.0) == math.atan2(3.0, -4.0)
+    assert hypot_(3.0, 4.0) == 5.0
+    assert min_(1.5, -2.0) == -2.0 and max_(1.5, -2.0) == 1.5
+    assert fma_(3.0, 4.0, 5.0) == math.fma(3.0, 4.0, 5.0)
+    assert floor_(_INF) == _INF and ceil_(-_INF) == -_INF
+    assert round_(2.5) == 2.0 and round_(3.5) == 4.0 and round_(-_INF) == -_INF
+    assert isposinf_(_INF) and not isneginf_(_INF) and isinf_(-_INF) and not isfinite_(_INF)
+    assert exp2_(1e30) == _INF  # saturates like the hardware instead of raising like math.exp2
+
+
+def test_sign() -> None:
+    for x in (1e-300, 0.5, 7.0, _INF):
+        assert sign_(x) == 1.0 and sign_(-x) == -1.0
+    assert sign_(0.0) == 0.0 and sign_(-0.0) == 0.0
+    assert math.isnan(sign_(math.nan))  # r = x in the zero branch reproduces np.sign(nan) = nan exactly
+
+
+def test_cbrt() -> None:
+    for x in (8.0, -27.0, 0.5, -1e-6, 1e18, 3.7):
+        assert cbrt_(x) == pytest.approx(math.cbrt(x), rel=1e-12), x
+    assert cbrt_(0.0) == 0.0 and cbrt_(-0.0) == 0.0
+
+
+def test_tan() -> None:
+    for x in (0.0, 0.3, -1.2, 2.0, 100.0, math.pi / 2):  # pi/2 is not exact in binary64, so tan() is finite there
+        assert tan_(x) == pytest.approx(math.tan(x), rel=1e-12), x
+
+
+def test_atan() -> None:
+    for x in (0.0, 1.0, -1.0, 0.001, -1e6, _INF):
+        assert atan_(x) == pytest.approx(math.atan(x), rel=1e-12), x
+
+
+def test_asin_acos() -> None:
+    for x in (0.0, 0.5, -0.5, 0.9, -0.999, 1.0, -1.0):
+        assert asin_(x) == pytest.approx(math.asin(x), rel=1e-7, abs=1e-9), x
+        assert acos_(x) == pytest.approx(math.acos(x), rel=1e-7, abs=1e-9), x
+    with pytest.raises(ValueError):
+        asin_(1.5)  # domain violation raises in plain Python (math.sqrt of a negative), like math.asin
+
+
+def test_exp_log() -> None:
+    for x in (0.0, 1.0, -1.0, 10.0, -30.0, 0.001):
+        assert exp_(x) == pytest.approx(math.exp(x), rel=1e-12), x
+    for x in (0.001, 0.5, 1.0, math.e, 100.0, 1e30):
+        assert log_(x) == pytest.approx(math.log(x), rel=1e-12, abs=1e-15), x
+        assert log10_(x) == pytest.approx(math.log10(x), rel=1e-12, abs=1e-15), x
+
+
+def test_pow_rungs_are_exact_including_negative_bases() -> None:
+    for b in (2.0, -2.0, 0.5, -1.5, 3.0):
+        for e in (0.0, 1.0, 2.0, 3.0, 4.0, 5.0):
+            assert pow_(b, e) == math.pow(b, e), (b, e)
+    assert pow_(0.0, 0.0) == 1.0
+    assert pow_(-2.0, 3.0) == -8.0
+
+
+def test_pow_general_path() -> None:
+    for b, e in ((2.0, 0.5), (3.0, 2.5), (10.0, -1.5), (0.5, 8.0), (1.0, 123.456)):
+        assert pow_(b, e) == pytest.approx(math.pow(b, e), rel=1e-12), (b, e)
+    with pytest.raises(ValueError):
+        pow_(-2.0, 6.0)  # off the rungs, the a>0 identity raises in plain Python where math.pow is 64.0
+
+
+def test_pow_zero_base() -> None:
+    # A zero base short-circuits to r = b, so the stub no longer routes through log2(0) (which raised here before) and
+    # matches math.pow for a non-negative exponent: 0**0 == 1, 0**positive == 0. Exponents off the 0..5 rungs (0.5,
+    # 7.0, ...) are the ones that used to reach the general path and fail.
+    for e in (0.0, 0.5, 1.0, 2.0, 5.0, 7.0, 123.4):
+        assert pow_(0.0, e) == math.pow(0.0, e), e
+
+
+def test_pow_unit_base() -> None:
+    # A unit base short-circuits to 1.0, so pow(1, e) == 1 for every e -- including a non-finite one, where the general
+    # path's exp2(e * log2(1)) = exp2(e * 0) would otherwise yield nan (inf * 0). Matches IEEE 754 / math.pow.
+    for e in (0.0, 0.5, 2.0, 7.0, -3.0, _INF, -_INF, math.nan):
+        assert pow_(1.0, e) == 1.0, e
+
+
+def test_hyperbolic() -> None:
+    for x in (-4.0, -1.0, -0.1, 0.0, 0.1, 1.0, 4.0):
+        assert sinh_(x) == pytest.approx(math.sinh(x), rel=1e-12, abs=1e-15), x
+        assert cosh_(x) == pytest.approx(math.cosh(x), rel=1e-12), x
+    for x in (-30.0, -2.0, 0.0, 2.0, 30.0):  # the stable sigmoid form holds tanh in [-1,1] without exp overflow
+        assert tanh_(x) == pytest.approx(math.tanh(x), rel=1e-12, abs=1e-15), x
+
+
+def test_inverse_hyperbolic() -> None:
+    # 1e200/1e300 exceed float64's own x*x overflow (~1.3e154), exercising the large-|x| branch that returns ln(2|x|).
+    for x in (-1e6, -2.0, 0.0, 2.0, 1e6, 1e200, -1e200, 1e300):  # the sign/abs form also keeps large-negative asinh
+        assert asinh_(x) == pytest.approx(math.asinh(x), rel=1e-12, abs=1e-15), x
+    for x in (1.0, 1.5, 4.0, 100.0, 1e200, 1e300):
+        assert acosh_(x) == pytest.approx(math.acosh(x), rel=1e-12, abs=1e-15), x
+    for x in (-0.99, -0.5, 0.0, 0.5, 0.99):
+        assert atanh_(x) == pytest.approx(math.atanh(x), rel=1e-12, abs=1e-15), x
+    with pytest.raises(ValueError):
+        acosh_(0.5)  # domain violation (sqrt of a negative), like math.acosh
+
+
+def test_expm1_log1p() -> None:
+    for x in (-1.0, -0.1, 0.1, 1.0, 10.0):
+        assert expm1_(x) == pytest.approx(math.expm1(x), rel=1e-12, abs=1e-15), x
+    for x in (-0.5, 0.0, 0.5, 10.0, 100.0):
+        assert log1p_(x) == pytest.approx(math.log1p(x), rel=1e-12, abs=1e-15), x
+
+
+def test_degrees_radians() -> None:
+    for x in (-3.14, -1.0, 0.0, 1.0, 90.0):
+        assert degrees_(x) == pytest.approx(math.degrees(x), rel=1e-12, abs=1e-15), x
+        assert radians_(x) == pytest.approx(math.radians(x), rel=1e-12, abs=1e-15), x

--- a/tests/test_library_stubs.py
+++ b/tests/test_library_stubs.py
@@ -72,7 +72,7 @@ def test_registry_resolves_the_expected_externals() -> None:
     for external in library_externals:
         assert isinstance(resolve(external), Library), external
     # ``@`` and ``.T`` are lowered by resolving these two, so the frontend holds no matrix expansion of its own.
-    assert resolve(np.matmul) == Library(matmul_) and resolve(np.transpose) == Library(transpose_)
+    assert resolve(np.matmul) == Library(matmul_) and resolve(np.transpose) == Library(transpose_)  # type: ignore[arg-type]
     assert resolve(np.dot) == resolve(np.matmul)  # identical on the supported 1-D/2-D non-scalar domain
     # An unregistered callable resolves to nothing; an unhashable shadow does not crash the lookup.
     assert resolve(math.erf) is None and resolve(np.zeros(3)) is None
@@ -234,14 +234,14 @@ def test_linalg_stubs_reject_the_shapes_they_do_not_support() -> None:
     # frontend surfaces at the user's call site, so they are asserted here rather than only through the compiler.
     scalar, vector, matrix, cube = np.float64(2.0), np.arange(3.0), np.ones((2, 3)), np.ones((2, 2, 2))
     with pytest.raises(ValueError, match="scalar"):
-        matmul_(scalar, vector)
+        matmul_(scalar, vector)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="1-D or 2-D"):
         matmul_(cube, vector)
     assert np.allclose(matmul_(matrix, vector), matrix @ vector)  # 2×3 @ 3 agrees, so the mismatch below is genuine
     with pytest.raises(ValueError, match="mismatch"):
         matmul_(matrix, np.arange(2.0))
     with pytest.raises(ValueError, match="transpose a scalar"):
-        transpose_(scalar)
+        transpose_(scalar)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="1-D or 2-D|not supported"):
         transpose_(cube)
     with pytest.raises(ValueError, match="square"):

--- a/tests/test_library_stubs.py
+++ b/tests/test_library_stubs.py
@@ -1,7 +1,8 @@
 """
 Plain-Python numerical verification of the library stubs: each composite stub is executed directly (no compiler
 involved) and compared against the math/numpy function it substitutes. This checks the ALGORITHM (the identity the
-stub encodes); the lowering of the same stubs is checked end-to-end in test_extended_operators / test_cosim.
+stub encodes); the lowering of the same stubs is checked end-to-end in test_extended_operators / test_matrix /
+test_cosim.
 """
 
 import math
@@ -10,6 +11,7 @@ import numpy as np
 import pytest
 
 from holoso._frontend._lib import Intrinsic, Library, resolve
+from holoso._frontend._lib._linalg import matmul_, outer_, trace_, transpose_
 from holoso._frontend._lib._intrinsics import (
     abs_,
     atan2_,
@@ -66,10 +68,15 @@ def test_registry_resolves_the_expected_externals() -> None:
     library_externals += [pow, math.pow, np.power, np.float_power]
     library_externals += [math.sinh, np.cosh, math.tanh, math.asinh, np.arcsinh, math.acosh, math.atanh]
     library_externals += [math.expm1, np.log1p, math.degrees, np.rad2deg, math.radians, np.deg2rad]
+    library_externals += [np.matmul, np.dot, np.transpose, np.trace, np.outer]
     for external in library_externals:
         assert isinstance(resolve(external), Library), external
+    # ``@`` and ``.T`` are lowered by resolving these two, so the frontend holds no matrix expansion of its own.
+    assert resolve(np.matmul) == Library(matmul_) and resolve(np.transpose) == Library(transpose_)
+    assert resolve(np.dot) == resolve(np.matmul)  # identical on the supported 1-D/2-D non-scalar domain
     # An unregistered callable resolves to nothing; an unhashable shadow does not crash the lookup.
     assert resolve(math.erf) is None and resolve(np.zeros(3)) is None
+    assert resolve(np.linalg.inv) is None and resolve(np.inner) is None  # deliberately not implemented yet
 
 
 def test_intrinsic_stubs_match_their_references() -> None:
@@ -194,3 +201,52 @@ def test_degrees_radians() -> None:
     for x in (-3.14, -1.0, 0.0, 1.0, 90.0):
         assert degrees_(x) == pytest.approx(math.degrees(x), rel=1e-12, abs=1e-15), x
         assert radians_(x) == pytest.approx(math.radians(x), rel=1e-12, abs=1e-15), x
+
+
+def test_matmul_matches_numpy_in_every_rank_combination() -> None:
+    rng = np.random.default_rng(20260710)
+    a, b = rng.normal(size=(3, 4)), rng.normal(size=(4, 2))
+    u, w = rng.normal(size=4), rng.normal(size=3)
+    # The left fold is not BLAS's summation order, so the agreement is up to rounding, not bit-exact.
+    assert np.allclose(matmul_(a, b), a @ b)
+    assert np.allclose(matmul_(a, u), a @ u)  # a 1-D right operand is a column whose axis is dropped
+    assert np.allclose(matmul_(w, a), w @ a)  # a 1-D left operand is a row whose axis is dropped
+    assert np.allclose(matmul_(u, u), u @ u)  # both promoted and both dropped: a scalar dot product
+    assert np.ndim(matmul_(u, u)) == 0
+
+
+def test_transpose_matches_numpy() -> None:
+    rng = np.random.default_rng(20260711)
+    m, v = rng.normal(size=(2, 5)), rng.normal(size=3)
+    assert np.allclose(transpose_(m), m.T)
+    assert np.allclose(transpose_(v), v.T)  # numpy leaves a vector alone
+
+
+def test_trace_and_outer_match_numpy() -> None:
+    rng = np.random.default_rng(20260712)
+    s, u, v = rng.normal(size=(4, 4)), rng.normal(size=3), rng.normal(size=5)
+    assert trace_(s) == pytest.approx(np.trace(s))
+    assert np.allclose(outer_(u, v), np.outer(u, v))
+
+
+def test_linalg_stubs_reject_the_shapes_they_do_not_support() -> None:
+    # The stub raises in plain Python exactly where lowering rejects the kernel; the messages are the diagnostics the
+    # frontend surfaces at the user's call site, so they are asserted here rather than only through the compiler.
+    scalar, vector, matrix, cube = np.float64(2.0), np.arange(3.0), np.ones((2, 3)), np.ones((2, 2, 2))
+    with pytest.raises(ValueError, match="scalar"):
+        matmul_(scalar, vector)
+    with pytest.raises(ValueError, match="1-D or 2-D"):
+        matmul_(cube, vector)
+    assert np.allclose(matmul_(matrix, vector), matrix @ vector)  # 2×3 @ 3 agrees, so the mismatch below is genuine
+    with pytest.raises(ValueError, match="mismatch"):
+        matmul_(matrix, np.arange(2.0))
+    with pytest.raises(ValueError, match="transpose a scalar"):
+        transpose_(scalar)
+    with pytest.raises(ValueError, match="1-D or 2-D|not supported"):
+        transpose_(cube)
+    with pytest.raises(ValueError, match="square"):
+        trace_(matrix)
+    with pytest.raises(ValueError, match="matrix"):
+        trace_(vector)
+    with pytest.raises(ValueError, match="1-D"):
+        outer_(matrix, vector)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -438,6 +438,34 @@ def test_state_attribute_named_t_shadows_transpose() -> None:
     assert [s.name for s in hir.state_slots] == ["T"]
 
 
+def test_state_attributes_named_shape_and_ndim_shadow_the_shape_queries() -> None:
+    # ``.shape``/``.ndim`` on the instance keep Python's own attribute-resolution priority, exactly as ``.T`` does:
+    # they are state reads, not compile-time shape queries.
+    @dataclasses.dataclass
+    class Holder:
+        shape: float
+        ndim: float
+        T: float
+
+        def step(self, a: float) -> float:
+            self.shape = self.shape + a
+            self.ndim = self.ndim * 2.0
+            self.T = self.T - a
+            return self.shape + self.ndim + self.T
+
+    hir = lower(Holder(0.0, 1.0, 2.0).step)
+    assert [s.name for s in hir.state_slots] == ["shape", "ndim", "T"]
+
+    # The reset snapshot is read at synthesis time, so the reference instance must stay untouched until then.
+    sim = _sim(Holder(0.5, 1.0, 2.0).step)
+    reference = Holder(0.5, 1.0, 2.0)
+    for a in (0.25, -1.5, 3.0):
+        want = reference.step(a)
+        returned, state_shape, state_ndim, state_t = _run(sim, a)
+        assert returned == pytest.approx(want)
+        assert (state_shape, state_ndim, state_t) == pytest.approx((reference.shape, reference.ndim, reference.T))
+
+
 def test_numpy_subscripts() -> None:
     def picks(m: Float64[np.ndarray, "2 3"]) -> tuple[float, float, float, float]:
         column = m[:, 2]
@@ -450,7 +478,7 @@ def test_numpy_subscripts() -> None:
     def too_many(m: Float64[np.ndarray, "2 2"]) -> float:
         return m[0, 1, 0]  # type: ignore[no-any-return]
 
-    with pytest.raises(UnsupportedConstruct, match="scalar"):
+    with pytest.raises(UnsupportedConstruct, match="too many indices"):
         lower(too_many)
 
 
@@ -1065,3 +1093,167 @@ def test_imu_frame_transform_fma_matches_numpy() -> None:
         inputs = (rotation, np.array([1.0, 2.0, 3.0]), np.array([0.1, -0.2, 9.9]), np.array([2.0, 0.0, -1.0]))
         want = np.asarray(imu_frame_transform.transform(*inputs)).flatten()
         assert np.allclose(_run(sim, *inputs), want, rtol=1e-9, atol=1e-300)
+
+
+# ---------------------------------------------------------------- linear algebra library functions
+
+
+def test_operators_are_the_library_functions() -> None:
+    # ``@`` and ``.T`` lower by resolving np.matmul / np.transpose in the registry, so the operator and its spelled
+    # call cannot drift apart: identical HIR, not merely identical values.
+    def with_operators(a: Float64[np.ndarray, "2 3"], b: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "2 2"]:
+        return a @ b.T  # type: ignore[no-any-return]
+
+    def with_calls(a: Float64[np.ndarray, "2 3"], b: Float64[np.ndarray, "2 3"]) -> Float64[np.ndarray, "2 2"]:
+        return np.matmul(a, np.transpose(b))  # type: ignore[no-any-return]
+
+    counts = [
+        (_arith_count(lower(k), FloatMul), _arith_count(lower(k), FloatAdd)) for k in (with_operators, with_calls)
+    ]
+    assert counts[0] == counts[1] == (12, 8)
+    for kernel in (with_operators, with_calls):
+        _assert_python_matches_holoso(
+            kernel, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), np.array([[0.5, -1.0, 2.0], [3.0, -2.0, 0.25]])
+        )
+
+
+def test_np_dot_is_the_matrix_product() -> None:
+    def dot_kernel(a: Float64[np.ndarray, "2 2"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return np.dot(a, x)  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(dot_kernel).outputs] == ["out_0", "out_1"]
+    _assert_python_matches_holoso(dot_kernel, np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([1.0, -1.0]))
+
+    def scalar_dot(a: float, x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return np.dot(a, x)  # type: ignore[no-any-return]
+
+    # numpy would multiply here; Holoso rejects rather than silently reinterpreting the matrix product as a broadcast.
+    with pytest.raises(UnsupportedConstruct, match="scalar"):
+        lower(scalar_dot)
+
+
+def test_np_trace_and_np_outer() -> None:
+    def tr(m: Float64[np.ndarray, "3 3"]) -> float:
+        return np.trace(m)  # type: ignore[no-any-return]
+
+    assert [o.name for o in lower(tr).outputs] == ["out_0"]
+    assert _arith_count(lower(tr), FloatMul) == 0  # a fold of the diagonal, no multiplies
+    _assert_python_matches_holoso(tr, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]))
+
+    def outer(u: Float64[np.ndarray, "2"], v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "2 3"]:
+        return np.outer(u, v)  # type: ignore[no-any-return]
+
+    assert _arith_count(lower(outer), FloatMul) == 6 and _arith_count(lower(outer), FloatAdd) == 0
+    _assert_python_matches_holoso(outer, np.array([1.0, -2.0]), np.array([0.5, 3.0, -1.0]))
+
+    def rect_trace(m: Float64[np.ndarray, "2 3"]) -> float:
+        return np.trace(m)  # type: ignore[no-any-return]
+
+    # numpy walks the shorter diagonal; Holoso rejects rather than reinterpreting.
+    with pytest.raises(UnsupportedConstruct, match="square"):
+        lower(rect_trace)
+
+    def outer_of_matrix(m: Float64[np.ndarray, "2 2"]) -> Float64[np.ndarray, "2 2"]:
+        return np.outer(m, m)  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="1-D"):
+        lower(outer_of_matrix)
+
+
+def test_trace_of_a_1x1_boolean_matrix_is_rejected_like_a_larger_one() -> None:
+    # The diagonal fold is seeded at 0.0, so even a 1x1 trace contracts through an addition and rejects a boolean
+    # diagonal, rather than passing the boolean through where numpy would widen it to an integer.
+    def bool_trace(flag: bool) -> bool:
+        return np.trace(np.array([[flag]]))  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match="floating-point"):
+        lower(bool_trace)
+
+
+def test_library_shape_rejection_is_attributed_to_the_user_call_site() -> None:
+    # A stub validates its own operands with a ``raise`` on a statically taken path; the error must name the user's
+    # spelling and point at the user's line, never into the stub source.
+    def bad(a: Float64[np.ndarray, "2 3"], x: Float64[np.ndarray, "2"]) -> Float64[np.ndarray, "2"]:
+        return a @ x  # type: ignore[no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match=r"in matmul\(\).*mismatch") as excinfo:
+        lower(bad)
+    assert excinfo.value.location is not None
+    assert excinfo.value.location.line is not None and "a @ x" in excinfo.value.location.line
+
+    def bad_t(a: float) -> float:
+        return a.T  # type: ignore[attr-defined, no-any-return]
+
+    with pytest.raises(UnsupportedConstruct, match=r"in transpose\(\).*transpose a scalar"):
+        lower(bad_t)
+
+
+def test_matrix_state_transposed_under_a_shape_guard_across_transactions() -> None:
+    # The reset snapshot fixes the shape, so the guard folds identically in the scan and in lowering, while the
+    # attribute itself is reassigned every transaction. Compare every port by NAME: the returned leaf is deduped onto
+    # the public state port that already carries it, so a positional comparison would read the wrong wire.
+    class Flip:
+        def __init__(self) -> None:
+            self.P = np.array([[1.0, 2.0], [3.0, 4.0]])
+            self.s = 0.0
+
+        def step(self, x: float) -> float:
+            self.P = self.P.T
+            if self.P.ndim == 2:
+                self.s = self.s + self.P[0][1] * x
+            return self.s
+
+    sim = _sim(Flip().step)
+    ports = [p.name for p in sim.outputs]
+    assert ports == ["state_P_0_0", "state_P_0_1", "state_P_1_0", "state_P_1_1", "state_s"]
+    reference = Flip()
+    for _ in range(4):
+        want = reference.step(2.0)
+        got = dict(zip(ports, [float(v) for v in sim.run(2.0)]))
+        assert got["state_s"] == pytest.approx(want)
+        assert [got[f"state_P_{i}_{j}"] for i in range(2) for j in range(2)] == pytest.approx(
+            list(reference.P.flatten())
+        )
+
+
+def test_matrix_product_inside_a_comprehension_inside_a_loop() -> None:
+    # The stub is inlined from inside a comprehension element, itself inside an unrolled loop, and its result feeds
+    # persistent state. Exercises the interaction of aggregate iteration, comprehension scoping, and stub inlining.
+    class Accumulate:
+        def __init__(self) -> None:
+            self.acc = 0.0
+
+        def step(self, a: Float64[np.ndarray, "2 2"], v: Float64[np.ndarray, "2"]) -> float:
+            for _ in range(2):
+                w = [(a @ v)[k] + (a.T @ v)[k] for k in range(2)]
+                self.acc = self.acc + w[0] + w[1]
+            return self.acc
+
+    a, v = np.array([[1.0, 0.5], [-0.5, 2.0]]), np.array([3.0, -1.0])
+    sim = _sim(Accumulate().step)
+    reference = Accumulate()
+    for _ in range(3):
+        want = reference.step(a, v)
+        assert _run(sim, a, v)[0] == pytest.approx(want)
+
+
+def test_for_over_an_aggregate_inside_a_while_loop() -> None:
+    # A target first bound inside the loop is not loop-carried, so aggregate iteration composes with a back-edge loop.
+    class SumRows:
+        def __init__(self) -> None:
+            self.s = 0.0
+
+        def step(self, m: Float64[np.ndarray, "2 2"], n: float) -> float:
+            j = 0.0
+            while j < n:
+                for row in m:
+                    self.s = self.s + row[0]
+                j = j + 1.0
+            return self.s
+
+    m = np.array([[1.0, 2.0], [3.0, 4.0]])
+    sim = _sim(SumRows().step)
+    reference = SumRows()
+    for _ in range(3):
+        want = reference.step(m, 2.0)
+        assert _run(sim, m, 2.0)[0] == pytest.approx(want)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1141,7 +1141,7 @@ def test_np_trace_and_np_outer() -> None:
     _assert_python_matches_holoso(tr, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]))
 
     def outer(u: Float64[np.ndarray, "2"], v: Float64[np.ndarray, "3"]) -> Float64[np.ndarray, "2 3"]:
-        return np.outer(u, v)  # type: ignore[no-any-return]
+        return np.outer(u, v)
 
     assert _arith_count(lower(outer), FloatMul) == 6 and _arith_count(lower(outer), FloatAdd) == 0
     _assert_python_matches_holoso(outer, np.array([1.0, -2.0]), np.array([0.5, 3.0, -1.0]))
@@ -1154,7 +1154,7 @@ def test_np_trace_and_np_outer() -> None:
         lower(rect_trace)
 
     def outer_of_matrix(m: Float64[np.ndarray, "2 2"]) -> Float64[np.ndarray, "2 2"]:
-        return np.outer(m, m)  # type: ignore[no-any-return]
+        return np.outer(m, m)
 
     with pytest.raises(UnsupportedConstruct, match="1-D"):
         lower(outer_of_matrix)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -43,6 +43,7 @@ from cordic_sincos import CordicSinCos  # noqa: E402
 from ekf1_stateful import Ekf1  # noqa: E402
 from ekf1_stateless import update_x_P  # noqa: E402
 from iir1_lpf import IIR1LPF  # noqa: E402
+import imu_frame_transform  # noqa: E402
 from latching_fault_register import LatchingFaultRegister  # noqa: E402
 from majority_voter import MajorityVoter  # noqa: E402
 from octave_index import octave_index  # noqa: E402
@@ -73,6 +74,7 @@ _EXAMPLES: dict[str, Callable[[], Callable[..., object]]] = {
     "octave_index": lambda: octave_index,
     "cordic_sincos": lambda: CordicSinCos().__call__,
     "integrator": lambda: TrapezoidalLeakyStreamingIntegrator(k=2**-22).__call__,
+    "imu_frame_transform": lambda: imu_frame_transform.transform,
     "ekf1_stateless": lambda: update_x_P,
     "ekf1_stateful": lambda: Ekf1().update,
 }
@@ -207,6 +209,11 @@ BASELINE: dict[str, Metrics] = {
         False, nreg=7, bnreg=1, steering=53, copies=0, min_ii=105, last_pc=105, max_block_span=105
     ),
     "integrator": Metrics(True, nreg=5, bnreg=0, steering=4, copies=0, min_ii=17, last_pc=17, max_block_span=17),
+    # The only example whose datapath is built entirely from the matrix product and transpose, so it is the gate that
+    # would catch a linear-algebra library stub expanding into more hardware than the operators it replaced.
+    "imu_frame_transform": Metrics(
+        True, nreg=20, bnreg=0, steering=35, copies=0, min_ii=42, last_pc=42, max_block_span=42
+    ),
     # The two largest kernels carry slightly higher register pressure as a deliberate latency-for-area point: the
     # uniform landing keeps min_ii/last_pc tight, so a result resides a cycle longer, raising register
     # pressure (nreg, and ekf1_stateless's steering with it). The baselines are non-regression ceilings (``<=``) pinned


### PR DESCRIPTION
## Summary
- Add an executable-stub registry for library functions (math intrinsics + numpy passthroughs).
- Add `np.matmul`/`np.dot`, `np.transpose`, `np.trace`, `np.outer` as registry stubs; `@` and `.T` now delegate to them instead of bespoke core code.
- Grow the supported Python subset (shape queries, comprehensions, aggregate iteration, statically-reachable `raise`) to make the stubs expressible.

Verified: emitted HIR/MIR/LIR/Verilog is byte-identical to the prior bespoke matrix code for all 18 examples; the dot product stays a left fold contracting to one `fmul` + (n-1) `ffma`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcC6WpHkk9419Cmm7Vmh1n