### PR TITLE
Integer arithmetic operators; fix cross-referencing loop-carried phi miscompilation

### DIFF
--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 
 After a change or milestone, or when prompted, dispatch fresh-context review agents at
 MAXIMUM THINKING EFFORT, then consolidate, fix, and repeat.
-The goal is adversarial, diverse, independent coverage at bounded cost.
+The goal is adversarial, diverse, independent coverage.
 
 The prompts given to the agents shall be extremely terse, at most a few sentences.
 Giving excessive detail may constrain their thinking causing the tunnel vision syndrome.
@@ -20,14 +20,12 @@ They must be given the opportunity to look at the work without bias or prejudice
 
 Run two reviewers in parallel per round:
 
-- A Claude agent with the FULL-SPECTRUM remit, in priority order: functional CORRECTNESS and
+- An *ultrathink* Claude agent with the FULL-SPECTRUM remit, in priority order: functional CORRECTNESS and
   ROBUSTNESS first, then SIMPLIFICATION opportunities, ARCHITECTURAL CLEANLINESS and CODE QUALITY,
-  and POLICY/STYLE compliance with the project's own docs (including the comment policy).
-- A DISSIMILAR tool (Codex when available) focusing on CORRECTNESS only, to maximize perspective
-  diversity and minimize blind spots.
+  and POLICY/STYLE compliance with the project's own docs.
 
-Agents/models not from Anthropic or OpenAI can be used, but treat them as low-credibility actors.
-They perform poorly, fail to follow instructions, and often produce incorrect analysis.
+- Codex running the *most advanced model* in *ultra* effort focusing on CORRECTNESS only, to maximize perspective
+  diversity and minimize blind spots.
 
 ## Reviewers are read-only
 
@@ -65,8 +63,8 @@ For every correctness defect, add a regression test verified to fail before the 
 
 ## When to stop
 
-A round is clean when the reviewers surface only trivial feedback or none; ONE clean round ends the
-loop. Do not chase literal zero feedback: with no real issues left, agents degrade into nitpicking,
+A round is clean when the reviewers surface only trivial feedback or none; the first clean round ends the loop.
+Do not chase literal zero feedback: with no real issues left, agents degrade into nitpicking,
 so a round is clean as soon as significant findings cease.
 
 ## Operational notes
@@ -78,3 +76,4 @@ is a common cause of stream-idle timeouts.
 Some headless agents hang waiting on stdin (like Codex) — redirect from `/dev/null`.
 
 Retry agents that fail on a transient or connection error until they succeed.
+If an agent gets stuck or hits a security guardrail, try resuming it first instead of restarting its work from scratch.

--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -2,34 +2,29 @@
 name: review-loop
 description: >-
   Multi-agent review/refine loop. Use after a change or milestone, or when asked to review work:
-  fan out fresh-context, single-focus reviewers across distinct tools, consolidate and fix, add a
-  regression test for every defect, and repeat until reviews stay clean for three consecutive turns.
+  dispatch a fresh-context full-spectrum reviewer plus a dissimilar correctness reviewer,
+  consolidate and fix, add a regression test for every defect, and repeat until a round is clean.
 ---
 
 # Adversarial review/refine loop
 
-After a change or milestone, or when prompted, dispatch a fan-out of fresh-context review agents at
+After a change or milestone, or when prompted, dispatch fresh-context review agents at
 MAXIMUM THINKING EFFORT, then consolidate, fix, and repeat.
-The goal is broad coverage from adversarial, diverse, independent perspectives.
+The goal is adversarial, diverse, independent coverage at bounded cost.
 
-The prompts given to the agents shall be extremely terse, at most a couple of sentences.
+The prompts given to the agents shall be extremely terse, at most a few sentences.
 Giving excessive detail may constrain their thinking causing the tunnel vision syndrome.
 They must be given the opportunity to look at the work without bias or prejudice.
 
-## Fan out — one focus per agent
+## The reviewer pair
 
-Spawn one agent per concern and run them in parallel. Never give an agent multiple jobs: it dilutes attention
-and degrades every answer. Cover at least these angles, one agent each:
+Run two reviewers in parallel per round:
 
-- Opportunities for SIMPLIFICATION.
-- Functional CORRECTNESS and ROBUSTNESS.
-- ARCHITECTURAL CLEANLINESS, DESIGN PRACTICES, CODE QUALITY.
-- POLICY and STYLE compliance with the project's own docs, including the comment cleanup.
-
-### Dissimilar agents
-
-In addition to the subagents above, dispatch distinct tools focusing on CORRECTNESS only to maximize the diversity
-of perspectives and minimize blind spots. Check which tools are available (Codex etc.) and use all of them.
+- A Claude agent with the FULL-SPECTRUM remit, in priority order: functional CORRECTNESS and
+  ROBUSTNESS first, then SIMPLIFICATION opportunities, ARCHITECTURAL CLEANLINESS and CODE QUALITY,
+  and POLICY/STYLE compliance with the project's own docs (including the comment policy).
+- A DISSIMILAR tool (Codex when available) focusing on CORRECTNESS only, to maximize perspective
+  diversity and minimize blind spots.
 
 Agents/models not from Anthropic or OpenAI can be used, but treat them as low-credibility actors.
 They perform poorly, fail to follow instructions, and often produce incorrect analysis.
@@ -39,6 +34,30 @@ They perform poorly, fail to follow instructions, and often produce incorrect an
 Review agents must not modify the worktree or run mutating commands. If one needs a mutable environment,
 it copies the worktree elsewhere.
 
+## Reviewers do not re-run the project test suites
+
+The gates (unit suite, typecheck, formatter) are already green at the reviewed commit; re-running them
+duplicates work and, for the broad sessions, wastes minutes of compute per round. State this in the
+reviewer prompts. Reviewer effort goes instead into adversarial counterexamples for behaviors the
+existing tests do NOT cover, executed in a scratch clone. Probes must run under the repo's own test
+interpreter (e.g. `.nox/tests/bin/python`, which mutates nothing) rather than whatever is on PATH:
+a version-skewed interpreter or dependency set can produce findings that do not apply to the project
+or miss ones that do. Reproducing their own findings before reporting remains mandatory.
+
+## Inputs are trusted — reject cybersec framing
+
+This is a compiler for trusted, well-meaning users, not a security boundary. Corner cases arise from
+honest mistakes, never from adversaries. Weigh every finding by its plausibility under honest use: a
+defect matters if a well-meaning user could plausibly trigger it (a typo, a misunderstood API, an
+unusual but legitimate code pattern), not if only a contrived hostile input can reach it. Findings
+whose reproduction requires deliberately pathological constructions — operator-overriding subclasses
+planted to lie, stateful accessors crafted to pass checks and then diverge, hostile metaclasses,
+sandbox-mangled namespaces — are out of scope: reject them outright at consolidation instead of
+hardening against them, and say so in the reviewer prompts. Graceful refusal of the honestly-weird is
+sufficient; airtightness against the malicious is explicitly a non-goal. A round is NOT unclean merely
+because such findings exist. Long loops degrade into exactly this kind of hardening; treat a round
+whose only findings are adversarial-input constructions as clean and stop.
+
 ## Consolidate and act
 
 When all reviewers return, merge their findings, discard the noise, and fix what is real.
@@ -46,11 +65,9 @@ For every correctness defect, add a regression test verified to fail before the 
 
 ## When to stop
 
-Repeat until the reviewers surface only trivial feedback (or none) for THREE consecutive turns — this is
-non-negotiable, however many iterations it takes. Do not chase literal zero feedback: with no real issues
-left, agents degrade into nitpicking, so stop as soon as significant findings cease, not before the
-three-turn streak. A blank turn followed by one that digs up a real defect is exactly why the streak must
-be consecutive; expect dozens (sometimes over a hundred) of agent sessions per full pass.
+A round is clean when the reviewers surface only trivial feedback or none; ONE clean round ends the
+loop. Do not chase literal zero feedback: with no real issues left, agents degrade into nitpicking,
+so a round is clean as soon as significant findings cease.
 
 ## Operational notes
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -478,7 +478,8 @@ port-affinity greedy seed refined by simulated annealing over the same objective
 Phi-arm coalescing eliminates most install copies: before coloring, each phi and its register-backed, identity-arm
 predecessors merge by union-find whenever the two sides do not interfere, so the arm value flows straight into the
 merged register with no copy (a diamond's mutually-exclusive arms always coalesce away). The pass is pure post-schedule
-register reassignment -- it changes only register and copy counts, never behavior or PC layout.
+register reassignment -- it changes only register and copy counts, never behavior; the surviving copy set feeds the
+per-block drain/push classification, so PC layout may shift with it.
 
 Commutative port assignment, after allocation, orients each commutative firing's two operands across its read ports to
 minimize total read-set size (a register read in both positions would otherwise sit in both ports' muxes). Commutation
@@ -507,8 +508,12 @@ A block's terminator offset is the latest cycle a value still lands in its frame
 block does not forward to a successor. A block whose boundary values are all already resident in predecessors pays none
 (the drain-only `Ret`s of loop/diamond kernels, whose body produces every output the `Ret` reads combinationally).
 A tail install lands at the block's work makespan, read-first at the boundary, and costs an extra terminator cycle only
-when its source is the block's own last-committing work; a source resident at block entry, or computed earlier than that
-last work, lands at the makespan and recovers cycles in every downstream block.
+when its source is an operator result committing at the block's makespan (its own last work, or conservatively any
+operator result from outside the block); a resident source (a constant, input, state read, or phi result) or an
+earlier-committing computed source lands at the makespan and recovers cycles in every downstream block. A source register
+that a sibling install writes is always a phi's, hence resident, hence fired at the makespan -- strictly before any
+sibling's write lands (same-step installs read all sources before any write lands; a pushed sibling lands later
+still) -- the invariant that keeps cross-referencing loop-carried phis (a swap) correct.
 
 Cross-block software pipelining then shrinks the terminator offset down to the issue-side envelope -- the latest PC at
 which the block still drives a control word -- whenever every successor is single-predecessor, so a spill cannot reach a
@@ -601,7 +606,7 @@ Each operator instance carries its own Holoso-exposed parameters and float forma
 param-name mismatch into a loud elaboration error.
 
 Support library. The auxiliary HDL shipped with a module is a single self-contained `holoso_support.v`, assembled in
-memory from the hand-written operators, wrappers, and included external RTL sources, so the end application introduces
+memory from hand-written operator catalogues plus included external RTL sources, so the end application introduces
 all RTL dependencies by adding one large file to the synthesis input.
 
 ### Numerical model

--- a/TODO.md
+++ b/TODO.md
@@ -46,17 +46,6 @@ inexact-int element of a module-level numpy array. Each reproduces at HEAD. The 
 surfaces re-expose the comparison variant but do not cause it. Fix: route every compile-time integer→float fold
 (`_static_float` and the ternary/attribute/ndarray-element paths) through the exactness check, closing the family.
 
-Two loop-carried variables that read each other silently miscompile. When a `while` body updates two carried
-variables in one step and one new value reads the other, the result is wrong with no diagnostic: `a, b = b, a + x`
-over three iterations returns 6.0 where Python gives 3.0, and it is already wrong at a single iteration (2.0 vs 1.0).
-A hand-rolled swap through a temporary (`t = b; b = a + x; a = t`) fails the same way, so it is not tuple-assignment
-specific; a lone accumulator (`a = a + x`) is correct. The front-end is sound -- `_loop_carried` reports both names
-and both header phis are built with the right mutually-recursive arms -- so the fault is downstream in how those phis
-are lowered, scheduled, and register-allocated: the two carried updates get ordered so one reads the other's
-already-updated value within the step. The numerical model and the MIR interpreter share the defect, so cosimulation
-cannot see it. This is the most serious of the four: an everyday construct, a silent wrong answer. Worth a dedicated
-look at loop-carried-phi scheduling.
-
 Closure free variables are not consulted, so a captured name resolves to a same-named module global (or to the
 builtin). A kernel reading a closure variable folds in a module-level global sharing its name (`x * gain` takes a
 module `gain`, not the freevar), and a captured rebinding of `range`/`len` is treated as the builtin (a freevar

--- a/holoso/_backend/verilog/_support.py
+++ b/holoso/_backend/verilog/_support.py
@@ -12,7 +12,7 @@ from ..._legal import output_header
 
 _logger = logging.getLogger(__name__)
 
-_TEMPLATE_FILE = "holoso_support_template.v"
+_TEMPLATE_FILES = ["holoso_int.v", "holoso_float.v"]
 _INLINE_FILE = "holoso_support_inline.vh"
 _MEGAFILE = "holoso_support.v"
 _SEPARATOR = "// " + "=" * 117
@@ -30,8 +30,11 @@ def _build_megafile() -> str:
     # Public modules sort before internal ones for readability of the assembled file.
     modules = sorted(zkf.get_rtl().items(), key=lambda rc: (rc[0].rsplit("/", 1)[-1].startswith("_"), rc[0]))
     assert modules, "no .v files in the ZKF RTL package"
-    template = resources.files(__package__).joinpath(_TEMPLATE_FILE).read_text(encoding="utf-8").strip()
-    blocks = [_megafile_header(), template]
+    package = resources.files(__package__)
+    blocks = [
+        _megafile_header(),
+        *(package.joinpath(name).read_text(encoding="utf-8").strip() for name in _TEMPLATE_FILES),
+    ]
     for rel, content in modules:
         blocks.append(f"{_SEPARATOR}\n// EMBEDDED FILE BEGIN: {rel}")
         blocks.append(content.strip())

--- a/holoso/_backend/verilog/holoso_float.v
+++ b/holoso/_backend/verilog/holoso_float.v
@@ -1,0 +1,566 @@
+// FLOATING POINT OPERATORS
+//
+// Using Zubax Kulibin float (ZKF) -- an IEEE 754-like format optimized for control systems and DSP applications.
+// ZKF technically has no negative zero, but it is not an error to produce it -- all operators ignore the sign bit
+// when the magnitude is zero.
+//
+// Parameters: WEXP -- exponent bit width, WMAN -- mantissa/significand bit width (incl. hidden bit).
+// The total width is WFULL=WEXP+WMAN (the significand MSb is absent but there is also the sign bit, like IEEE 754).
+//
+// Streaming wrappers require a LATENCY parameter, which is forwarded to the wrapped Kulibin operator for checking.
+// Operator-specific parameters are forwarded to the corresponding operator.
+
+`timescale 1ns/1ps
+
+// Combinational floating-point sign conditioner operator; to be used at the inputs/outputs of arithmetic operators.
+// Sign conditioning is a trivial and/xor single-bit gate enabling free computation of abs/neg.
+// Conditional inputs can be tied off to constants, in which case the corresponding circuits are optimized away.
+// Function:
+//      y =     +x      if op=0
+//      y =     -x      if op=1
+//      y = +abs(x)     if op=2
+//      y = -abs(x)     if op=3
+module holoso_fsgnop#(parameter WFULL = 24) (input wire [WFULL-1:0] x, input wire [1:0] op, output wire [WFULL-1:0] y);
+    wire   op_abs = op[1];
+    wire   op_neg = op[0];
+    wire   s_in   = x[WFULL-1];
+    wire   s_out  = (s_in & ~op_abs) ^ op_neg;
+    assign y      = { s_out, x[WFULL-2:0] };
+endmodule
+
+// Floating point adder/subtractor with sign conditioning:  y = sgnop(sgnop(a) + sgnop(b))
+// E.g., subtraction: y=a+(-b); negative absolute difference: y=-abs(a-b), magnitude difference: y=abs(a)-abs(b), ...
+// The inputs are sampled once at in_valid and are not required to remain stable during operation.
+module holoso_fadd#(parameter WEXP = 6, parameter WMAN = 18,
+                    parameter STAGE_INPUT = 0, parameter STAGE_DECODE = 0, parameter STAGE_ALIGN = 0,
+                    parameter STAGE_NORMALIZE = 0, parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0,
+                    parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] b_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire [WEXP+WMAN-1:0] b,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] b1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a), .op(a_sgnop), .y(a1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_b (.x(b), .op(b_sgnop), .y(b1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_add#(.WEXP(WEXP), .WMAN(WMAN), .STAGE_INPUT(STAGE_INPUT),
+             .STAGE_DECODE(STAGE_DECODE), .STAGE_ALIGN(STAGE_ALIGN), .STAGE_NORMALIZE(STAGE_NORMALIZE),
+             .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT), .LATENCY(LATENCY)) u_add (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1), .b(b1),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Floating point multiplier with sign conditioning: y = sgnop(sgnop(a) * sgnop(b))
+// The inputs are sampled once at in_valid and are not required to remain stable during operation.
+// Caution: STAGE_PRODUCT is almost never a good idea unless WMAN is wider than DSP multiplier input widths.
+module holoso_fmul#(parameter WEXP = 6, parameter WMAN = 18, parameter WMULTIPLIER = 0,
+                    parameter STAGE_INPUT = 0, parameter STAGE_PRODUCT = 0,
+                    parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0,
+                    parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] b_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire [WEXP+WMAN-1:0] b,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] b1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a), .op(a_sgnop), .y(a1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_b (.x(b), .op(b_sgnop), .y(b1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_mul#(.WEXP(WEXP), .WMAN(WMAN), .WMULTIPLIER(WMULTIPLIER), .STAGE_INPUT(STAGE_INPUT),
+             .STAGE_PRODUCT(STAGE_PRODUCT), .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT),
+             .LATENCY(LATENCY)) u_mul (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1), .b(b1),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Floating point fused multiply-add with sign conditioning:  y = sgnop(sgnop(a)*sgnop(b) + sgnop(c))
+// The product is kept full-width and rounded once together with c (a single rounding, unlike a multiply then add).
+// The inputs are sampled once at in_valid and are not required to remain stable during operation.
+module holoso_ffma#(parameter WEXP = 6, parameter WMAN = 18,
+                    parameter WMULTIPLIER = 0, parameter STAGE_INPUT = 0, parameter STAGE_PRODUCT = 0,
+                    parameter STAGE_DECODE = 0, parameter STAGE_ALIGN = 0, parameter STAGE_NORMALIZE = 0,
+                    parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] b_sgnop,
+    input  wire           [1:0] c_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire [WEXP+WMAN-1:0] b,
+    input  wire [WEXP+WMAN-1:0] c,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] b1;
+    wire [WFULL-1:0] c1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a), .op(a_sgnop), .y(a1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_b (.x(b), .op(b_sgnop), .y(b1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_c (.x(c), .op(c_sgnop), .y(c1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_fma#(.WEXP(WEXP), .WMAN(WMAN), .WMULTIPLIER(WMULTIPLIER), .STAGE_INPUT(STAGE_INPUT),
+             .STAGE_PRODUCT(STAGE_PRODUCT), .STAGE_DECODE(STAGE_DECODE), .STAGE_ALIGN(STAGE_ALIGN),
+             .STAGE_NORMALIZE(STAGE_NORMALIZE), .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT),
+             .LATENCY(LATENCY)) u_fma (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1), .b(b1), .c(c1),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Constant-power-of-two scaler with sign conditioning:  y = sgnop(sgnop(a) * 2^K)
+// K is a signed integer exponent shift; -2^(WEXP-1) < K < 2^(WEXP-1). The scaling is exact.
+// The inputs are sampled once at in_valid and are not required to remain stable during operation.
+module holoso_fmul_ilog2_const#(parameter WEXP = 6, parameter WMAN = 18, parameter integer K = 0,
+                                parameter STAGE_INPUT = 0, parameter STAGE_DECODE = 0,
+                                parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a),  .op(a_sgnop), .y(a1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_mul_ilog2_const#(.WEXP(WEXP), .WMAN(WMAN), .K(K),
+                         .STAGE_INPUT(STAGE_INPUT), .STAGE_DECODE(STAGE_DECODE), .LATENCY(LATENCY)) u_mul_ilog2_const (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Power-of-two scaler with sign conditioning: y = sgnop(sgnop(a) * 2^k).
+// Every representable k is legal; large values collapse to infinities or zero.
+// Scaling is exact while the result remains normal and finite.
+// Zero and infinity retain their class regardless of k before output sign conditioning.
+module holoso_fmul_ilog2#(parameter WEXP = 6, parameter WMAN = 18, parameter WINT = WEXP + WMAN,
+                          parameter STAGE_INPUT = 0, parameter STAGE_DECODE = 0,
+                          parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire signed [WINT-1:0] k,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    localparam Y_SGNOP_LATENCY = (LATENCY == 0) ? 1 + STAGE_INPUT + STAGE_DECODE : LATENCY;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a), .op(a_sgnop), .y(a1));
+    zkf_pipe#(.W(2), .N(Y_SGNOP_LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_mul_ilog2#(.WEXP(WEXP), .WMAN(WMAN), .WK(WINT), .STAGE_INPUT(STAGE_INPUT),
+                   .STAGE_DECODE(STAGE_DECODE), .LATENCY(LATENCY)) u_mul_ilog2 (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1), .k(k),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Floating point divider with sign conditioning: y = sgnop(sgnop(a) / sgnop(b))
+// div0 is asserted alongside out_valid when the divisor is (positive) zero; the value of y is then unspecified.
+// The quotient is rounded.
+// The inputs are sampled once at in_valid and are not required to remain stable during operation.
+module holoso_fdiv#(parameter WEXP = 6, parameter WMAN = 18,
+                    parameter STAGE_INPUT = 0, parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0,
+                    parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] b_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire [WEXP+WMAN-1:0] b,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y,
+    output wire                 div0
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] b1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a),  .op(a_sgnop), .y(a1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_b (.x(b),  .op(b_sgnop), .y(b1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_div#(.WEXP(WEXP), .WMAN(WMAN),
+             .STAGE_INPUT(STAGE_INPUT), .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT),
+             .LATENCY(LATENCY)) u_div (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1), .b(b1),
+        .out_valid(out_valid), .q(y1), .div0(div0)
+    );
+endmodule
+
+// Floating point min/max sorter with sign conditioning on inputs and outputs:
+//      min = sgnop(min(sgnop(a), sgnop(b)))
+//      max = sgnop(max(sgnop(a), sgnop(b)))
+// Useful for e.g. sort-by-absolute-value or producing sign-flipped extrema.
+module holoso_fsort#(parameter WEXP = 6, parameter WMAN = 18, parameter integer STAGE_INPUT = 0,
+                     parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] b_sgnop,
+    input  wire           [1:0] min_sgnop,
+    input  wire           [1:0] max_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire [WEXP+WMAN-1:0] b,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] min,
+    output wire [WEXP+WMAN-1:0] max
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] b1;
+    wire [WFULL-1:0] min1;
+    wire [WFULL-1:0] max1;
+    wire       [3:0] out_sgnop_q;
+    wire       [1:0] min_sgnop_q = out_sgnop_q[1:0];
+    wire       [1:0] max_sgnop_q = out_sgnop_q[3:2];
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a   (.x(a),    .op(a_sgnop),   .y(a1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_b   (.x(b),    .op(b_sgnop),   .y(b1));
+    zkf_pipe#(.W(4), .N(LATENCY)) u_out_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid),
+                                                    .in({max_sgnop, min_sgnop}), .out_valid(), .out(out_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_min (.x(min1), .op(min_sgnop_q), .y(min));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_max (.x(max1), .op(max_sgnop_q), .y(max));
+    zkf_sort#(.WEXP(WEXP), .WMAN(WMAN), .STAGE_INPUT(STAGE_INPUT), .LATENCY(LATENCY)) u_sort (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1), .b(b1),
+        .out_valid(out_valid), .min(min1), .max(max1)
+    );
+endmodule
+
+// Fixed-latency facade over the handshaked, non-throughput-1 zkf_sincos CORDIC (one transaction in flight): the
+// scheduler spaces issues by initiation_interval = LATENCY+1, so the core is idle at issue, out_ready is tied high,
+// and the result is captured on its out_valid cycle -- the same static-schedule contract as the pipelined wrappers.
+module holoso_fsincos#(parameter WEXP = 6, parameter WMAN = 18, parameter WMULTIPLIER = 0,
+                       parameter integer UNROLL100 = 100,
+                       parameter integer STAGE_INPUT = 0, parameter integer STAGE_PRODUCT = 0,
+                       parameter integer STAGE_NORMALIZE = 0, parameter integer STAGE_PACK = 0,
+                       parameter integer STAGE_OUTPUT = 0, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] sin_sgnop,
+    input  wire           [1:0] cos_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] sin,
+    output wire [WEXP+WMAN-1:0] cos
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] sin1;
+    wire [WFULL-1:0] cos1;
+    wire       [3:0] out_sgnop_q;
+    wire             core_in_ready;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a   (.x(a),    .op(a_sgnop),           .y(a1));
+    zkf_pipe#(.W(4), .N(LATENCY)) u_out_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid),
+                                                    .in({cos_sgnop, sin_sgnop}), .out_valid(), .out(out_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_sin (.x(sin1), .op(out_sgnop_q[1:0]), .y(sin));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_cos (.x(cos1), .op(out_sgnop_q[3:2]), .y(cos));
+    zkf_sincos#(.WEXP(WEXP), .WMAN(WMAN), .WMULTIPLIER(WMULTIPLIER), .UNROLL100(UNROLL100),
+                .STAGE_INPUT(STAGE_INPUT), .STAGE_PRODUCT(STAGE_PRODUCT), .STAGE_NORMALIZE(STAGE_NORMALIZE),
+                .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT), .LATENCY(LATENCY)) u_sincos (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .in_ready(core_in_ready), .x(a1),
+        .out_valid(out_valid), .out_ready(1'b1), .sin(sin1), .cos(cos1), .quadrant()
+    );
+`ifdef SIMULATION
+    always @(posedge clk) begin
+        if (!rst && in_valid && !core_in_ready)
+            $fatal(1, "holoso_fsincos over-issued: in_valid while busy (initiation_interval too small)");
+    end
+`endif
+endmodule
+
+// Fixed-latency facade over the handshaked zkf_atan2 CORDIC (see holoso_fsincos). Operand a is y, b is x; outputs
+// theta in turns and mag = hypot(y, x).
+module holoso_fatan2#(parameter WEXP = 6, parameter WMAN = 18, parameter WMULTIPLIER = 0,
+                      parameter integer UNROLL100 = 100,
+                      parameter integer STAGE_INPUT = 0, parameter integer STAGE_PRODUCT = 0,
+                      parameter integer STAGE_NORMALIZE = 0, parameter integer STAGE_PACK = 0,
+                      parameter integer STAGE_OUTPUT = 0, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] b_sgnop,
+    input  wire           [1:0] theta_sgnop,
+    input  wire           [1:0] mag_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire [WEXP+WMAN-1:0] b,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] theta,
+    output wire [WEXP+WMAN-1:0] mag
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] b1;
+    wire [WFULL-1:0] theta1;
+    wire [WFULL-1:0] mag1;
+    wire       [3:0] out_sgnop_q;
+    wire             core_in_ready;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a     (.x(a), .op(a_sgnop), .y(a1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_b     (.x(b), .op(b_sgnop), .y(b1));
+    zkf_pipe#(.W(4), .N(LATENCY)) u_out_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid),
+                                                    .in({mag_sgnop, theta_sgnop}), .out_valid(), .out(out_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_theta (.x(theta1), .op(out_sgnop_q[1:0]), .y(theta));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_mag   (.x(mag1),   .op(out_sgnop_q[3:2]), .y(mag));
+    zkf_atan2#(.WEXP(WEXP), .WMAN(WMAN), .WMULTIPLIER(WMULTIPLIER), .UNROLL100(UNROLL100),
+               .STAGE_INPUT(STAGE_INPUT), .STAGE_PRODUCT(STAGE_PRODUCT), .STAGE_NORMALIZE(STAGE_NORMALIZE),
+               .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT), .LATENCY(LATENCY)) u_atan2 (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .in_ready(core_in_ready), .y(a1), .x(b1),
+        .out_valid(out_valid), .out_ready(1'b1), .theta(theta1), .mag(mag1)
+    );
+`ifdef SIMULATION
+    always @(posedge clk) begin
+        if (!rst && in_valid && !core_in_ready)
+            $fatal(1, "holoso_fatan2 over-issued: in_valid while busy (initiation_interval too small)");
+    end
+`endif
+endmodule
+
+// Floating point comparator with sign conditioning on inputs only:
+//      (a_gt_b, a_eq_b, a_lt_b) = compare(sgnop(a), sgnop(b))
+// Outputs are mutually-exclusive one-hot flags.
+module holoso_fcmp#(parameter WEXP = 6, parameter WMAN = 18, parameter integer STAGE_INPUT = 0,
+                    parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] b_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    input  wire [WEXP+WMAN-1:0] b,
+    output wire                 out_valid,
+    output wire                 a_gt_b,
+    output wire                 a_eq_b,
+    output wire                 a_lt_b
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] b1;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a), .op(a_sgnop), .y(a1));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_b (.x(b), .op(b_sgnop), .y(b1));
+    zkf_cmp#(.WEXP(WEXP), .WMAN(WMAN), .STAGE_INPUT(STAGE_INPUT), .LATENCY(LATENCY)) u_cmp (
+        .clk(clk), .rst(rst), .in_valid(in_valid), .a(a1), .b(b1),
+        .out_valid(out_valid), .a_gt_b(a_gt_b), .a_eq_b(a_eq_b), .a_lt_b(a_lt_b));
+endmodule
+
+// Base-two exponential with sign conditioning:  y = sgnop(2 ** sgnop(a))
+// The input is sampled once at in_valid and is not required to remain stable during operation.
+module holoso_fexp2#(parameter WEXP = 6, parameter WMAN = 18, parameter WMULTIPLIER = 0,
+                     parameter STAGE_INPUT = 0, parameter STAGE_REDUCE = 0, parameter STAGE_PRODUCT = 0,
+                     parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0,
+                     parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a),  .op(a_sgnop), .y(a1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_exp2#(.WEXP(WEXP), .WMAN(WMAN), .WMULTIPLIER(WMULTIPLIER),
+              .STAGE_INPUT(STAGE_INPUT), .STAGE_REDUCE(STAGE_REDUCE), .STAGE_PRODUCT(STAGE_PRODUCT),
+              .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT), .LATENCY(LATENCY)) u_exp2 (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .x(a1),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Base-two logarithm with sign conditioning:  y = sgnop(log2(sgnop(a)))
+// domain_error is asserted alongside out_valid when the conditioned operand is negative; pole when it is zero. y is
+// -inf in both cases. The input is sampled once at in_valid and is not required to remain stable during operation.
+module holoso_flog2#(parameter WEXP = 6, parameter WMAN = 18, parameter WMULTIPLIER = 0,
+                     parameter STAGE_INPUT = 0, parameter STAGE_DECODE = 0, parameter STAGE_PRODUCT = 0,
+                     parameter STAGE_PRODUCT_FINAL = 0, parameter STAGE_NORMALIZE = 0,
+                     parameter STAGE_NORMALIZE_OUTPUT = 0, parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0,
+                     parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y,
+    output wire                 domain_error,
+    output wire                 pole
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a),  .op(a_sgnop), .y(a1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_log2#(.WEXP(WEXP), .WMAN(WMAN), .WMULTIPLIER(WMULTIPLIER),
+              .STAGE_INPUT(STAGE_INPUT), .STAGE_DECODE(STAGE_DECODE), .STAGE_PRODUCT(STAGE_PRODUCT),
+              .STAGE_PRODUCT_FINAL(STAGE_PRODUCT_FINAL), .STAGE_NORMALIZE(STAGE_NORMALIZE),
+              .STAGE_NORMALIZE_OUTPUT(STAGE_NORMALIZE_OUTPUT), .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT),
+              .LATENCY(LATENCY)) u_log2 (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .x(a1),
+        .out_valid(out_valid), .y(y1), .domain_error(domain_error), .pole(pole)
+    );
+endmodule
+
+// Floating point round-to-integer with sign conditioning:  y = sgnop(round(sgnop(a), round_mode))
+// round_mode selects the mode per transaction: 0 nearest-even, 1 floor, 2 ceil, 3 trunc (the zkf_round encoding).
+// The input is sampled once at in_valid and is not required to remain stable during operation.
+module holoso_fround#(parameter WEXP = 6, parameter WMAN = 18,
+                      parameter STAGE_INPUT = 0, parameter STAGE_DECODE = 0,
+                      parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0,
+                      parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] round_mode,
+    input  wire           [1:0] y_sgnop,
+    input  wire [WEXP+WMAN-1:0] a,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a), .op(a_sgnop), .y(a1));
+    zkf_pipe#(.W(2), .N(LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_round#(.WEXP(WEXP), .WMAN(WMAN), .STAGE_INPUT(STAGE_INPUT), .STAGE_DECODE(STAGE_DECODE),
+               .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT), .LATENCY(LATENCY)) u_round (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a1), .round_mode(round_mode),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Signed-integer-to-float conversion with output sign conditioning.
+// Conversion is round-to-nearest, ties-to-even; values outside the finite float range become signed infinity.
+module holoso_ffromint#(parameter WEXP = 6, parameter WMAN = 18, parameter WINT = WEXP + WMAN,
+                        parameter STAGE_INPUT = 0, parameter STAGE_NORMALIZE = 0,
+                        parameter STAGE_PACK = 0, parameter STAGE_OUTPUT = 0,
+                        parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire signed [WINT-1:0] a,
+    input  wire           [1:0] y_sgnop,
+    output wire                 out_valid,
+    output wire [WEXP+WMAN-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    localparam Y_SGNOP_LATENCY =
+        (LATENCY == 0) ? 1 + STAGE_INPUT + STAGE_NORMALIZE + STAGE_PACK + STAGE_OUTPUT : LATENCY;
+    wire [WFULL-1:0] y1;
+    wire       [1:0] y_sgnop_q;
+    zkf_pipe#(.W(2), .N(Y_SGNOP_LATENCY)) u_y_sgnop_pipe (.clk(clk), .rst(rst), .in_valid(in_valid), .in(y_sgnop),
+                                                  .out_valid(), .out(y_sgnop_q));
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_y (.x(y1), .op(y_sgnop_q), .y(y));
+    zkf_from_int#(.WEXP(WEXP), .WMAN(WMAN), .WINT(WINT), .STAGE_INPUT(STAGE_INPUT),
+                  .STAGE_NORMALIZE(STAGE_NORMALIZE), .STAGE_PACK(STAGE_PACK), .STAGE_OUTPUT(STAGE_OUTPUT),
+                  .LATENCY(LATENCY)) u_from_int (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .a(a),
+        .out_valid(out_valid), .y(y1)
+    );
+endmodule
+
+// Float-to-signed-integer conversion with input sign conditioning.
+// Finite values round to nearest, ties-to-even. Saturation is normal behavior, not an error.
+// Values above 2^(WINT-1)-1 saturate to that maximum; values below -2^(WINT-1) saturate to that minimum (incl. infs).
+module holoso_ftoint#(parameter WEXP = 6, parameter WMAN = 18, parameter WINT = WEXP + WMAN,
+                      parameter STAGE_INPUT = 0, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire                 in_valid,
+    input  wire           [1:0] a_sgnop,
+    input  wire           [1:0] round_mode,
+    input  wire [WEXP+WMAN-1:0] a,
+    output wire                 out_valid,
+    output wire signed [WINT-1:0] y
+);
+    localparam WFULL = WEXP + WMAN;
+    wire [WFULL-1:0] a1;
+    holoso_fsgnop#(.WFULL(WFULL)) u_sgnop_a (.x(a), .op(a_sgnop), .y(a1));
+    zkf_to_int#(.WEXP(WEXP), .WMAN(WMAN), .WINT(WINT), .STAGE_INPUT(STAGE_INPUT), .LATENCY(LATENCY)) u_to_int (
+        .clk(clk), .rst(rst),
+        .in_valid(in_valid), .round_mode(round_mode), .a(a1),
+        .out_valid(out_valid), .y(y)
+    );
+endmodule

--- a/holoso/_backend/verilog/holoso_int.v
+++ b/holoso/_backend/verilog/holoso_int.v
@@ -1,0 +1,696 @@
+// SIGNED INTEGER OPERATORS
+//
+// Every operator has a mandatory input and output latches, exposing no combinational circuits outside.
+//
+//  Module          | Operation                                     |Latency| Inputs    | Outputs
+//  ----------------|-----------------------------------------------|-------|-----------|---------------------------
+//  holoso_iadds    | Signed addition, saturated                    | 2     | a, b      | y, saturated
+//  holoso_isubs    | Signed subtraction, saturated                 | 2     | a, b      | y, saturated
+//  holoso_imuls    | Signed multiplication, saturated              | 2..6  | a, b      | y, saturated
+//  holoso_idivs    | Signed division and modulo, saturated         | 2+W/2 | num, den  | quo, rem, saturated, div0
+//  holoso_iabss    | Absolute value, saturated                     | 2     | x         | y, saturated
+//  holoso_ashift   | Arith. shift by runtime amount left+/right-   | 2     | x, shamt  | y
+//  holoso_ashiftc  | Like holoso_ashift but by a constant          | 0     | x, shamt  | (inline comb function)
+//  holoso_icmp     | Signed comparison                             | 2     | a, b      | a_gt_b, a_eq_b, a_lt_b
+
+`timescale 1ns/1ps
+
+// Signed integer adder with saturation.
+module holoso_iadds#(parameter W = 44, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg signed [W-1:0] y,
+    output reg saturated
+);
+    localparam integer LATENCY_REF = 2;
+    localparam signed [W-1:0] MIN = {1'b1, {(W-1){1'b0}}};
+    localparam signed [W-1:0] MAX = {1'b0, {(W-1){1'b1}}};
+    generate
+        if ((LATENCY != 0) && (LATENCY != LATENCY_REF)) begin : g_invalid_latency
+            _holoso_invalid_integer_latency u_invalid();
+        end
+    endgenerate
+
+    reg signed [W-1:0] a_q;
+    reg signed [W-1:0] b_q;
+    reg input_valid_q;
+    wire [W:0] sum_ext = {1'b0, a_q} + {1'b0, b_q};
+    wire carry_into_sign = sum_ext[W-1] ^ a_q[W-1] ^ b_q[W-1];
+    wire overflow = carry_into_sign ^ sum_ext[W];
+
+    always @(posedge clk) begin
+        a_q <= a;
+        b_q <= b;
+        y <= overflow ? (a_q[W-1] ? MIN : MAX) : sum_ext[W-1:0];
+        saturated <= overflow;
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            out_valid <= input_valid_q;
+        end
+    end
+endmodule
+
+// Signed integer subtractor with saturation.
+module holoso_isubs#(parameter W = 44, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg signed [W-1:0] y,
+    output reg saturated
+);
+    localparam integer LATENCY_REF = 2;
+    localparam signed [W-1:0] MIN = {1'b1, {(W-1){1'b0}}};
+    localparam signed [W-1:0] MAX = {1'b0, {(W-1){1'b1}}};
+    generate
+        if ((LATENCY != 0) && (LATENCY != LATENCY_REF)) begin : g_invalid_latency
+            _holoso_invalid_integer_latency u_invalid();
+        end
+    endgenerate
+
+    reg signed [W-1:0] a_q;
+    reg signed [W-1:0] b_q;
+    reg input_valid_q;
+    wire signed [W-1:0] diff = a_q - b_q;
+    wire overflow = (a_q[W-1] ^ b_q[W-1]) & (diff[W-1] ^ a_q[W-1]);
+
+    always @(posedge clk) begin
+        a_q <= a;
+        b_q <= b;
+        y <= overflow ? (a_q[W-1] ? MIN : MAX) : diff;
+        saturated <= overflow;
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            out_valid <= input_valid_q;
+        end
+    end
+endmodule
+
+// Signed integer multiplier with saturation. Inputs and outputs are always registered; the internals are configurable.
+// LATENCY = 2 + STAGE_PRODUCT
+// STAGE_PRODUCT=0: native multiplication without additional registers;
+// STAGE_PRODUCT=1: native multiplication with a dedicated product result stage (DSP output latch);
+// STAGE_PRODUCT=2: native multiplication with operand capture and product result stages (DSP registered on both ends);
+// STAGE_PRODUCT=3: STAGE_PRODUCT=2 plus registered 2x2 split products and reduction;
+// STAGE_PRODUCT=4: STAGE_PRODUCT=2 plus registered 3x3 split products, row reduction, and final reduction.
+module holoso_imuls #(parameter W = 44, parameter integer STAGE_PRODUCT = 0, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg signed [W-1:0] y,
+    output reg saturated
+);
+    localparam integer WP = 2 * W;
+    localparam integer LATENCY_REF = 2 + STAGE_PRODUCT;
+    localparam signed [W-1:0] MIN = {1'b1, {(W-1){1'b0}}};
+    localparam signed [W-1:0] MAX = {1'b0, {(W-1){1'b1}}};
+    generate
+        if ((LATENCY != 0) && (LATENCY != LATENCY_REF)) begin : g_invalid_latency
+            _holoso_invalid_integer_latency u_invalid();
+        end
+    endgenerate
+
+    reg signed [W-1:0] input_a;
+    reg signed [W-1:0] input_b;
+    reg input_valid_q;
+    wire signed [WP-1:0] product;
+    wire product_valid;
+    generate
+        if (STAGE_PRODUCT == 0) begin : g_sp0
+            _holoso_imuls_sp0#(.W(W)) u_product (
+                .clk(clk), .rst(rst), .in_valid(input_valid_q), .a(input_a), .b(input_b),
+                .out_valid(product_valid), .product(product)
+            );
+        end else if (STAGE_PRODUCT == 1) begin : g_sp1
+            _holoso_imuls_sp1#(.W(W)) u_product (
+                .clk(clk), .rst(rst), .in_valid(input_valid_q), .a(input_a), .b(input_b),
+                .out_valid(product_valid), .product(product)
+            );
+        end else if (STAGE_PRODUCT == 2) begin : g_sp2
+            _holoso_imuls_sp2#(.W(W)) u_product (
+                .clk(clk), .rst(rst), .in_valid(input_valid_q), .a(input_a), .b(input_b),
+                .out_valid(product_valid), .product(product)
+            );
+        end else if (STAGE_PRODUCT == 3) begin : g_sp3
+            _holoso_imuls_sp3#(.W(W)) u_product (
+                .clk(clk), .rst(rst), .in_valid(input_valid_q), .a(input_a), .b(input_b),
+                .out_valid(product_valid), .product(product)
+            );
+        end else if (STAGE_PRODUCT == 4) begin : g_sp4
+            _holoso_imuls_sp4#(.W(W)) u_product (
+                .clk(clk), .rst(rst), .in_valid(input_valid_q), .a(input_a), .b(input_b),
+                .out_valid(product_valid), .product(product)
+            );
+        end else begin : g_invalid_stage_product
+            _holoso_invalid_imuls_stage_product u_invalid();
+        end
+    endgenerate
+
+    wire overflow = |(product[WP-1:W] ^ {W{product[W-1]}});
+    always @(posedge clk) begin
+        input_a <= a;
+        input_b <= b;
+        y <= overflow ? (product[WP-1] ? MIN : MAX) : product[W-1:0];
+        saturated <= overflow;
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            out_valid <= product_valid;
+        end
+    end
+endmodule
+
+module _holoso_imuls_sp0#(parameter W = 44) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output wire out_valid,
+    output wire signed [2*W-1:0] product
+);
+    assign out_valid = in_valid;
+    assign product = a * b;
+endmodule
+
+module _holoso_imuls_sp1#(parameter W = 44) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg signed [2*W-1:0] product
+);
+    always @(posedge clk) begin
+        product <= a * b;
+        if (rst) out_valid <= 1'b0;
+        else     out_valid <= in_valid;
+    end
+endmodule
+
+module _holoso_imuls_sp2#(parameter W = 44) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg signed [2*W-1:0] product
+);
+    reg signed [W-1:0] a_q;
+    reg signed [W-1:0] b_q;
+    reg input_valid_q;
+    always @(posedge clk) begin
+        a_q <= a;
+        b_q <= b;
+        product <= a_q * b_q;
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            out_valid <= input_valid_q;
+        end
+    end
+endmodule
+
+module _holoso_imuls_sp3#(parameter W = 44) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg signed [2*W-1:0] product
+);
+    localparam integer WP = 2 * W;
+    localparam integer SW = (W + 1) / 2;
+    localparam integer EW = 2 * SW;
+    localparam integer WS = SW + 1;
+    localparam integer WSP = 2 * WS;
+
+    reg signed [W-1:0] a_q;
+    reg signed [W-1:0] b_q;
+    reg input_valid_q;
+    wire signed [EW-1:0] a_ext = {{(EW-W){a_q[W-1]}}, a_q};
+    wire signed [EW-1:0] b_ext = {{(EW-W){b_q[W-1]}}, b_q};
+    wire signed [WS-1:0] a_slice [0:1];
+    wire signed [WS-1:0] b_slice [0:1];
+    assign a_slice[0] = $signed({1'b0, a_ext[0 +: SW]});
+    assign a_slice[1] = $signed(a_ext[SW +: SW]);
+    assign b_slice[0] = $signed({1'b0, b_ext[0 +: SW]});
+    assign b_slice[1] = $signed(b_ext[SW +: SW]);
+
+    wire signed [WSP-1:0] partial [0:3];
+    assign partial[0] = a_slice[0] * b_slice[0];
+    assign partial[1] = a_slice[0] * b_slice[1];
+    assign partial[2] = a_slice[1] * b_slice[0];
+    assign partial[3] = a_slice[1] * b_slice[1];
+    reg signed [WSP-1:0] partial_q [0:3];
+    reg partial_valid_q;
+    wire signed [WP-1:0] term [0:3];
+    assign term[0] = partial_q[0];
+    assign term[1] = $signed(partial_q[1]) <<< SW;
+    assign term[2] = $signed(partial_q[2]) <<< SW;
+    assign term[3] = $signed(partial_q[3]) <<< (2 * SW);
+
+    integer i;
+    always @(posedge clk) begin
+        a_q <= a;
+        b_q <= b;
+        for (i = 0; i < 4; i = i + 1) partial_q[i] <= partial[i];
+        product <= term[0] + term[1] + term[2] + term[3];
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            partial_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            partial_valid_q <= input_valid_q;
+            out_valid <= partial_valid_q;
+        end
+    end
+endmodule
+
+module _holoso_imuls_sp4#(parameter W = 44) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg signed [2*W-1:0] product
+);
+    localparam integer WP = 2 * W;
+    localparam integer SW = (W + 2) / 3;
+    localparam integer EW = 3 * SW;
+    localparam integer WS = SW + 1;
+    localparam integer WSP = 2 * WS;
+
+    reg signed [W-1:0] a_q;
+    reg signed [W-1:0] b_q;
+    reg input_valid_q;
+    wire signed [EW-1:0] a_ext = {{(EW-W){a_q[W-1]}}, a_q};
+    wire signed [EW-1:0] b_ext = {{(EW-W){b_q[W-1]}}, b_q};
+    wire signed [WS-1:0] a_slice [0:2];
+    wire signed [WS-1:0] b_slice [0:2];
+    assign a_slice[0] = $signed({1'b0, a_ext[0 +: SW]});
+    assign a_slice[1] = $signed({1'b0, a_ext[SW +: SW]});
+    assign a_slice[2] = $signed(a_ext[2*SW +: SW]);
+    assign b_slice[0] = $signed({1'b0, b_ext[0 +: SW]});
+    assign b_slice[1] = $signed({1'b0, b_ext[SW +: SW]});
+    assign b_slice[2] = $signed(b_ext[2*SW +: SW]);
+
+    wire signed [WSP-1:0] partial [0:8];
+    genvar ai, bi;
+    generate
+        for (ai = 0; ai < 3; ai = ai + 1) begin : g_partial_row
+            for (bi = 0; bi < 3; bi = bi + 1) begin : g_partial_column
+                assign partial[ai*3 + bi] = a_slice[ai] * b_slice[bi];
+            end
+        end
+    endgenerate
+    reg signed [WSP-1:0] partial_q [0:8];
+    reg partial_valid_q;
+    wire signed [WP-1:0] row_term [0:8];
+    genvar ri, rj;
+    generate
+        for (ri = 0; ri < 3; ri = ri + 1) begin : g_row_term_row
+            for (rj = 0; rj < 3; rj = rj + 1) begin : g_row_term_column
+                assign row_term[ri*3 + rj] = $signed(partial_q[ri*3 + rj]) <<< (rj * SW);
+            end
+        end
+    endgenerate
+    wire signed [WP-1:0] row_sum [0:2];
+    assign row_sum[0] = row_term[0] + row_term[1] + row_term[2];
+    assign row_sum[1] = row_term[3] + row_term[4] + row_term[5];
+    assign row_sum[2] = row_term[6] + row_term[7] + row_term[8];
+    reg signed [WP-1:0] row_sum_q [0:2];
+    reg row_valid_q;
+    wire signed [WP-1:0] column [0:2];
+    assign column[0] = row_sum_q[0];
+    assign column[1] = row_sum_q[1] <<< SW;
+    assign column[2] = row_sum_q[2] <<< (2 * SW);
+    wire signed [WP-1:0] sum_xor = column[0] ^ column[1] ^ column[2];
+    wire signed [WP-1:0] sum_carry = ((column[0] & column[1]) | (column[0] & column[2]) | (column[1] & column[2])) << 1;
+    wire signed [WP-1:0] sum = sum_xor + sum_carry;
+
+    integer i;
+    always @(posedge clk) begin
+        a_q <= a;
+        b_q <= b;
+        for (i = 0; i < 9; i = i + 1) partial_q[i] <= partial[i];
+        for (i = 0; i < 3; i = i + 1) row_sum_q[i] <= row_sum[i];
+        product <= sum;
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            partial_valid_q <= 1'b0;
+            row_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            partial_valid_q <= input_valid_q;
+            row_valid_q <= partial_valid_q;
+            out_valid <= row_valid_q;
+        end
+    end
+endmodule
+
+// Signed saturating division with Python floor or truncation-toward-zero quotient semantics.
+// Division by zero returns MIN for a negative numerator and MAX otherwise, preserves the numerator as remainder,
+// and asserts outputs div0 and saturated.
+// LATENCY = 2 + ceil(W/2)
+module holoso_idivs #(parameter W = 44, parameter integer QUOTIENT_FLOOR = 1, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] num,
+    input  wire signed [W-1:0] den,
+    output reg out_valid,
+    output reg signed [W-1:0] quo,
+    output reg signed [W-1:0] rem,
+    output reg saturated,
+    output reg div0
+);
+    localparam integer NSTEPS = (W + 1) / 2;
+    localparam integer WPAD = 2 * NSTEPS;
+    localparam integer WDIV = W + WPAD;
+    localparam integer LATENCY_REF = 2 + NSTEPS;
+    localparam signed [W-1:0] MIN = {1'b1, {(W-1){1'b0}}};
+    localparam signed [W-1:0] MAX = {1'b0, {(W-1){1'b1}}};
+
+    generate
+        if ((LATENCY != 0) && (LATENCY != LATENCY_REF)) begin : g_invalid_latency
+            _holoso_invalid_integer_latency u_invalid();
+        end
+    endgenerate
+
+    wire [W-1:0] num_magnitude = num[W-1] ? -num : num;
+    wire [W-1:0] den_magnitude = den[W-1] ? -den : den;
+    wire [W+1:0] den_magnitude3 = {1'b0, den_magnitude, 1'b0} + {2'b00, den_magnitude};
+    wire input_div0 = den == {W{1'b0}};
+    wire input_overflow = (num == MIN) && (den == {W{1'b1}});
+
+    reg [NSTEPS:0] valid_q;
+    reg [WDIV-1:0] work_q [0:NSTEPS];
+    reg [W-1:0] den_q [0:NSTEPS];
+    reg [W+1:0] den3_q [0:NSTEPS];
+    reg num_negative_q [0:NSTEPS];
+    reg den_negative_q [0:NSTEPS];
+    reg div0_q [0:NSTEPS];
+    reg overflow_q [0:NSTEPS];
+    wire [WDIV-1:0] step_work [1:NSTEPS];
+
+    genvar i_stage;
+    generate
+        for (i_stage = 1; i_stage <= NSTEPS; i_stage = i_stage + 1) begin : g_stage
+            wire [W-1:0] remainder_next;
+            wire [1:0] digit;
+            wire [WPAD-1:0] quotient_work_next = (work_q[i_stage-1][WPAD-1:0] << 2) | digit;
+            assign step_work[i_stage] = {remainder_next, quotient_work_next};
+            _holoso_idiv_radix4_step #(.W(W)) u_step (
+                .den(den_q[i_stage-1]),
+                .den3(den3_q[i_stage-1]),
+                .partial_rem(work_q[i_stage-1][WDIV-1:WPAD]),
+                .next_bits(work_q[i_stage-1][WPAD-1 -: 2]),
+                .rem_next(remainder_next),
+                .digit(digit)
+            );
+        end
+    endgenerate
+
+    wire [W-1:0] quotient_magnitude = work_q[NSTEPS][W-1:0];
+    wire [W-1:0] remainder_magnitude = work_q[NSTEPS][WDIV-1:WPAD];
+    wire signs_differ = num_negative_q[NSTEPS] ^ den_negative_q[NSTEPS];
+    wire remainder_nonzero = |remainder_magnitude;
+    wire signed [W-1:0] corrected_quo;
+    wire signed [W-1:0] corrected_rem;
+
+    generate
+        if (QUOTIENT_FLOOR == 1) begin : g_floor
+            reg [W-1:0] floor_quo;
+            wire [W-1:0] negative_quo = -quotient_magnitude;
+            wire [W-1:0] unequal_rem = den_negative_q[NSTEPS] ?
+                (remainder_magnitude - den_q[NSTEPS]) : (den_q[NSTEPS] - remainder_magnitude);
+            wire [W-1:0] unequal_rem_or_zero = remainder_nonzero ? unequal_rem : {W{1'b0}};
+            wire [W-1:0] equal_rem = den_negative_q[NSTEPS] ? -remainder_magnitude : remainder_magnitude;
+            always @* begin
+                case ({signs_differ, remainder_nonzero})
+                    2'b10: floor_quo = negative_quo;
+                    2'b11: floor_quo = ~quotient_magnitude;
+                    default: floor_quo = quotient_magnitude;
+                endcase
+            end
+            assign corrected_quo = floor_quo;
+            assign corrected_rem = signs_differ ? unequal_rem_or_zero : equal_rem;
+        end else if (QUOTIENT_FLOOR == 0) begin : g_truncate
+            assign corrected_quo = signs_differ ? -quotient_magnitude : quotient_magnitude;
+            assign corrected_rem = num_negative_q[NSTEPS] ? -remainder_magnitude : remainder_magnitude;
+        end else begin : g_invalid_quotient_mode
+            _holoso_invalid_idivs_quotient_mode u_invalid();
+            assign corrected_quo = {W{1'bx}};
+            assign corrected_rem = {W{1'bx}};
+        end
+    endgenerate
+
+    integer i;
+    always @(posedge clk) begin
+        work_q[0] <= {{WPAD{1'b0}}, num_magnitude};
+        den_q[0] <= den_magnitude;
+        den3_q[0] <= den_magnitude3;
+        num_negative_q[0] <= num[W-1];
+        den_negative_q[0] <= den[W-1];
+        div0_q[0] <= input_div0;
+        overflow_q[0] <= input_overflow;
+        for (i = 1; i <= NSTEPS; i = i + 1) begin
+            work_q[i] <= step_work[i];
+            den_q[i] <= den_q[i-1];
+            den3_q[i] <= den3_q[i-1];
+            num_negative_q[i] <= num_negative_q[i-1];
+            den_negative_q[i] <= den_negative_q[i-1];
+            div0_q[i] <= div0_q[i-1];
+            overflow_q[i] <= overflow_q[i-1];
+        end
+        if (div0_q[NSTEPS]) begin
+            quo <= num_negative_q[NSTEPS] ? MIN : MAX;
+            rem <= num_negative_q[NSTEPS] ? -remainder_magnitude : remainder_magnitude;
+        end else if (overflow_q[NSTEPS]) begin
+            quo <= MAX;
+            rem <= {W{1'b0}};
+        end else begin
+            quo <= corrected_quo;
+            rem <= corrected_rem;
+        end
+        saturated <= div0_q[NSTEPS] | overflow_q[NSTEPS];
+        div0 <= div0_q[NSTEPS];
+        if (rst) begin
+            valid_q <= {(NSTEPS+1){1'b0}};
+            out_valid <= 1'b0;
+        end else begin
+            valid_q <= {valid_q[NSTEPS-1:0], in_valid};
+            out_valid <= valid_q[NSTEPS];
+        end
+    end
+endmodule
+
+module _holoso_idiv_radix4_step #(parameter W = 44) (
+    input  wire [W-1:0] den,
+    input  wire [W+1:0] den3,
+    input  wire [W-1:0] partial_rem,
+    input  wire [1:0] next_bits,
+    output reg [W-1:0] rem_next,
+    output reg [1:0] digit
+);
+    localparam integer WCANDIDATE = W + 2;
+    localparam integer WDIFF = WCANDIDATE + 1;
+
+    wire [WCANDIDATE-1:0] den1 = {2'b00, den};
+    wire [WCANDIDATE-1:0] den2 = {1'b0, den, 1'b0};
+    wire [WCANDIDATE-1:0] candidate = {partial_rem, next_bits};
+    wire [WDIFF-1:0] diff1 = {1'b0, candidate} - {1'b0, den1};
+    wire [WDIFF-1:0] diff2 = {1'b0, candidate} - {1'b0, den2};
+    wire [WDIFF-1:0] diff3 = {1'b0, candidate} - {1'b0, den3};
+    wire ge1 = !diff1[WCANDIDATE];
+    wire ge2 = !diff2[WCANDIDATE];
+    wire ge3 = !diff3[WCANDIDATE];
+
+    always @* begin
+        casez ({ge3, ge2, ge1})
+            3'b1??: begin
+                rem_next = diff3[W-1:0];
+                digit = 2'd3;
+            end
+            3'b01?: begin
+                rem_next = diff2[W-1:0];
+                digit = 2'd2;
+            end
+            3'b001: begin
+                rem_next = diff1[W-1:0];
+                digit = 2'd1;
+            end
+            default: begin
+                rem_next = candidate[W-1:0];
+                digit = 2'd0;
+            end
+        endcase
+    end
+endmodule
+
+// Signed integer absolute value with saturation: the edge case -(2**(W-1)) is mapped to (2**(W-1)-1) with saturated=1.
+module holoso_iabss#(parameter W = 44, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] x,
+    output reg out_valid,
+    output reg signed [W-1:0] y,
+    output reg saturated
+);
+    localparam integer LATENCY_REF = 2;
+    localparam signed [W-1:0] MIN = {1'b1, {(W-1){1'b0}}};
+    localparam signed [W-1:0] MAX = {1'b0, {(W-1){1'b1}}};
+    generate
+        if ((LATENCY != 0) && (LATENCY != LATENCY_REF)) begin : g_invalid_latency
+            _holoso_invalid_integer_latency u_invalid();
+        end
+    endgenerate
+
+    reg signed [W-1:0] x_q;
+    reg input_valid_q;
+    wire signed [W-1:0] neg = -x_q;
+    wire clamp = x_q == MIN;
+
+    always @(posedge clk) begin
+        x_q <= x;
+        y <= x_q[W-1] ? (clamp ? MAX : neg) : x_q;
+        saturated <= clamp;
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            out_valid <= input_valid_q;
+        end
+    end
+endmodule
+
+// Signed integer barrel shifter: shift left if shamt>0, shift right if shamt<0.
+// For constant shamt use ordinary inline combinational shift expression instead.
+module holoso_ashift#(parameter W = 44, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] x,
+    input  wire signed [W-1:0] shamt,
+    output reg out_valid,
+    output reg signed [W-1:0] y
+);
+    localparam integer LATENCY_REF = 2;
+    localparam integer SW = $clog2(W);
+    localparam integer PW = $clog2(SW);
+    localparam [SW:0] W_AMOUNT = W;
+    generate
+        if ((LATENCY != 0) && (LATENCY != LATENCY_REF)) begin : g_invalid_latency
+            _holoso_invalid_integer_latency u_invalid();
+        end
+    endgenerate
+
+    reg signed [W-1:0] x_q;
+    reg signed [W-1:0] shamt_q;
+    reg input_valid_q;
+    wire [SW-1:0] shamt_narrow = shamt_q[SW-1:0];
+    wire [SW-1:0] right_prefix [0:PW];
+    assign right_prefix[0] = shamt_narrow;
+    generate
+        genvar i;
+        for (i = 0; i < PW; i = i + 1) begin : g_right_prefix
+            assign right_prefix[i+1] = right_prefix[i] | (right_prefix[i] << (1 << i));
+        end
+    endgenerate
+    wire [SW-1:0] right_amount = ~shamt_narrow ^ ~(right_prefix[PW] << 1);
+    wire [SW:0] left_amount_ext = {1'b0, shamt_narrow};
+    wire [SW:0] right_amount_ext = {1'b0, right_amount};
+    wire left_large = (|shamt_q[W-1:SW]) | (left_amount_ext >= W_AMOUNT);
+    wire right_large = (~&shamt_q[W-1:SW]) | (~|shamt_narrow) | (right_amount_ext >= W_AMOUNT);
+    wire signed [W-1:0] shifted_left = x_q << shamt_narrow;
+    wire signed [W-1:0] shifted_right = x_q >>> right_amount;
+
+    always @(posedge clk) begin
+        x_q <= x;
+        shamt_q <= shamt;
+        casez ({shamt_q[W-1], right_large, left_large})
+            3'b0?1: y <= {W{1'b0}};
+            3'b0?0: y <= shifted_left;
+            3'b11?: y <= {W{x_q[W-1]}};
+            3'b10?: y <= shifted_right;
+            default: y <= {W{1'bx}};
+        endcase
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            out_valid <= input_valid_q;
+        end
+    end
+endmodule
+
+// Signed integer comparator.
+module holoso_icmp#(parameter W = 44, parameter integer LATENCY = 0) (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire signed [W-1:0] a,
+    input  wire signed [W-1:0] b,
+    output reg out_valid,
+    output reg a_gt_b,
+    output reg a_eq_b,
+    output reg a_lt_b
+);
+    localparam integer LATENCY_REF = 2;
+    generate
+        if ((LATENCY != 0) && (LATENCY != LATENCY_REF)) begin : g_invalid_latency
+            _holoso_invalid_integer_latency u_invalid();
+        end
+    endgenerate
+
+    reg signed [W-1:0] a_q;
+    reg signed [W-1:0] b_q;
+    reg input_valid_q;
+    wire signed [W:0] diff = $signed({a_q[W-1], a_q}) - $signed({b_q[W-1], b_q});
+    wire less = diff[W];
+    wire equal = a_q == b_q;
+
+    always @(posedge clk) begin
+        a_q <= a;
+        b_q <= b;
+        a_gt_b <= ~less & ~equal;
+        a_eq_b <= equal;
+        a_lt_b <= less;
+        if (rst) begin
+            input_valid_q <= 1'b0;
+            out_valid <= 1'b0;
+        end else begin
+            input_valid_q <= in_valid;
+            out_valid <= input_valid_q;
+        end
+    end
+endmodule

--- a/holoso/_backend/verilog/holoso_support_inline.vh
+++ b/holoso/_backend/verilog/holoso_support_inline.vh
@@ -1,5 +1,30 @@
 // BEGIN holoso_support_inline.vh: the file is spliced into each generated module.
 
+// Arithmetic shift by a constant. Positive shamt shifts left. For variable shamt use holoso_ashift.
+function signed [W-1:0] holoso_ashiftc;
+    input signed [W-1:0] x;
+    input signed [W-1:0] shamt;
+    reg signed [W:0] shamt_ext;
+    reg [$clog2(W)-1:0] shamt_narrow;
+    reg signed [W-1:0] shifted_left;
+    reg signed [W-1:0] shifted_right;
+    begin
+        shamt_ext = {shamt[W-1], shamt};
+        shamt_narrow = shamt[$clog2(W)-1:0];
+        shifted_left = x << shamt_narrow;
+        shifted_right = x >>> -shamt_narrow;
+        if (shamt_ext >= W) begin
+            holoso_ashiftc = {W{1'b0}};
+        end else if (shamt_ext <= -W) begin
+            holoso_ashiftc = {W{x[W-1]}};
+        end else if (shamt[W-1]) begin
+            holoso_ashiftc = shifted_right;
+        end else begin
+            holoso_ashiftc = shifted_left;
+        end
+    end
+endfunction
+
 // Combinational mapping from float to boolean: a zero or a subnormal (if supported) float is false, otherwise true.
 // E.g., if IEEE 754 binary32 is used (with subnormals), values with magnitude under ~1e-38 are mapped to falsity.
 function holoso_ftobool;

--- a/holoso/_lir/_bankalloc.py
+++ b/holoso/_lir/_bankalloc.py
@@ -98,6 +98,16 @@ def layout_and_allocate(
     return _LayoutAllocation(overlap, inst_of, instances, consts, const_pool, alloc)
 
 
+def install_source_commit(sched: Schedule, source_node: MirNode, source: ValueId) -> int | None:
+    """
+    A tail install source's commit cycle in the installing block's own frame, None for a block-entry-RESIDENT source --
+    exactly ``install_issue_cycle``'s contract. The lone encoding of the residency-to-commit rule, shared by the push
+    classification, the interference residence, and the LIR copy placement, so the three cannot drift apart (a drift
+    here recreates the placement-disagreement class of the phi-swap miscompile).
+    """
+    return None if value_resident_at_entry(source_node) else sched.commit_or_makespan(source)
+
+
 def _install_pushes_makespan(sched: Schedule, source_node: MirNode, source: ValueId) -> bool:
     """
     Whether a tail install of ``source`` lands PAST the work makespan -- the per-install +1 drain. True only for a
@@ -105,8 +115,7 @@ def _install_pushes_makespan(sched: Schedule, source_node: MirNode, source: Valu
     an earlier-committing or block-entry-resident source fits at the makespan. Decided through the one
     ``install_issue_cycle`` so this classification, the LIR placement, and the interference residence cannot drift.
     """
-    resident = value_resident_at_entry(source_node)
-    return install_issue_cycle(sched.makespan, resident, sched.commit_or_makespan(source)) > sched.makespan
+    return install_issue_cycle(sched.makespan, install_source_commit(sched, source_node, source)) > sched.makespan
 
 
 def actual_install_blocks(
@@ -116,22 +125,18 @@ def actual_install_blocks(
     The post-coalescing install classification (the refinement ``block_has_install`` seeds): each block that actually
     installs at its tail, mapped to whether any of its installs lands past the work makespan -- a computed source that
     is the block's own last work, so the install must read-first it and the block pays the +1 drain (``True``). An
-    install whose source commits earlier, or is block-entry resident (a literal constant -- including the const branch
-    materialization already in ``alloc.bool_writes`` -- an input, or a state read), fits at the makespan (``False``), so
-    its +1 drain is unnecessary and drops here, which the fixpoint feeds back to the next layout. A CFG-shape phi-arm
-    predecessor whose every arm coalesced installs nothing and drops out entirely.
+    install whose source commits earlier, or is block-entry resident per ``value_resident_at_entry`` (including the
+    const branch materialization already in ``alloc.bool_writes``), fits at the makespan (``False``). How narrowing
+    and regrowth of this classification drive the layout is the caller's protocol (the install fixpoint in the
+    builder).
     """
     install: dict[int, bool] = {}
-    for bid, copies in alloc.copies.items():
-        sched = block_sched[bid]
-        for c in copies:
-            pushes = _install_pushes_makespan(sched, float_mir.nodes[c.source], c.source)
-            install[bid] = install.get(bid, False) or pushes
-    for bid, writes in alloc.bool_writes.items():
-        sched = block_sched[bid]
-        for w in writes:
-            pushes = _install_pushes_makespan(sched, bool_mir.nodes[w.source], w.source)
-            install[bid] = install.get(bid, False) or pushes
+    for nodes, bank_installs in ((float_mir.nodes, alloc.copies), (bool_mir.nodes, alloc.bool_writes)):
+        for bid, entries in bank_installs.items():
+            sched = block_sched[bid]
+            for entry in entries:
+                pushes = _install_pushes_makespan(sched, nodes[entry.source], entry.source)
+                install[bid] = install.get(bid, False) or pushes
     return install
 
 
@@ -381,18 +386,6 @@ _BOOL = _BoolBank()
 
 
 @dataclass(frozen=True, slots=True)
-class _ArmSource:
-    """
-    A phi arm's install source in the install's (predecessor) block frame: whether it is block-entry resident (a const,
-    input, or state read -- needs no read-first sampling, so it never pushes the install past the makespan) and its
-    commit cycle there (the block makespan when it has no local commit -- a phi or a value computed in another block).
-    """
-
-    resident: bool
-    source_commit: int
-
-
-@dataclass(frozen=True, slots=True)
 class _InterferenceBuilder:
     """
     Builds a bank's interference graph: the loop-invariant liveness facts (residency, result landings, definition
@@ -410,23 +403,23 @@ class _InterferenceBuilder:
     phi_block: dict[ValueId, int]
     arm_out: dict[int, frozenset[ValueId]]
     inflight_defs: dict[int, dict[ValueId, int]]
-    # block -> phi dest -> its arm source in THIS block's frame (resident flag + commit), so the interference residence
-    # matches the LIR copy's placement and cannot drift onto a foreign block's frame.
-    install_source: dict[int, dict[ValueId, _ArmSource]]
+    # block -> phi dest -> its arm source's commit cycle in THIS block's frame, None for a block-entry-resident source
+    # (``install_issue_cycle``'s contract), so the interference residence matches the LIR copy's placement and cannot
+    # drift onto a foreign block's frame.
+    install_source: dict[int, dict[ValueId, int | None]]
     fetch_lag: int
 
     def _install_fire(self, block: int, vid: ValueId) -> int:
-        """The install's block-local fire step, via the same helpers as the LIR install so residence matches exactly."""
-        src = self.install_source[block][vid]
-        issue = install_issue_cycle(self.work_makespan[block], src.resident, src.source_commit)
-        fire = inline_fire_cycle(issue, self.fetch_lag)
-        # The interference residence must land within the block, exactly like the emitted copy (build asserts the same):
-        # a fire past the terminator would mean the source commit was read in a foreign block's coordinate frame.
-        assert install_landing(fire) <= self.term_offset[block], (
-            f"block {block}: install of {vid} lands at {install_landing(fire)} past the terminator "
-            f"{self.term_offset[block]} -- interference residence off the predecessor frame"
-        )
-        return fire
+        """
+        The install's block-local fire step, via the same helpers as the LIR install so residence matches exactly.
+        It MAY transiently land past the current terminator: after a push-bit narrowing, an intermediate coalescing
+        attempt can hold a computed arm de-coalesced whose install no longer fits the shortened boundary -- the outer
+        install fixpoint then re-widens (pins) the classification and re-runs, and only the converged round's
+        placements are emitted (the build-side landing assert guards those). Frame confinement itself is guaranteed by
+        ``install_issue_cycle``'s own precondition, so there is nothing falsifiable to assert here.
+        """
+        issue = install_issue_cycle(self.work_makespan[block], self.install_source[block][vid])
+        return inline_fire_cycle(issue, self.fetch_lag)
 
     def build(
         self,
@@ -485,15 +478,16 @@ def _allocate_bank(
     arm_out = phi_arm_out(mir, phi_nodes, values)
     boundary_base = bank.boundary_base(mir, values, ret_block)
 
-    # Per block, each phi dest whose arm originates there -> its source in the PREDECESSOR's own frame (where the
-    # install fires, not the source's home block): the resident flag (a resident source needs no read-first sampling)
-    # and the source commit. The same rule build and actual_install_blocks apply, so the interference residence cannot
+    # Per block, each phi dest whose arm originates there -> its source's commit cycle in the PREDECESSOR's own frame
+    # (where the install fires, not the source's home block), None for a block-entry-resident source that needs no
+    # read-first sampling. The same rule build and actual_install_blocks apply, so the interference residence cannot
     # drift onto a foreign block's frame.
-    install_source: dict[int, dict[ValueId, _ArmSource]] = {}
+    install_source: dict[int, dict[ValueId, int | None]] = {}
     for vid, phi in phi_nodes.items():
         for pred, value, _conditioner in phi.arms:
-            resident = value_resident_at_entry(view.nodes[value])
-            install_source.setdefault(pred, {})[vid] = _ArmSource(resident, block_sched[pred].commit_or_makespan(value))
+            install_source.setdefault(pred, {})[vid] = install_source_commit(
+                block_sched[pred], view.nodes[value], value
+            )
 
     interference = _InterferenceBuilder(
         mir=mir,
@@ -506,7 +500,7 @@ def _allocate_bank(
         phi_block=phi_block,
         arm_out=arm_out,
         inflight_defs=block_inflight,
-        install_source={b: dict(m) for b, m in install_source.items()},
+        install_source=install_source,
         fetch_lag=fetch_lag,
     )
 
@@ -662,12 +656,12 @@ def _allocate(
     """
     Assign wide and boolean registers across the CFG. Both banks are colored by hardware-frame liveness, reusing
     registers across mutually-exclusive and non-overlapping live ranges. A phi is resolved by installing each arm's
-    value into the phi's register with a copy at the predecessor's tail; the copies are a parallel (simultaneous)
-    bundle, so a swap is read-then-write correct. ``block_makespan`` (install-inclusive) and ``block_term_offset`` (the
-    drained boundary, or the overlap-shrunk terminator) come from the overlap layout, so the liveness boundary matches
-    the laid-out block spans exactly. ``block_inflight`` carries each block's received cross-block spills (split per
-    bank), reserving a spilled value's register across every successor frame it lands in even where the value is
-    dataflow-dead.
+    value into the phi's register with a copy at the predecessor's tail; copies sharing a fire step are a parallel
+    (read-then-write) bundle, and placement keeps a swap correct (see ``value_resident_at_entry``).
+    ``block_makespan`` (install-inclusive) and ``block_term_offset`` (the drained boundary, or the overlap-shrunk
+    terminator) come from the overlap layout, so the liveness boundary matches the laid-out block spans exactly.
+    ``block_inflight`` carries each block's received cross-block spills (split per bank), reserving a spilled value's
+    register across every successor frame it lands in even where the value is dataflow-dead.
     """
     float_inflight = {
         bid: {vid: land for vid, land in spills.items() if vid in float_mir.operation_nodes}

--- a/holoso/_lir/_build.py
+++ b/holoso/_lir/_build.py
@@ -3,6 +3,7 @@ Build a finished :class:`Lir` from MIR: the top-level orchestration that schedul
 both register banks (coalescing phi arms), constructs the per-block LIR, and assembles the final program.
 """
 
+import logging
 from dataclasses import replace
 
 from .._errors import UnsupportedConstruct
@@ -20,10 +21,10 @@ from .._mir import (
 from .._operators import PortConditioner
 from .._util import ValueId
 from ._ir import *
-from ._mir_facts import block_has_install, value_resident_at_entry
+from ._mir_facts import block_has_install, pred_count
 from ._portassign import assign_commutative_ports
 from ._schedule import resolve_pool
-from ._bankalloc import actual_install_blocks, layout_and_allocate
+from ._bankalloc import actual_install_blocks, install_source_commit, layout_and_allocate
 from ._build_base import Allocation, PooledConst
 from ._construct import (
     bool_operand,
@@ -37,6 +38,8 @@ from ._construct import (
     tapped_wide_lanes,
 )
 from ._layout import install_inclusive_makespan, layout_blocks
+
+_logger = logging.getLogger(__name__)
 
 
 def build(mir: Mir, module_name: str, fetch_stages: int) -> Lir:
@@ -143,6 +146,15 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int) -> Lir:
                     f"block {mir_block.id} branches on a phi that takes an arm from the same block; the install "
                     f"would overwrite the condition before the branch reads it"
                 )
+    # The phi-residency classification (``value_resident_at_entry``) rests on every phi-bearing block being
+    # multi-predecessor, which is what keeps overlap spills out of phi registers; a future pass emitting a phi into a
+    # single-predecessor block would silently void that argument (the sibling-install tripwire does not read-gate
+    # installs against in-flight landings), so the reliance is machine-checked here.
+    pred_edges = pred_count(mir)
+    for mir_block in mir.blocks:
+        assert (
+            not mir_block.phis or pred_edges[mir_block.id] >= 2
+        ), f"block {mir_block.id} carries phis with {pred_edges[mir_block.id]} predecessor edge(s)"
     pool = resolve_pool(mir.nodes)
     # Schedule every block in reverse-postorder (a block after its forward-edge predecessors) and lay out each block's
     # terminator offset, with cross-block software pipelining: a block whose successors are all single-predecessor
@@ -151,47 +163,81 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int) -> Lir:
     #
     # The install set is computed to a fixpoint. ``block_has_install`` marks a block install-bearing from the CFG shape
     # (any phi arm originates in it), but a block whose every arm COALESCES onto the merged register installs nothing,
-    # so that +1 drain (and overlap-ineligibility) is spurious. So: lay out and allocate with the conservative CFG set,
-    # recompute the install set from the ACTUAL coalesced copies, and re-run until it stops shrinking. Convergence is by
-    # monotonicity -- dropping a block's spurious drain frees registers one step earlier, which only enables more
-    # coalescing, so the install set is non-increasing over a finite block set and reaches a fixpoint (the assert guards
-    # the monotonicity; the loop's iteration bound is derived below). Determinism is preserved: the allocator is
-    # seed-fixed and the install set is rebuilt the same way each pass.
+    # so that +1 drain (and overlap-ineligibility) is spurious. So: lay out and allocate with the conservative CFG
+    # seed, recompute the classification from the ACTUAL coalesced copies, and re-run to a fixed point. The movement is
+    # TWO-SIDED: a classification mostly narrows (dropping a spurious drain), but the shortened boundary feeds a greedy
+    # coalescing that is not monotone in the interference, so a narrowed classification can have to grow back -- and
+    # every regrowth is pinned (see the loop body), so each block moves a bounded number of times and the composition
+    # with the inner per-bank ``coalesce_and_color`` fixpoint (its forbidden-merge set non-decreasing) terminates.
+    # Determinism is preserved: the allocator is seed-fixed and the classification is rebuilt the same way each pass.
     #
-    # This install fixpoint NESTS a second one: each ``layout_and_allocate`` round runs the per-bank phi-coalescing /
-    # coloring fixpoint in ``coalesce_and_color``. Both are bounded and monotone -- the install set non-increasing here,
-    # the inner forbidden-merge set non-decreasing there -- so the composition terminates in a bounded number of outer
-    # rounds (the loop bound below), each a bounded inner fixpoint. The coupling is one-way and cannot deadlock: a
-    # shrinking install set only relieves register pressure, enabling more coalescing, never forbidding a merge the
-    # inner round already made.
-    #
-    # The same fixpoint also sheds the state slot's read-first boundary-copy drain charge once the slot coalesces:
-    # ``has_state_copy`` starts conservative (a state slot needs a copy) and clears as coalescing removes it, monotone
-    # alongside the install set. It is a single bool: the MIR has one Ret, so the charge is op-wide on that block.
+    # The same fixpoint also drives the state slot's read-first boundary-copy drain charge: ``has_state_copy`` starts
+    # conservative (a state slot needs a copy), usually clears as coalescing removes the copy, and latches back on the
+    # regrowth channel noted in the loop. It is a single bool: the MIR has one Ret, so the charge is op-wide there.
     has_install_blocks = block_has_install(mir, float_mir, bool_mir)
     ret_block = mir.ret_block
     # Conservative seed for the state-copy fixpoint -- the pre-allocation form of ``_has_state_copy``: assume every
     # state slot needs a boundary copy.
     has_state_copy = bool(float_mir.state_slots or bool_mir.state_slots)
-    # Iteration bound. All three descending quantities only drop (monotonicity argument at the asserts below): the
-    # install set (<= len(blocks) removals as coalescing frees registers), the per-block push bit (<= len(blocks)
-    # narrowings), and the single-keyed state-copy charge (height 1). Worst case is their SUM plus a confirming round;
-    # the 2*len(blocks)+3 loop bound below leaves a safe margin, with the asserts and the else-clause as loud backstops.
-    for _ in range(2 * len(mir.blocks) + 3):
+    # Iteration bound. Every non-final round makes one of the bounded monotone moves per block -- a push-bit narrowing,
+    # an install-set key removal, or a pin (a pinned block never moves again), at most three over the run -- or moves
+    # the state-copy charge along its drop-then-latch chain (at most two moves). Worst case is their SUM plus a
+    # confirming round; the 3*len(blocks)+4 loop bound below leaves a safe margin, with the else-clause as the loud
+    # backstop.
+    seed_keys = frozenset(has_install_blocks)
+    pinned_push: set[int] = set()
+    state_copy_latched = False
+    for round_index in range(3 * len(mir.blocks) + 4):
         result = layout_and_allocate(mir, float_mir, bool_mir, pool, has_install_blocks, has_state_copy, fetch_lag)
-        actual = actual_install_blocks(result.alloc, float_mir, bool_mir, result.overlap.block_sched)
-        actual_state = _has_state_copy(float_mir, bool_mir, result.alloc, result.const_pool)
-        # The descent is monotone and the fixed point is sound. MONOTONE: a block leaves the install set only by
+        raw = actual_install_blocks(result.alloc, float_mir, bool_mir, result.overlap.block_sched)
+        # The two derivations of install-bearing -- the CFG-shape seed and the post-allocation copies -- must agree on
+        # the key universe: a block outside the seed can never install, so a wider ``raw`` means the derivations
+        # drifted, which must fail loudly rather than be absorbed as a silent permanent pin. On the FIRST round the
+        # bits must agree too: nothing has narrowed yet, so a push the conservative seed missed is the same drift,
+        # not legitimate regrowth.
+        assert raw.keys() <= seed_keys, "post-allocation installs appeared outside the CFG-shape seed"
+        assert round_index > 0 or all(
+            has_install_blocks[b] or not bit for b, bit in raw.items()
+        ), "a first-round push classification exceeded the conservative CFG-shape seed"
+        # A narrowed classification may have to GROW BACK: the shortened boundary feeds the next round's coalescing,
+        # whose greedy merge order is not monotone in the interference, so a computed arm that coalesced under the
+        # longer boundary can come back residual -- its install then needs the +1 drain the narrowing removed, and a
+        # whole dropped KEY can likewise resurface. Any regrowth is PINNED: a pinned block stays install-bearing with a
+        # forced +1 drain for the rest of the run, so the two-sided movement still converges (key removals and pins are
+        # each monotone, bounded by the block count). An intermediate allocation built on a stale narrower boundary is
+        # discarded by the re-run; the converged round has validated every surviving install against a boundary
+        # consistent with its own classification.
+        regrown = {b for b, bit in raw.items() if b not in has_install_blocks or (bit and not has_install_blocks[b])}
+        if regrown - pinned_push:
+            _logger.info("Install fixpoint round %d: pinning regrown block(s) %s", round_index, sorted(regrown))
+        pinned_push |= regrown
+        actual = raw | dict.fromkeys(pinned_push, True)
+        # The state-copy charge has its own regrowth channel (a final pin conflict can force a slot back out of
+        # coalescing onto a copy), so it is a one-way latch rather than a pure descent.
+        raw_state = _has_state_copy(float_mir, bool_mir, result.alloc, result.const_pool)
+        if raw_state and not has_state_copy:
+            if not state_copy_latched:
+                _logger.info("Install fixpoint round %d: latching the state-copy charge", round_index)
+            state_copy_latched = True
+        actual_state = raw_state or state_copy_latched
+        # The moves are monotone and the fixed point is sound. MONOTONE: a block leaves the install set only by
         # coalescing away its phi-arm install, but a phi arm makes its merge successor multi-predecessor, so such a
         # block can never satisfy ``overlaps`` and never spills -- before or after it leaves -- so no block becomes
-        # overlap-eligible across rounds, every schedule is round-invariant, and the push bit and install set only drop.
-        # SOUND: a converged classification (actual == has_install_blocks) is self-consistent, and ``landing <=
-        # term_offset`` then holds by the drain math (not the asserts), so the layout is correct even under -O. The
-        # asserts below pin the narrowing; a never-converging run -- unreachable -- falls to the ``else``, which RAISES.
-        assert actual.keys() <= has_install_blocks.keys(), "install fixpoint must not grow"
-        assert all(has_install_blocks[b] or not copy for b, copy in actual.items()), "install drain must not widen"
-        assert actual_state <= has_state_copy, "state-copy fixpoint must not grow"
+        # overlap-eligible across rounds and every schedule is round-invariant; keys only shrink except through the
+        # growing pin set, and the state latch has height one. SOUND: a converged classification
+        # (actual == has_install_blocks) is self-consistent, and ``landing <= term_offset`` then holds by the drain
+        # math, so the layout is correct even under -O; every widening is legitimized by the unconditional pin/latch
+        # merges above (an assert here would be tautological), and a never-converging run -- unreachable -- falls to
+        # the ``else``, which RAISES.
         if actual == has_install_blocks and actual_state == has_state_copy:
+            _logger.info(
+                "Install fixpoint converged after %d round(s): %d install-bearing block(s), %d pinned, "
+                "state copy %s",
+                round_index + 1,
+                len(actual),
+                len(pinned_push),
+                "charged" if actual_state else "elided",
+            )
             break
         has_install_blocks, has_state_copy = actual, actual_state
     else:
@@ -224,21 +270,21 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int) -> Lir:
             )
         ]
         work_makespan = sched.makespan
-        # ``resident`` records whether the source is available at block entry (a const, input, or state read) -- it
-        # needs no read-first sampling. The placement (``install_issue_cycle``) charges the +1 only when a COMPUTED
-        # source is the block's own last work; a resident or earlier-committing computed source pays none.
+        # A None commit from ``install_source_commit`` is a block-entry-resident source needing no read-first
+        # sampling. The placement (``install_issue_cycle``) charges the +1 only for a computed source committing at
+        # the makespan; a resident or earlier-committing computed source pays none.
         copies = []
         for c in alloc.copies.get(block.id, []):
             fsrc = operand_signed(float_mir, c.source, c.sign, alloc, const_pool)
-            resident = value_resident_at_entry(float_mir.nodes[c.source])
-            iss = install_issue_cycle(work_makespan, resident, sched.commit_or_makespan(c.source))
-            copies.append(FloatCopy(RegRef(c.dst), fsrc, iss, resident))
+            commit = install_source_commit(sched, float_mir.nodes[c.source], c.source)
+            copies.append(FloatCopy(RegRef(c.dst), fsrc, install_issue_cycle(work_makespan, commit), commit is None))
         bool_writes = []
         for w in alloc.bool_writes.get(block.id, []):
             bsrc = bool_operand(bool_mir, w.source, alloc, w.inversion)
-            resident = value_resident_at_entry(bool_mir.nodes[w.source])
-            iss = install_issue_cycle(work_makespan, resident, sched.commit_or_makespan(w.source))
-            bool_writes.append(BoolWrite(BoolRegRef(w.dst), bsrc, iss, resident))
+            commit = install_source_commit(sched, bool_mir.nodes[w.source], w.source)
+            bool_writes.append(
+                BoolWrite(BoolRegRef(w.dst), bsrc, install_issue_cycle(work_makespan, commit), commit is None)
+            )
         # The block makespan carries the install +1 only when some install lands past the work makespan (a computed
         # source that is the block's own last work); ``has_install_blocks`` maps each install-bearing block to that bit.
         block_makespan = install_inclusive_makespan(work_makespan, has_install_blocks.get(block.id, False))
@@ -257,10 +303,21 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int) -> Lir:
         # but a Ret wrap drops it -- a silently dead install. This is the vector-independent structural invariant that a
         # value cosim cannot see (a dead install that does not change outputs passes every value comparison).
         term_offset = overlap.block_term_offset[block.id]
-        install_landings = [c.landing(fetch_lag) for c in copies] + [w.landing(fetch_lag) for w in bool_writes]
+        installs: list[FloatCopy | BoolWrite] = [*copies, *bool_writes]
+        install_landings = [x.landing(fetch_lag) for x in installs]
         assert all(
             landing <= term_offset for landing in install_landings
         ), f"block {block.id}: a phi-arm install lands at {max(install_landings)} past the terminator {term_offset}"
+        # A tail install must read its source register strictly before a sibling install's write to that register
+        # lands (see ``value_resident_at_entry`` for why placement guarantees this): the structural tripwire for a
+        # placement regression, which the value cosim shares with the model and cannot see. Cross-bank pairs are inert
+        # (RegRef never equals BoolRegRef), so one check serves both banks.
+        for writer in installs:
+            for reader in installs:
+                if reader.source.source == writer.dst:
+                    assert reader.fire_step(fetch_lag) < writer.landing(
+                        fetch_lag
+                    ), f"block {block.id}: a tail install reads {writer.dst} after a sibling install's write lands"
         blocks.append(
             LirBlock(
                 block.id,

--- a/holoso/_lir/_ir.py
+++ b/holoso/_lir/_ir.py
@@ -128,20 +128,22 @@ def install_landing(fire_step: int) -> int:
     return fire_step + READ_FIRST_EDGE
 
 
-def install_issue_cycle(work_makespan: int, resident_source: bool, source_commit: int) -> int:
+def install_issue_cycle(work_makespan: int, source_commit: int | None) -> int:
     """
-    The scheduler-frame placement of a block's tail install. The install sits at the work makespan -- landing read-first
-    at the boundary, after every in-block read, the latest placement (minimal destination residence). It is pushed one
-    step past only when a COMPUTED source commits AT the makespan, which the install must fire after to read-first
-    (``source_commit + READ_FIRST_EDGE`` then exceeds the makespan): either the block's own last-committing op, or --
-    conservatively -- a source not scheduled in this block (a phi or a value computed elsewhere), which the callers pass
-    ``source_commit == work_makespan`` so the placement never reads off a foreign frame. A loop-carried copy sourcing an
-    EARLIER in-block op, and a resident source (constant, input, state read), stay at the makespan and pay no terminator
-    cycle. The per-install dual of ``install_inclusive_makespan`` (which carries the +1 into the block makespan exactly
-    when an install lands past the makespan), so the placement and the drain agree and an install cannot land past its
-    block's terminator.
+    The scheduler-frame placement of a block's tail install; ``source_commit`` is None for a block-entry-RESIDENT
+    source (per ``value_resident_at_entry``: a constant, input, state read, or phi result), which needs no read-first
+    sampling. The install sits at the work makespan -- landing read-first at the boundary, after every in-block read,
+    the latest placement (minimal destination residence). It is pushed one step past only when a COMPUTED source
+    commits AT the makespan, which the install must fire after to read-first (``source_commit + READ_FIRST_EDGE`` then
+    exceeds the makespan): either the block's own last-committing op, or -- conservatively -- an operator result not
+    scheduled in this block (a possible overlap spill), which the callers pass ``source_commit == work_makespan`` so
+    the placement never reads off a foreign frame. A resident source and a copy sourcing an EARLIER in-block op stay
+    at the makespan and pay no terminator cycle; keeping phi sources unpushed is load-bearing for the same-step
+    parallel-bundle contract cross-referencing loop-header phis rely on. The per-install dual of
+    ``install_inclusive_makespan`` (which carries the +1 into the block makespan exactly when an install lands past the
+    makespan), so the placement and the drain agree and an install cannot land past its block's terminator.
     """
-    if resident_source:
+    if source_commit is None:
         return work_makespan
     assert source_commit <= work_makespan, "install source_commit lies outside the install's own block frame"
     return max(work_makespan, source_commit + READ_FIRST_EDGE)
@@ -502,10 +504,9 @@ class FloatCopy:
     A register-to-register move installing a phi arm's value into the merged register at a predecessor's tail: ``dst``
     takes ``source`` on the block-relative ``issue_cycle``. Used when a phi arm is not an operator result that can be
     coalesced directly onto the merged register (e.g. an input, a constant, or a value defined in another block).
-    ``resident_source`` records whether ``source`` is available at block entry (a constant, input, or state read) rather
-    than computed by this block's work -- informational; the placement (``issue_cycle``, via ``install_issue_cycle``)
-    sits at the work makespan unless a computed source is the block's last work. The builder sets it from
-    ``value_resident_at_entry``, which a ``RegRef`` operand alone cannot reveal.
+    ``resident_source`` records whether ``source`` is available at block entry (``value_resident_at_entry``, which a
+    ``RegRef`` operand alone cannot reveal) rather than computed -- informational; the placement (``issue_cycle``) is
+    ``install_issue_cycle``'s, pushed past the work makespan only for a computed source committing there.
     """
 
     dst: RegRef
@@ -529,9 +530,9 @@ class FloatCopy:
 class BoolWrite:
     """
     A boolean register install of a phi arm (a bool const or another bool register, with the arm's folded inversion)
-    on a block-relative cycle. ``resident_source`` records whether ``source`` is available at block entry (a constant,
-    input, or state read) rather than computed by this block's work -- informational; the placement sits at the work
-    makespan unless a computed source is the block's last work (see :class:`FloatCopy`).
+    on a block-relative cycle. ``resident_source`` records whether ``source`` is available at block entry
+    (``value_resident_at_entry``) rather than computed -- informational; the placement is ``install_issue_cycle``'s
+    (see :class:`FloatCopy`).
     """
 
     dst: BoolRegRef

--- a/holoso/_lir/_layout.py
+++ b/holoso/_lir/_layout.py
@@ -9,7 +9,7 @@ from .._util import ValueId
 from ._ir import *
 from ._schedule import Schedule, schedule_ops
 from ._build_base import OverlapLayout
-from ._mir_facts import mir_operation, mir_rpo, succ_map
+from ._mir_facts import mir_operation, mir_rpo, pred_count, succ_map
 
 
 def _value_word_and_landing(mir: Mir, vid: ValueId, issue: int, fetch_lag: int) -> tuple[int, int, HardwareOperator]:
@@ -132,10 +132,7 @@ def schedule_with_overlap(
     landing (plus the tail install) and the carries are empty -- identical to an isolated per-block schedule.
     """
     succ = succ_map(mir)
-    pred_count: dict[int, int] = {block.id: 0 for block in mir.blocks}
-    for targets in succ.values():
-        for target in targets:
-            pred_count[target] += 1
+    preds = pred_count(mir)
     blocks_by_id = {block.id: block for block in mir.blocks}
     block_sched: dict[int, Schedule] = {}
     block_makespan: dict[int, int] = {}
@@ -163,7 +160,7 @@ def schedule_with_overlap(
         makespan = install_inclusive_makespan(sched.makespan, install_pushes_makespan)
         block_makespan[bid] = makespan
         targets = succ[bid]
-        overlaps = bool(targets) and not has_install and all(pred_count[target] == 1 for target in targets)
+        overlaps = bool(targets) and not has_install and all(preds[target] == 1 for target in targets)
         # The drained boundary is the latest cycle a value LANDS in this block's frame, taken per op -- a pooled result
         # and an inline result both write the array combinationally and land at the same bank-independent cycle. Three
         # landings are INVISIBLE to the op schedule and are added explicitly: (1) a phi tail install -- one whose source
@@ -173,8 +170,8 @@ def schedule_with_overlap(
         # boundary, paying neither the +1 step nor the later drain; (2) a NON-coalesced state slot's read-first boundary
         # copy lands at ``boundary_step(sched.makespan)`` -- its source is among the op landings, but the copy adds the
         # fetch-pipeline; ``has_state_copy`` flags whether the lone Ret block has one, decided by the coalescing
-        # fixpoint -- a coalesced slot writes its register in place and needs no copy, so the charge clears; (3) the
-        # entry's input loads land on cycle 1.
+        # fixpoint -- a coalesced slot writes its register in place and needs no copy, so the charge usually clears
+        # (the fixpoint may latch it back on); (3) the entry's input loads land on cycle 1.
         work_drain = max(
             (_value_word_and_landing(mir, vid, issue, fetch_lag)[1] for vid, issue in sched.issue_cycle.items()),
             default=0,

--- a/holoso/_lir/_liveness.py
+++ b/holoso/_lir/_liveness.py
@@ -68,9 +68,9 @@ class BankLiveness:
     boundary_users: dict[int, frozenset[ValueId]] = field(default_factory=dict)  # block -> boundary-read values
     arm_out: dict[int, frozenset[ValueId]] = field(default_factory=dict)  # block -> phi-arm values live out of it
     # block -> {phi dest installed at its tail: the install's block-local FIRE step}. The fire step is per install, not
-    # per block: a computed-source copy fires at its copy step, an install of a block-entry-resident source (const,
-    # input, state read) one read-first edge earlier, so its destination register is occupied from the true (earlier)
-    # write cycle and a tenant cannot be clobbered.
+    # per block: a computed-source copy fires at its copy step, an install of a block-entry-resident source
+    # (``value_resident_at_entry``) one read-first edge earlier, so its destination register is occupied from the true
+    # (earlier) write cycle and a tenant cannot be clobbered.
     installs: dict[int, dict[ValueId, int]] = field(default_factory=dict)
     # Cross-block overlap: per block, a predecessor value whose in-flight write SPILLS past the predecessor's shrunk
     # terminator and lands in THIS block, mapped to its block-local landing cycle. The spilled write fires

--- a/holoso/_lir/_mir_facts.py
+++ b/holoso/_lir/_mir_facts.py
@@ -31,15 +31,22 @@ def mir_operation(mir: Mir, vid: ValueId) -> MirOperation:
 def value_resident_at_entry(node: MirNode) -> bool:
     """
     Whether a value is resident in its register from a block's first step rather than produced by the block's own work:
-    a literal constant, an input load, or a persistent-state read. A value computed in some block (an operator result or
-    a phi) is NOT entry-resident -- it lands mid/late-block. One input to a tail install's PLACEMENT: a resident source
-    is available from block entry, so the install sits at the work makespan and pays no terminator cycle; a computed
-    source sits there too but is pushed one step when it is the block's own last-committing work (decided by its commit
-    cycle in ``install_issue_cycle``). The lone source of this residency fact, shared by the install seed, the
-    post-coalescing refinement, the builder, and the allocator residence, so they cannot drift. The positive test means
-    a future node kind defaults to non-resident -- the safe direction (the conservative computed-source treatment).
+    a literal constant, an input load, a persistent-state read, or a phi result. A phi is entry-resident in any
+    frontend-generated (well-formed, dominance-respecting) MIR: its register settles before any frame that reads it
+    begins -- install-bearing predecessors drain rather than overlap, multi-predecessor blocks receive no spills, and a
+    phi is never itself an in-flight spill. Residency decides a tail install's PLACEMENT (``install_issue_cycle``):
+    every resident-source install sits AT the work makespan, so installs that read each other's registers (the
+    cross-referencing loop-header phis of ``a, b = b, a + x``) share one fire step, where both backends resolve them as
+    a read-then-write parallel bundle; classifying a phi as computed instead pushes its install one step past its
+    siblings, which then read an already-overwritten source. An operator result stays NOT entry-resident: locally it
+    genuinely lands mid/late-block, and a foreign one may arrive as an overlap spill; its conservative pushed placement
+    is harmless because an operator-result source is live through the boundary (``phi_arm_out``), so interference keeps
+    every sibling install destination off its register. The lone source of this residency fact, shared by the install
+    seed, the post-coalescing refinement, the builder, and the allocator residence, so they cannot drift. The positive
+    test means a future node kind defaults to non-resident -- the safe direction (the conservative computed-source
+    treatment).
     """
-    return isinstance(node, (MirConst, MirInput, MirStateRead))
+    return isinstance(node, (MirConst, MirInput, MirStateRead, MirPhi))
 
 
 def succ_map(mir: Mir) -> dict[int, list[int]]:
@@ -53,6 +60,18 @@ def succ_map(mir: Mir) -> dict[int, list[int]]:
             case MirRet():
                 succ[block.id] = []
     return succ
+
+
+def pred_count(mir: Mir) -> dict[int, int]:
+    """
+    Predecessor EDGE count per block (a both-arms-same-target branch counts twice): the multi-predecessor fact that
+    gates cross-block overlap in the layout and underpins the phi-residency premise checked by the builder.
+    """
+    count: dict[int, int] = {block.id: 0 for block in mir.blocks}
+    for targets in succ_map(mir).values():
+        for target in targets:
+            count[target] += 1
+    return count
 
 
 def mir_rpo(mir: Mir) -> list[int]:
@@ -97,9 +116,9 @@ def const_branch_conditions(mir: Mir, bool_mir: MirBoolView) -> dict[int, ValueI
     """
     Per block, the constant branch condition it materializes at its tail. A block whose ``MirBranch`` tests a globally
     interned boolean constant has no condition register, so the constant is written into a bool register in the
-    branching block. The single source of this CFG-shape fact, shared by ``block_has_install`` and the install fixpoint
-    seed (which must agree, or the monotonicity assert trips) and the allocator's materialization (which also needs the
-    condition value to write).
+    branching block. The single source of this CFG-shape fact, shared by ``block_has_install`` (whose key universe the
+    install fixpoint asserts every post-allocation classification stays within) and the allocator's materialization
+    (which also needs the condition value to write).
     """
     conditions: dict[int, ValueId] = {}
     for block in mir.blocks:
@@ -112,8 +131,8 @@ def const_branch_conditions(mir: Mir, bool_mir: MirBoolView) -> dict[int, ValueI
 def block_has_install(mir: Mir, float_mir: MirFloatView, bool_mir: MirBoolView) -> dict[int, bool]:
     """
     Each install-bearing block mapped to whether it carries a COMPUTED-source install -- a float copy or a bool write
-    whose source is produced by the block's own work (an operator result or phi) rather than block-entry RESIDENT (a
-    literal constant, including a phi-arm const arm or a const branch condition, an input, or a state read). This is the
+    whose source is an operator result rather than block-entry RESIDENT (a literal constant, including a phi-arm const
+    arm or a const branch condition, an input, a state read, or a phi result). This is the
     CONSERVATIVE seed for the makespan +1: a computed source MIGHT be the block's own last work, which the install must
     fire one step past to read-first (pushing the makespan); the fixpoint's ``actual_install_blocks`` narrows it to the
     blocks that actually push, once the schedule is known. Determinable from the MIR shape before register assignment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "numpy~=2.4",
     "scipy~=1.17",
-    "zkf~=0.2.1",
+    "zkf~=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/synth/__init__.py
+++ b/synth/__init__.py
@@ -4,9 +4,12 @@ Out-of-context (OOC) synthesis-evaluation harness for Holoso-generated modules.
 Concrete flows are imported per tool so pulling in one does not require the others. A generated module's only
 dependency is the bundled support library, so the flow needs nothing beyond the synthesis result::
 
+    from holoso import SynthesisResult
+    from synth import build_compiler_ooc_design
     from synth.flows.yosys import YosysEcp5Flow, Ecp5Device
     result: SynthesisResult = ...  # See holoso API
-    artifact = YosysEcp5Flow(device=Ecp5Device(), target_frequency_MHz=100.0).prepare(result)
+    design = build_compiler_ooc_design(result)
+    artifact = YosysEcp5Flow(device=Ecp5Device(), target_frequency_MHz=100.0).prepare(design)
     report = artifact.synthesize()
     print(report.fmax_MHz, report.slack_ns, report.resources["DSP"].used)
 
@@ -15,4 +18,7 @@ Tool availability is discovered at runtime by checking the `$PATH` and searching
 """
 
 from ._ooc import build_ooc_wrapper as build_ooc_wrapper
+from ._synth import OocDesign as OocDesign
+from ._synth import SourceFile as SourceFile
+from ._synth import build_compiler_ooc_design as build_compiler_ooc_design
 from ._synth import SynthReport as SynthReport

--- a/synth/__main__.py
+++ b/synth/__main__.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from holoso import synthesize, FloatFormat, OpConfig
 
-from ._synth import BUILD_ROOT, SynthReport
+from ._synth import BUILD_ROOT, SynthReport, build_compiler_ooc_design
 from .flows import Flow, FlowId, make_flow
 
 
@@ -217,7 +217,7 @@ def _run_flow(
     try:
         result = synthesize(target, ops=ops, name=name)
         result.write(directory / "holoso_result")
-        return flow.prepare(result).synthesize(directory)
+        return flow.prepare(build_compiler_ooc_design(result)).synthesize(directory)
     except Exception as exc:  # one tool's failure must not stop the others
         return _Failure(type(flow).__name__, directory, str(exc))
 

--- a/synth/_synth.py
+++ b/synth/_synth.py
@@ -1,16 +1,17 @@
 import os
+import re
 import shlex
 import subprocess
 import tempfile
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 from holoso import SynthesisResult
 
 from ._flow_id import FlowId
-from ._ooc import OocWrapper
+from ._ooc import build_ooc_wrapper
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUILD_ROOT = REPO_ROOT / "build" / "synth"
@@ -80,8 +81,27 @@ class SynthReport:
 
 @dataclass(frozen=True, slots=True)
 class SourceFile:
-    path: Path  # relative to the artifact directory
+    path: Path
     content: str
+
+    def __post_init__(self) -> None:
+        if self.path.is_absolute() or not self.path.parts or ".." in self.path.parts:
+            raise ValueError(f"source path must stay relative to the artifact directory: {self.path}")
+
+
+@dataclass(frozen=True, slots=True)
+class OocDesign:
+    top: str
+    files: Sequence[SourceFile]
+
+    def __post_init__(self) -> None:
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", self.top) is None:
+            raise ValueError(f"invalid OOC top name: {self.top!r}")
+        files = tuple(self.files)
+        _validate_unique_source_paths(files)
+        if not files or any(source.path.suffix != ".v" for source in files):
+            raise ValueError("OOC designs require at least one Verilog-2005 .v source file")
+        object.__setattr__(self, "files", files)
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,14 +115,22 @@ class CommandSpec:
 class SynthArtifact:
     flow: FlowId
     top: str
-    files: list[SourceFile]
+    files: Sequence[SourceFile]
     commands: list[CommandSpec]
     runner: Callable[[Path], SynthReport]
 
+    def __post_init__(self) -> None:
+        files = tuple(self.files)
+        _validate_unique_source_paths(files)
+        object.__setattr__(self, "files", files)
+
     def write(self, directory: Path) -> None:
         directory.mkdir(parents=True, exist_ok=True)
+        root = directory.resolve()
         for source in self.files:
-            target = directory / source.path
+            target = (directory / source.path).resolve()
+            if not target.is_relative_to(root):
+                raise ValueError(f"source path escapes artifact directory: {source.path}")
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(source.content, encoding="utf-8")
 
@@ -112,13 +140,21 @@ class SynthArtifact:
         return self.runner(target)
 
 
-def assemble(result: SynthesisResult, wrapper: OocWrapper) -> list[SourceFile]:
+def _validate_unique_source_paths(files: Sequence[SourceFile]) -> None:
+    paths = [source.path for source in files]
+    if len(paths) != len(set(paths)):
+        raise ValueError("OOC source paths must be unique")
+
+
+def build_compiler_ooc_design(result: SynthesisResult) -> OocDesign:
     """
     A generated module instantiates only support-library modules, all of which live inside the single bundled
     ``holoso_support.v``; nothing else is needed. Everything is bundled in memory so a recipe directory is
     self-contained.
     """
-    return [SourceFile(Path(name), content) for name, content in result.verilog_output.support_files.items()] + [
+    wrapper = build_ooc_wrapper(result)
+    files = [SourceFile(Path(name), content) for name, content in result.verilog_output.support_files.items()] + [
         SourceFile(Path(f"{result.module_name}.v"), result.verilog_output.verilog),
         SourceFile(Path(f"{wrapper.top}.v"), wrapper.verilog),
     ]
+    return OocDesign(top=wrapper.top, files=files)

--- a/synth/flows/_flow.py
+++ b/synth/flows/_flow.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 
-from holoso import SynthesisResult
-
-from .._synth import SynthArtifact
+from .._synth import OocDesign, SynthArtifact
 
 
 class Flow(ABC):
@@ -10,4 +8,4 @@ class Flow(ABC):
     def available(self) -> bool: ...
 
     @abstractmethod
-    def prepare(self, result: SynthesisResult) -> SynthArtifact: ...
+    def prepare(self, design: OocDesign) -> SynthArtifact: ...

--- a/synth/flows/diamond.py
+++ b/synth/flows/diamond.py
@@ -5,11 +5,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from holoso import SynthesisResult
-
 from .._detect import find_tool
-from .._ooc import build_ooc_wrapper
-from .._synth import CommandSpec, ResourceUse, SourceFile, SynthArtifact, SynthReport, assemble, run_logged
+from .._synth import CommandSpec, OocDesign, ResourceUse, SourceFile, SynthArtifact, SynthReport, run_logged
 from .._flow_id import FlowId
 from ._flow import Flow
 
@@ -35,11 +32,10 @@ class DiamondEcp5Flow(Flow):
             return False
         return (diamond.resolve().parent / "diamond_env").is_file() or find_tool("pnmainc") is not None
 
-    def prepare(self, result: SynthesisResult) -> SynthArtifact:
-        wrapper = build_ooc_wrapper(result)
-        top = wrapper.top
-        src = assemble(result, wrapper)
-        verilog_paths = [sf.path for sf in src if sf.path.suffix == ".v"]
+    def prepare(self, design: OocDesign) -> SynthArtifact:
+        top = design.top
+        src = design.files
+        verilog_paths = [source.path for source in src]
 
         lpf = SourceFile(Path(f"{top}.lpf"), _lpf(self.target_frequency_MHz))
         sty = SourceFile(Path(f"{top}.sty"), _strategy(self.target_frequency_MHz))
@@ -116,9 +112,8 @@ def _ldf(top: str, device: str, verilog_paths: list[Path]) -> str:
     ]
     for path in verilog_paths:
         rel = _xml_attr(path.as_posix())
-        is_top = path.stem == top
         lines.append(f'        <Source name="{rel}" type="Verilog" type_short="Verilog">')
-        lines.append(f'            <Options top_module="{_xml_attr(top)}"/>' if is_top else "            <Options/>")
+        lines.append("            <Options/>")
         lines.append("        </Source>")
     lines += [
         f'        <Source name="{top}.lpf" type="Logic Preference" type_short="LPF">',
@@ -196,6 +191,7 @@ def _parse(flow: DiamondEcp5Flow, directory: Path) -> SynthReport:
             _resource(r"Number of LUT4s:\s+([0-9]+) out of ([0-9]+)", mrp, "LUT4"),
             _resource(r"SLICE\s+([0-9]+)/([0-9]+)", par, "SLICE"),
             _resource(r"PIO \(prelim\)\s+([0-9]+)/([0-9]+)", par, "PIO"),
+            _resource(r"MULT18\s+([0-9]+)/([0-9]+)", par, "MULT18"),
         )
         if use is not None
     }

--- a/synth/flows/vivado.py
+++ b/synth/flows/vivado.py
@@ -4,11 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from holoso import SynthesisResult
-
 from .._detect import find_tool, require_tool
-from .._ooc import build_ooc_wrapper
-from .._synth import CommandSpec, ResourceUse, SourceFile, SynthArtifact, SynthReport, assemble, run_logged
+from .._synth import CommandSpec, OocDesign, ResourceUse, SourceFile, SynthArtifact, SynthReport, run_logged
 from .._flow_id import FlowId
 from ._flow import Flow
 
@@ -33,11 +30,10 @@ class VivadoArtix7Flow(Flow):
     def available(self) -> bool:
         return find_tool("vivado") is not None
 
-    def prepare(self, result: SynthesisResult) -> SynthArtifact:
-        wrapper = build_ooc_wrapper(result)
-        top = wrapper.top
-        src = assemble(result, wrapper)
-        verilog_paths = [sf.path for sf in src if sf.path.suffix == ".v"]
+    def prepare(self, design: OocDesign) -> SynthArtifact:
+        top = design.top
+        src = design.files
+        verilog_paths = [source.path for source in src]
 
         period_ns = 1000.0 / self.target_frequency_MHz
         xdc = SourceFile(Path(_XDC), f"create_clock -name clk -period {period_ns:.4f} [get_ports clk]\n")
@@ -61,7 +57,7 @@ class VivadoArtix7Flow(Flow):
 
 
 def _tcl(top: str, part: str, verilog_paths: list[Path]) -> str:
-    read_list = " ".join(path.as_posix() for path in verilog_paths)
+    read_list = " ".join(_tcl_quote(path.as_posix()) for path in verilog_paths)
     return "\n".join(
         [
             f"read_verilog [list {read_list}]",
@@ -76,6 +72,13 @@ def _tcl(top: str, part: str, verilog_paths: list[Path]) -> str:
             "",
         ]
     )
+
+
+def _tcl_quote(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$").replace("[", "\\[").replace("]", "\\]")
+    )
+    return f'"{escaped}"'
 
 
 def _parse_utilization(text: str) -> dict[str, ResourceUse]:

--- a/synth/flows/yosys.py
+++ b/synth/flows/yosys.py
@@ -3,11 +3,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from holoso import SynthesisResult
-
 from .._detect import find_tool, require_tool
-from .._ooc import build_ooc_wrapper
-from .._synth import CommandSpec, ResourceUse, SourceFile, SynthArtifact, SynthReport, assemble, run_logged
+from .._synth import CommandSpec, OocDesign, ResourceUse, SourceFile, SynthArtifact, SynthReport, run_logged
 from .._flow_id import FlowId
 from ._flow import Flow
 
@@ -35,11 +32,11 @@ class YosysEcp5Flow(Flow):
     def available(self) -> bool:
         return find_tool("yosys") is not None and find_tool("nextpnr-ecp5") is not None
 
-    def prepare(self, result: SynthesisResult) -> SynthArtifact:
-        wrapper = build_ooc_wrapper(result)
-        top = wrapper.top
-        src = assemble(result, wrapper)
-        script = SourceFile(Path(_SCRIPT), _yosys_script(top, result.module_name))
+    def prepare(self, design: OocDesign) -> SynthArtifact:
+        top = design.top
+        src = design.files
+        verilog_paths = [source.path for source in src]
+        script = SourceFile(Path(_SCRIPT), _yosys_script(top, verilog_paths))
 
         nextpnr_args: list[str] = [
             f"--{self.device.size}",
@@ -72,13 +69,10 @@ class YosysEcp5Flow(Flow):
         return SynthArtifact(flow=FlowId.YOSYS_ECP5, top=top, files=[*src, script], commands=commands, runner=runner)
 
 
-def _yosys_script(top: str, dut_module: str) -> str:
-    # The support library is self-contained, so every instantiated module is already in scope after these reads.
+def _yosys_script(top: str, verilog_paths: list[Path]) -> str:
     return "\n".join(
         [
-            "read_verilog -I . holoso_support.v",
-            f"read_verilog -I . {dut_module}.v",
-            f"read_verilog -I . {top}.v",
+            *(f"read_verilog -I . {json.dumps(path.as_posix(), ensure_ascii=False)}" for path in verilog_paths),
             f"hierarchy -check -top {top}",
             # Retiming underperforms on many OOC targets today, apparently around the fmul DSP/packer boundary.
             # Revisit this if future Yosys/nextpnr versions or RTL changes make retiming consistently beneficial.

--- a/synth/test_integer_ooc.py
+++ b/synth/test_integer_ooc.py
@@ -1,0 +1,767 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+
+import pytest
+from holoso._backend.verilog._support import support_files
+from synth import OocDesign, SourceFile
+
+from synth._ooc import KEEP_ATTR
+from synth._synth import BUILD_ROOT
+from synth.flows import FlowId, make_flow
+
+_SATURATING = ("holoso_iadds", "holoso_isubs", "holoso_iabss")
+_SINGLE_OUTPUT = ("holoso_ashift",)
+_UNARY = frozenset(("holoso_iabss",))
+
+
+@dataclass(frozen=True, slots=True)
+class _Target:
+    operator: str
+    width: int
+    flow: FlowId
+    target_frequency_MHz: float
+
+    @property
+    def label(self) -> str:
+        return f"{self.operator}-w{self.width}-{self.flow.value}-{self.target_frequency_MHz:g}MHz"
+
+
+@dataclass(frozen=True, slots=True)
+class _MultiplierTarget:
+    width: int
+    flow: FlowId
+    target_frequency_MHz: float
+    stage_product: int
+    latency: int
+
+    def __post_init__(self) -> None:
+        assert self.latency == 2 + self.stage_product
+
+    @property
+    def label(self) -> str:
+        return f"holoso_imuls-w{self.width}-s{self.stage_product}-{self.flow.value}-{self.target_frequency_MHz:g}MHz"
+
+
+@dataclass(frozen=True, slots=True)
+class _DividerTarget:
+    width: int
+    quotient_floor: int
+    flow: FlowId
+    target_frequency_MHz: float
+    latency: int
+
+    def __post_init__(self) -> None:
+        assert self.quotient_floor in (0, 1)
+        assert self.latency == 2 + (self.width + 1) // 2
+
+    @property
+    def label(self) -> str:
+        return (
+            f"holoso_idivs-w{self.width}-f{self.quotient_floor}-" f"{self.flow.value}-{self.target_frequency_MHz:g}MHz"
+        )
+
+
+_TARGETS = tuple(
+    _Target(operator, width, flow, frequency)
+    for operator in (*_SATURATING, "holoso_icmp", *_SINGLE_OUTPUT)
+    for width in (24, 44)
+    for flow, frequency in (
+        (FlowId.YOSYS_ECP5, 100.0),
+        (FlowId.DIAMOND_ECP5, 100.0),
+        (FlowId.VIVADO_ARTIX7, 150.0),
+    )
+)
+
+_MULTIPLIER_TARGETS = (
+    _MultiplierTarget(24, FlowId.YOSYS_ECP5, 100.0, stage_product=3, latency=5),
+    _MultiplierTarget(24, FlowId.DIAMOND_ECP5, 100.0, stage_product=0, latency=2),
+    _MultiplierTarget(24, FlowId.VIVADO_ARTIX7, 150.0, stage_product=1, latency=3),
+    _MultiplierTarget(44, FlowId.YOSYS_ECP5, 100.0, stage_product=4, latency=6),
+    _MultiplierTarget(44, FlowId.DIAMOND_ECP5, 100.0, stage_product=4, latency=6),
+    _MultiplierTarget(44, FlowId.VIVADO_ARTIX7, 150.0, stage_product=4, latency=6),
+)
+
+_DIVIDER_TARGETS = (
+    _DividerTarget(24, 0, FlowId.YOSYS_ECP5, 100.0, latency=14),
+    _DividerTarget(24, 0, FlowId.DIAMOND_ECP5, 100.0, latency=14),
+    _DividerTarget(24, 0, FlowId.VIVADO_ARTIX7, 150.0, latency=14),
+    _DividerTarget(24, 1, FlowId.YOSYS_ECP5, 100.0, latency=14),
+    _DividerTarget(24, 1, FlowId.DIAMOND_ECP5, 100.0, latency=14),
+    _DividerTarget(24, 1, FlowId.VIVADO_ARTIX7, 150.0, latency=14),
+    _DividerTarget(44, 0, FlowId.YOSYS_ECP5, 100.0, latency=24),
+    _DividerTarget(44, 0, FlowId.DIAMOND_ECP5, 100.0, latency=24),
+    _DividerTarget(44, 0, FlowId.VIVADO_ARTIX7, 150.0, latency=24),
+    _DividerTarget(44, 1, FlowId.YOSYS_ECP5, 100.0, latency=24),
+    _DividerTarget(44, 1, FlowId.DIAMOND_ECP5, 100.0, latency=24),
+    _DividerTarget(44, 1, FlowId.VIVADO_ARTIX7, 150.0, latency=24),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _MixedTarget(ABC):
+    wexp: int
+    wman: int
+    wint: int
+    flow: FlowId
+    target_frequency_MHz: float
+
+    def _validate(self) -> None:
+        assert self.wexp >= 2
+        assert self.wman >= 4
+        assert self.wint >= 2
+
+    @property
+    @abstractmethod
+    def operator(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def latency(self) -> int:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def stage_label(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def label(self) -> str:
+        return (
+            f"{self.operator}-e{self.wexp}m{self.wman}-i{self.wint}-{self.stage_label}-"
+            f"{self.flow.value}-{self.target_frequency_MHz:g}MHz"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _FromIntTarget(_MixedTarget):
+    stage_input: int = 0
+    stage_normalize: int = 0
+    stage_pack: int = 0
+    stage_output: int = 0
+
+    def __post_init__(self) -> None:
+        self._validate()
+
+    @property
+    def operator(self) -> str:
+        return "holoso_ffromint"
+
+    @property
+    def latency(self) -> int:
+        return 1 + self.stage_input + self.stage_normalize + self.stage_pack + self.stage_output
+
+    @property
+    def stage_label(self) -> str:
+        return f"i{self.stage_input}n{self.stage_normalize}p{self.stage_pack}o{self.stage_output}"
+
+
+@dataclass(frozen=True, slots=True)
+class _ToIntTarget(_MixedTarget):
+    stage_input: int = 0
+
+    def __post_init__(self) -> None:
+        self._validate()
+
+    @property
+    def operator(self) -> str:
+        return "holoso_ftoint"
+
+    @property
+    def latency(self) -> int:
+        return 4 + self.stage_input
+
+    @property
+    def stage_label(self) -> str:
+        return f"i{self.stage_input}"
+
+
+@dataclass(frozen=True, slots=True)
+class _MulILog2Target(_MixedTarget):
+    stage_input: int = 0
+    stage_decode: int = 0
+
+    def __post_init__(self) -> None:
+        self._validate()
+
+    @property
+    def operator(self) -> str:
+        return "holoso_fmul_ilog2"
+
+    @property
+    def latency(self) -> int:
+        return 1 + self.stage_input + self.stage_decode
+
+    @property
+    def stage_label(self) -> str:
+        return f"i{self.stage_input}d{self.stage_decode}"
+
+
+_MIXED_TARGETS: tuple[_MixedTarget, ...] = (
+    *(
+        _FromIntTarget(wexp, wman, wint, flow, frequency, stage_normalize=1)
+        for wexp, wman, wint in ((6, 18, 24), (8, 36, 44))
+        for flow, frequency in ((FlowId.YOSYS_ECP5, 100.0), (FlowId.DIAMOND_ECP5, 100.0))
+    ),
+    *(_FromIntTarget(wexp, wman, wint, FlowId.VIVADO_ARTIX7, 150.0) for wexp, wman, wint in ((6, 18, 24), (8, 36, 44))),
+    *(
+        _ToIntTarget(6, 18, 24, flow, frequency)
+        for flow, frequency in (
+            (FlowId.YOSYS_ECP5, 100.0),
+            (FlowId.DIAMOND_ECP5, 100.0),
+            (FlowId.VIVADO_ARTIX7, 150.0),
+        )
+    ),
+    _ToIntTarget(8, 36, 44, FlowId.YOSYS_ECP5, 100.0, stage_input=1),
+    _ToIntTarget(8, 36, 44, FlowId.DIAMOND_ECP5, 100.0),
+    _ToIntTarget(8, 36, 44, FlowId.VIVADO_ARTIX7, 150.0),
+    *(
+        _MulILog2Target(6, 18, 24, flow, frequency)
+        for flow, frequency in (
+            (FlowId.YOSYS_ECP5, 100.0),
+            (FlowId.DIAMOND_ECP5, 100.0),
+            (FlowId.VIVADO_ARTIX7, 150.0),
+        )
+    ),
+    _MulILog2Target(8, 36, 44, FlowId.YOSYS_ECP5, 100.0),
+    _MulILog2Target(8, 36, 44, FlowId.DIAMOND_ECP5, 100.0, stage_decode=1),
+    _MulILog2Target(8, 36, 44, FlowId.VIVADO_ARTIX7, 150.0),
+)
+
+pytestmark = pytest.mark.synth
+
+
+def _build_ooc_design(operator: str, width: int) -> OocDesign:
+    top = f"{operator}_w{width}_ooc"
+    if operator == "holoso_icmp":
+        wrapper = _render_cmp_wrapper(top, width)
+    elif operator in _SINGLE_OUTPUT:
+        wrapper = _render_shift_wrapper(top, width)
+    else:
+        wrapper = _render_saturating_wrapper(top, operator, width)
+    files = [SourceFile(Path(name), content) for name, content in support_files().items()]
+    files.append(SourceFile(Path(f"{top}.v"), wrapper))
+    return OocDesign(top=top, files=files)
+
+
+def _build_multiplier_ooc_design(target: _MultiplierTarget) -> OocDesign:
+    top = f"holoso_imuls_w{target.width}_s{target.stage_product}_ooc"
+    parameters = f".W({target.width}), .STAGE_PRODUCT({target.stage_product}), .LATENCY({target.latency})"
+    wrapper = _render_saturating_wrapper(top, "holoso_imuls", target.width, parameters)
+    files = [SourceFile(Path(name), content) for name, content in support_files().items()]
+    files.append(SourceFile(Path(f"{top}.v"), wrapper))
+    return OocDesign(top=top, files=files)
+
+
+def _build_divider_ooc_design(target: _DividerTarget) -> OocDesign:
+    top = f"holoso_idivs_w{target.width}_f{target.quotient_floor}_ooc"
+    wrapper = _render_divider_wrapper(top, target.width, target.latency, target.quotient_floor)
+    files = [SourceFile(Path(name), content) for name, content in support_files().items()]
+    files.append(SourceFile(Path(f"{top}.v"), wrapper))
+    return OocDesign(top=top, files=files)
+
+
+def _build_mixed_ooc_design(target: _MixedTarget) -> OocDesign:
+    top = f"{target.operator.removeprefix('holoso_')}_e{target.wexp}m{target.wman}_i{target.wint}_ooc"
+    wrapper = _render_mixed_wrapper(top, target)
+    files = [SourceFile(Path(name), content) for name, content in support_files().items()]
+    files.append(SourceFile(Path(f"{top}.v"), wrapper))
+    return OocDesign(top=top, files=files)
+
+
+def _render_mixed_wrapper(top: str, target: _MixedTarget) -> str:
+    if isinstance(target, _FromIntTarget):
+        return _render_ffromint_wrapper(top, target)
+    if isinstance(target, _ToIntTarget):
+        return _render_ftoint_wrapper(top, target)
+    assert isinstance(target, _MulILog2Target)
+    return _render_fmul_ilog2_wrapper(top, target)
+
+
+def _render_ffromint_wrapper(top: str, target: _FromIntTarget) -> str:
+    wfull = target.wexp + target.wman
+    wio = max(wfull, target.wint)
+    zero_padding = f"{{{wio - wfull}{{1'b0}}}}"
+    return f"""`default_nettype none
+
+module {top} (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire in_sel,
+    input  wire [{wio - 1}:0] io_in,
+    output wire out_valid,
+    output wire [{wio - 1}:0] io_out
+);
+    {KEEP_ATTR} reg r_in_valid;
+    {KEEP_ATTR} reg signed [{target.wint - 1}:0] r_a;
+    {KEEP_ATTR} reg [1:0] r_y_sgnop;
+    wire dut_out_valid;
+    wire [{wfull - 1}:0] dut_y;
+    {KEEP_ATTR} reg r_out_valid;
+    {KEEP_ATTR} reg [{wfull - 1}:0] r_y;
+
+    assign out_valid = r_out_valid;
+    assign io_out = {{{zero_padding}, r_y}};
+
+    holoso_ffromint#(
+        .WEXP({target.wexp}), .WMAN({target.wman}), .WINT({target.wint}),
+        .STAGE_INPUT({target.stage_input}), .STAGE_NORMALIZE({target.stage_normalize}),
+        .STAGE_PACK({target.stage_pack}), .STAGE_OUTPUT({target.stage_output}), .LATENCY({target.latency})
+    ) dut (
+        .clk(clk), .rst(rst), .in_valid(r_in_valid), .a(r_a), .y_sgnop(r_y_sgnop),
+        .out_valid(dut_out_valid), .y(dut_y)
+    );
+
+    always @(posedge clk) begin
+        if (in_sel) r_y_sgnop <= io_in[1:0];
+        else        r_a <= io_in[{target.wint - 1}:0];
+        r_y <= dut_y;
+        if (rst) begin
+            r_in_valid <= 1'b0;
+            r_out_valid <= 1'b0;
+            r_y_sgnop <= 2'b00;
+        end else begin
+            r_in_valid <= in_valid;
+            r_out_valid <= dut_out_valid;
+        end
+    end
+endmodule
+
+`default_nettype wire
+"""
+
+
+def _render_ftoint_wrapper(top: str, target: _ToIntTarget) -> str:
+    wfull = target.wexp + target.wman
+    wio = max(wfull, target.wint)
+    zero_padding = f"{{{wio - target.wint}{{1'b0}}}}"
+    return f"""`default_nettype none
+
+module {top} (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire [1:0] in_sel,
+    input  wire [{wio - 1}:0] io_in,
+    output wire out_valid,
+    output wire [{wio - 1}:0] io_out
+);
+    {KEEP_ATTR} reg r_in_valid;
+    {KEEP_ATTR} reg [{wfull - 1}:0] r_a;
+    {KEEP_ATTR} reg [1:0] r_a_sgnop;
+    {KEEP_ATTR} reg [1:0] r_round_mode;
+    wire dut_out_valid;
+    wire signed [{target.wint - 1}:0] dut_y;
+    {KEEP_ATTR} reg r_out_valid;
+    {KEEP_ATTR} reg signed [{target.wint - 1}:0] r_y;
+
+    assign out_valid = r_out_valid;
+    assign io_out = {{{zero_padding}, r_y}};
+
+    holoso_ftoint#(
+        .WEXP({target.wexp}), .WMAN({target.wman}), .WINT({target.wint}),
+        .STAGE_INPUT({target.stage_input}), .LATENCY({target.latency})
+    ) dut (
+        .clk(clk), .rst(rst), .in_valid(r_in_valid), .a_sgnop(r_a_sgnop), .round_mode(r_round_mode), .a(r_a),
+        .out_valid(dut_out_valid), .y(dut_y)
+    );
+
+    always @(posedge clk) begin
+        case (in_sel)
+            2'd0: r_a <= io_in[{wfull - 1}:0];
+            2'd1: r_a_sgnop <= io_in[1:0];
+            2'd2: r_round_mode <= io_in[1:0];
+            default: ;
+        endcase
+        r_y <= dut_y;
+        if (rst) begin
+            r_in_valid <= 1'b0;
+            r_out_valid <= 1'b0;
+            r_a_sgnop <= 2'b00;
+            r_round_mode <= 2'b00;
+        end else begin
+            r_in_valid <= in_valid;
+            r_out_valid <= dut_out_valid;
+        end
+    end
+endmodule
+
+`default_nettype wire
+"""
+
+
+def _render_fmul_ilog2_wrapper(top: str, target: _MulILog2Target) -> str:
+    wfull = target.wexp + target.wman
+    wio = max(wfull, target.wint)
+    zero_padding = f"{{{wio - wfull}{{1'b0}}}}"
+    return f"""`default_nettype none
+
+module {top} (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire [1:0] in_sel,
+    input  wire [{wio - 1}:0] io_in,
+    output wire out_valid,
+    output wire [{wio - 1}:0] io_out
+);
+    {KEEP_ATTR} reg r_in_valid;
+    {KEEP_ATTR} reg [{wfull - 1}:0] r_a;
+    {KEEP_ATTR} reg signed [{target.wint - 1}:0] r_k;
+    {KEEP_ATTR} reg [1:0] r_a_sgnop;
+    {KEEP_ATTR} reg [1:0] r_y_sgnop;
+    wire dut_out_valid;
+    wire [{wfull - 1}:0] dut_y;
+    {KEEP_ATTR} reg r_out_valid;
+    {KEEP_ATTR} reg [{wfull - 1}:0] r_y;
+
+    assign out_valid = r_out_valid;
+    assign io_out = {{{zero_padding}, r_y}};
+
+    holoso_fmul_ilog2#(
+        .WEXP({target.wexp}), .WMAN({target.wman}), .WINT({target.wint}),
+        .STAGE_INPUT({target.stage_input}), .STAGE_DECODE({target.stage_decode}), .LATENCY({target.latency})
+    ) dut (
+        .clk(clk), .rst(rst), .in_valid(r_in_valid), .a_sgnop(r_a_sgnop), .y_sgnop(r_y_sgnop), .a(r_a), .k(r_k),
+        .out_valid(dut_out_valid), .y(dut_y)
+    );
+
+    always @(posedge clk) begin
+        case (in_sel)
+            2'd0: r_a <= io_in[{wfull - 1}:0];
+            2'd1: r_k <= io_in[{target.wint - 1}:0];
+            2'd2: r_a_sgnop <= io_in[1:0];
+            default: r_y_sgnop <= io_in[1:0];
+        endcase
+        r_y <= dut_y;
+        if (rst) begin
+            r_in_valid <= 1'b0;
+            r_out_valid <= 1'b0;
+            r_a_sgnop <= 2'b00;
+            r_y_sgnop <= 2'b00;
+        end else begin
+            r_in_valid <= in_valid;
+            r_out_valid <= dut_out_valid;
+        end
+    end
+endmodule
+
+`default_nettype wire
+"""
+
+
+def _render_divider_wrapper(top: str, width: int, latency: int, quotient_floor: int) -> str:
+    assert quotient_floor in (0, 1)
+    zero_padding = f"{{{width - 1}{{1'b0}}}}"
+    return f"""`default_nettype none
+
+module {top} (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire in_sel,
+    input  wire [{width - 1}:0] io_in,
+    output wire out_valid,
+    input  wire [1:0] out_sel,
+    output wire [{width - 1}:0] io_out
+);
+    {KEEP_ATTR} reg r_in_valid;
+    {KEEP_ATTR} reg [{width - 1}:0] r_num;
+    {KEEP_ATTR} reg [{width - 1}:0] r_den;
+    wire dut_out_valid;
+    wire [{width - 1}:0] dut_quo;
+    wire [{width - 1}:0] dut_rem;
+    wire dut_saturated;
+    wire dut_div0;
+    {KEEP_ATTR} reg r_out_valid;
+    {KEEP_ATTR} reg [{width - 1}:0] r_io_out;
+
+    assign out_valid = r_out_valid;
+    assign io_out = r_io_out;
+
+    holoso_idivs#(.W({width}), .QUOTIENT_FLOOR({quotient_floor}), .LATENCY({latency})) dut (
+        .clk(clk), .rst(rst), .in_valid(r_in_valid), .num(r_num), .den(r_den),
+        .out_valid(dut_out_valid), .quo(dut_quo), .rem(dut_rem), .saturated(dut_saturated), .div0(dut_div0)
+    );
+
+    always @(posedge clk) begin
+        if (in_sel) r_den <= io_in;
+        else        r_num <= io_in;
+        case (out_sel)
+            2'd0: r_io_out <= dut_quo;
+            2'd1: r_io_out <= dut_rem;
+            2'd2: r_io_out <= {{{zero_padding}, dut_saturated}};
+            default: r_io_out <= {{{zero_padding}, dut_div0}};
+        endcase
+        if (rst) begin
+            r_in_valid <= 1'b0;
+            r_out_valid <= 1'b0;
+        end else begin
+            r_in_valid <= in_valid;
+            r_out_valid <= dut_out_valid;
+        end
+    end
+endmodule
+
+`default_nettype wire
+"""
+
+
+def _render_saturating_wrapper(top: str, operator: str, width: int, parameters: str | None = None) -> str:
+    binary_port = f"    input  wire in_sel,\n" if operator not in _UNARY else ""
+    operand_reg = f"    {KEEP_ATTR} reg [{width - 1}:0] r_b;\n" if operator not in _UNARY else ""
+    operand_port = ", .b(r_b)" if operator not in _UNARY else ""
+    first_operand_port = "x" if operator in _UNARY else "a"
+    operand_load = (
+        "        if (in_sel) r_b <= io_in;\n        else        r_a <= io_in;"
+        if operator not in _UNARY
+        else ("        r_a <= io_in;")
+    )
+    parameters = parameters or f".W({width}), .LATENCY(2)"
+    return f"""`default_nettype none
+
+module {top} (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+{binary_port}    input  wire [{width - 1}:0] io_in,
+    output wire out_valid,
+    input  wire out_sel,
+    output wire [{width - 1}:0] io_out
+);
+    {KEEP_ATTR} reg r_in_valid;
+    {KEEP_ATTR} reg [{width - 1}:0] r_a;
+{operand_reg}    wire dut_out_valid;
+    wire [{width - 1}:0] dut_y;
+    wire dut_saturated;
+    {KEEP_ATTR} reg r_out_valid;
+    {KEEP_ATTR} reg [{width - 1}:0] r_y;
+    {KEEP_ATTR} reg r_saturated;
+    {KEEP_ATTR} reg [{width - 1}:0] r_io_out;
+
+    assign out_valid = r_out_valid;
+    assign io_out = r_io_out;
+
+    {operator}#({parameters}) dut (
+        .clk(clk), .rst(rst), .in_valid(r_in_valid), .{first_operand_port}(r_a){operand_port},
+        .out_valid(dut_out_valid), .y(dut_y), .saturated(dut_saturated)
+    );
+
+    always @(posedge clk) begin
+{operand_load}
+        r_y <= dut_y;
+        r_saturated <= dut_saturated;
+        r_io_out <= out_sel ? r_saturated : r_y;
+        if (rst) begin
+            r_in_valid <= 1'b0;
+            r_out_valid <= 1'b0;
+        end else begin
+            r_in_valid <= in_valid;
+            r_out_valid <= dut_out_valid;
+        end
+    end
+endmodule
+
+`default_nettype wire
+"""
+
+
+def _render_cmp_wrapper(top: str, width: int) -> str:
+    zero_padding = f"{{{width - 1}{{1'b0}}}}"
+    return f"""`default_nettype none
+
+module {top} (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire in_sel,
+    input  wire [{width - 1}:0] io_in,
+    output wire out_valid,
+    input  wire [1:0] out_sel,
+    output wire [{width - 1}:0] io_out
+);
+    {KEEP_ATTR} reg r_in_valid;
+    {KEEP_ATTR} reg [{width - 1}:0] r_a;
+    {KEEP_ATTR} reg [{width - 1}:0] r_b;
+    wire dut_out_valid;
+    wire dut_a_gt_b;
+    wire dut_a_eq_b;
+    wire dut_a_lt_b;
+    {KEEP_ATTR} reg r_out_valid;
+    {KEEP_ATTR} reg r_a_gt_b;
+    {KEEP_ATTR} reg r_a_eq_b;
+    {KEEP_ATTR} reg r_a_lt_b;
+    {KEEP_ATTR} reg [{width - 1}:0] r_io_out;
+
+    assign out_valid = r_out_valid;
+    assign io_out = r_io_out;
+
+    holoso_icmp#(.W({width}), .LATENCY(2)) dut (
+        .clk(clk), .rst(rst), .in_valid(r_in_valid), .a(r_a), .b(r_b), .out_valid(dut_out_valid),
+        .a_gt_b(dut_a_gt_b), .a_eq_b(dut_a_eq_b), .a_lt_b(dut_a_lt_b)
+    );
+
+    always @(posedge clk) begin
+        if (in_sel) r_b <= io_in;
+        else        r_a <= io_in;
+        r_a_gt_b <= dut_a_gt_b;
+        r_a_eq_b <= dut_a_eq_b;
+        r_a_lt_b <= dut_a_lt_b;
+        case (out_sel)
+            2'd0: r_io_out <= {{{zero_padding}, r_a_gt_b}};
+            2'd1: r_io_out <= {{{zero_padding}, r_a_eq_b}};
+            default: r_io_out <= {{{zero_padding}, r_a_lt_b}};
+        endcase
+        if (rst) begin
+            r_in_valid <= 1'b0;
+            r_out_valid <= 1'b0;
+        end else begin
+            r_in_valid <= in_valid;
+            r_out_valid <= dut_out_valid;
+        end
+    end
+endmodule
+
+`default_nettype wire
+"""
+
+
+def _render_shift_wrapper(top: str, width: int) -> str:
+    return f"""`default_nettype none
+
+module {top} (
+    input  wire clk,
+    input  wire rst,
+    input  wire in_valid,
+    input  wire in_sel,
+    input  wire [{width - 1}:0] io_in,
+    output wire out_valid,
+    output wire [{width - 1}:0] io_out
+);
+    {KEEP_ATTR} reg r_in_valid;
+    {KEEP_ATTR} reg [{width - 1}:0] r_x;
+    {KEEP_ATTR} reg [{width - 1}:0] r_shamt;
+    wire dut_out_valid;
+    wire [{width - 1}:0] dut_y;
+    {KEEP_ATTR} reg r_out_valid;
+    {KEEP_ATTR} reg [{width - 1}:0] r_y;
+    {KEEP_ATTR} reg [{width - 1}:0] r_io_out;
+
+    assign out_valid = r_out_valid;
+    assign io_out = r_io_out;
+
+    holoso_ashift#(.W({width}), .LATENCY(2)) dut (
+        .clk(clk), .rst(rst), .in_valid(r_in_valid), .x(r_x), .shamt(r_shamt),
+        .out_valid(dut_out_valid), .y(dut_y)
+    );
+
+    always @(posedge clk) begin
+        if (in_sel) r_shamt <= io_in;
+        else        r_x <= io_in;
+        r_y <= dut_y;
+        r_io_out <= r_y;
+        if (rst) begin
+            r_in_valid <= 1'b0;
+            r_out_valid <= 1'b0;
+        end else begin
+            r_in_valid <= in_valid;
+            r_out_valid <= dut_out_valid;
+        end
+    end
+endmodule
+
+`default_nettype wire
+"""
+
+
+@pytest.mark.parametrize("target", _TARGETS, ids=lambda target: target.label)
+def test_integer_operator_closes_timing(target: _Target) -> None:
+    flow = make_flow(target.flow, target.target_frequency_MHz)
+    if not flow.available():
+        pytest.skip(f"{target.flow.value} tool not available")
+
+    directory = BUILD_ROOT / "integer" / target.label
+    shutil.rmtree(directory, ignore_errors=True)
+    report = flow.prepare(_build_ooc_design(target.operator, target.width)).synthesize(directory)
+    assert report.fmax_MHz >= target.target_frequency_MHz, (
+        f"{target.label}: f_max {report.fmax_MHz:.2f} MHz < target {target.target_frequency_MHz:.2f} MHz "
+        f"(slack {report.slack_ns:+.3f} ns); logs in {report.artifact_dir}"
+    )
+
+
+@pytest.mark.parametrize("target", _MULTIPLIER_TARGETS, ids=lambda target: target.label)
+def test_integer_multiplier_closes_timing(target: _MultiplierTarget) -> None:
+    flow = make_flow(target.flow, target.target_frequency_MHz)
+    if not flow.available():
+        pytest.skip(f"{target.flow.value} tool not available")
+
+    directory = BUILD_ROOT / "integer" / target.label
+    shutil.rmtree(directory, ignore_errors=True)
+    report = flow.prepare(_build_multiplier_ooc_design(target)).synthesize(directory)
+    assert report.fmax_MHz >= target.target_frequency_MHz, (
+        f"{target.label}: f_max {report.fmax_MHz:.2f} MHz < target {target.target_frequency_MHz:.2f} MHz "
+        f"(slack {report.slack_ns:+.3f} ns); logs in {report.artifact_dir}"
+    )
+    dsp_used = sum(
+        resource.used for name, resource in report.resources.items() if "DSP" in name.upper() or "MULT" in name.upper()
+    )
+    assert dsp_used > 0, f"{target.label}: no DSP resources reported; logs in {report.artifact_dir}"
+
+
+@pytest.mark.parametrize("target", _DIVIDER_TARGETS, ids=lambda target: target.label)
+def test_integer_divider_closes_timing(target: _DividerTarget) -> None:
+    flow = make_flow(target.flow, target.target_frequency_MHz)
+    if not flow.available():
+        pytest.skip(f"{target.flow.value} tool not available")
+
+    directory = BUILD_ROOT / "integer" / target.label
+    shutil.rmtree(directory, ignore_errors=True)
+    report = flow.prepare(_build_divider_ooc_design(target)).synthesize(directory)
+    assert report.fmax_MHz >= target.target_frequency_MHz, (
+        f"{target.label}: f_max {report.fmax_MHz:.2f} MHz < target {target.target_frequency_MHz:.2f} MHz "
+        f"(slack {report.slack_ns:+.3f} ns); logs in {report.artifact_dir}"
+    )
+    dsp_used = sum(
+        resource.used for name, resource in report.resources.items() if "DSP" in name.upper() or "MULT" in name.upper()
+    )
+    assert dsp_used == 0, f"{target.label}: unexpected DSP resources reported; logs in {report.artifact_dir}"
+
+
+@pytest.mark.parametrize("target", _MIXED_TARGETS, ids=lambda target: target.label)
+def test_mixed_operator_closes_timing(target: _MixedTarget) -> None:
+    flow = make_flow(target.flow, target.target_frequency_MHz)
+    if not flow.available():
+        pytest.skip(f"{target.flow.value} tool not available")
+
+    directory = BUILD_ROOT / "integer" / target.label
+    shutil.rmtree(directory, ignore_errors=True)
+    report = flow.prepare(_build_mixed_ooc_design(target)).synthesize(directory)
+    assert report.fmax_MHz >= target.target_frequency_MHz, (
+        f"{target.label}: f_max {report.fmax_MHz:.2f} MHz < target {target.target_frequency_MHz:.2f} MHz "
+        f"(slack {report.slack_ns:+.3f} ns); logs in {report.artifact_dir}"
+    )
+    if target.operator == "holoso_fmul_ilog2":
+        dsp_used = sum(
+            resource.used
+            for name, resource in report.resources.items()
+            if "DSP" in name.upper() or "MULT" in name.upper()
+        )
+        assert dsp_used == 0, f"{target.label}: unexpected DSP resources reported; logs in {report.artifact_dir}"
+
+
+def test_mixed_wrapper_registers_native_result_width() -> None:
+    from_int = _render_ffromint_wrapper("top", _FromIntTarget(6, 18, 44, FlowId.YOSYS_ECP5, 100.0))
+    to_int = _render_ftoint_wrapper("top", _ToIntTarget(8, 36, 24, FlowId.YOSYS_ECP5, 100.0))
+    mul_ilog2 = _render_fmul_ilog2_wrapper("top", _MulILog2Target(6, 18, 44, FlowId.YOSYS_ECP5, 100.0))
+    assert "reg [23:0] r_y;" in from_int
+    assert "reg signed [23:0] r_y;" in to_int
+    assert "input  wire [1:0] in_sel," in to_int
+    assert "reg [1:0] r_round_mode;" in to_int
+    assert ".round_mode(r_round_mode)" in to_int
+    assert "reg [23:0] r_y;" in mul_ilog2
+    assert "r_io_out" not in from_int
+    assert "r_io_out" not in to_int
+    assert "r_io_out" not in mul_ilog2

--- a/synth/test_ooc.py
+++ b/synth/test_ooc.py
@@ -1,11 +1,12 @@
 import re
+from pathlib import Path
 
 import pytest
 
 from holoso import synthesize, SynthesisResult, FloatFormat
 from holoso import FAddOperator, FCmpOperator, FDivOperator, FMulILog2OperatorFamily, FMulOperator, OpConfig
 
-from synth import SynthReport, build_ooc_wrapper
+from synth import OocDesign, SourceFile, SynthReport, build_compiler_ooc_design, build_ooc_wrapper
 from synth.flows import FlowId
 from synth.flows.diamond import DiamondEcp5Flow
 from synth.flows.vivado import VivadoArtix7Flow
@@ -41,6 +42,27 @@ WIDE: SynthesisResult = synthesize(wide, ops=OPS, name="wide")
 
 requires_diamond = pytest.mark.skipif(not DiamondEcp5Flow().available(), reason="Lattice Diamond not found")
 requires_vivado = pytest.mark.skipif(not VivadoArtix7Flow().available(), reason="Vivado not found")
+
+
+def _artifact_file(design: OocDesign, flow: YosysEcp5Flow | VivadoArtix7Flow, path: str) -> str:
+    artifact = flow.prepare(design)
+    return next(source.content for source in artifact.files if source.path == Path(path))
+
+
+def test_flow_scripts_quote_source_paths() -> None:
+    design = OocDesign("top", [SourceFile(Path("rtl dir/$unit[0].v"), "module top; endmodule\n")])
+    yosys = _artifact_file(design, YosysEcp5Flow(), "synth.ys")
+    vivado = _artifact_file(design, VivadoArtix7Flow(), "run_vivado.tcl")
+    assert 'read_verilog -I . "rtl dir/$unit[0].v"' in yosys
+    assert 'read_verilog [list "rtl dir/\\$unit\\[0\\].v"]' in vivado
+
+
+def test_ooc_design_snapshots_source_files() -> None:
+    source = SourceFile(Path("top.v"), "module top; endmodule\n")
+    files = [source]
+    design = OocDesign("top", files)
+    files.append(SourceFile(Path("late.v"), ""))
+    assert design.files == (source,)
 
 
 def _native_data_bits(result: SynthesisResult) -> int:
@@ -85,7 +107,7 @@ def _assert_sane(report: SynthReport, flow: FlowId) -> None:
 
 def test_yosys_ecp5_end_to_end() -> None:
     wrapper = build_ooc_wrapper(KERN)
-    report = YosysEcp5Flow(target_frequency_MHz=100.0).prepare(KERN).synthesize()
+    report = YosysEcp5Flow(target_frequency_MHz=100.0).prepare(build_compiler_ooc_design(KERN)).synthesize()
     _assert_sane(report, FlowId.YOSYS_ECP5)
     # Out of context: no IO pads, so the bounded primary IO is the only boundary.
     assert report.resources["TRELLIS_IO"].used == 0
@@ -96,14 +118,14 @@ def test_yosys_ecp5_end_to_end() -> None:
 
 def test_yosys_ecp5_wide_selectors_synthesize() -> None:
     # A kernel whose selectors are multi-bit must still elaborate and route.
-    report = YosysEcp5Flow(target_frequency_MHz=100.0).prepare(WIDE).synthesize()
+    report = YosysEcp5Flow(target_frequency_MHz=100.0).prepare(build_compiler_ooc_design(WIDE)).synthesize()
     _assert_sane(report, FlowId.YOSYS_ECP5)
     assert report.resources["TRELLIS_IO"].used == 0
 
 
 @requires_diamond
 def test_diamond_ecp5_end_to_end() -> None:
-    report = DiamondEcp5Flow(target_frequency_MHz=100.0).prepare(KERN).synthesize()
+    report = DiamondEcp5Flow(target_frequency_MHz=100.0).prepare(build_compiler_ooc_design(KERN)).synthesize()
     _assert_sane(report, FlowId.DIAMOND_ECP5)
     # The muxed wrapper bounds the pin count, so Diamond's PIO usage stays small and the design fits real pins.
     pio = report.resources.get("PIO")
@@ -112,7 +134,7 @@ def test_diamond_ecp5_end_to_end() -> None:
 
 @requires_vivado
 def test_vivado_end_to_end() -> None:
-    report = VivadoArtix7Flow(target_frequency_MHz=100.0).prepare(KERN).synthesize()
+    report = VivadoArtix7Flow(target_frequency_MHz=100.0).prepare(build_compiler_ooc_design(KERN)).synthesize()
     _assert_sane(report, FlowId.VIVADO_ARTIX7)
     assert report.resources["Slice LUTs"].used > 0
     assert report.resources["Slice Registers"].used > 0

--- a/tests/_modelref.py
+++ b/tests/_modelref.py
@@ -425,6 +425,63 @@ def phi_swap_loop(x: float, n: float) -> float:
     return a * 2.0 + b
 
 
+def phi_swap_computed_loop(x: float, n: float) -> float:
+    """
+    The computed-arm variant of :func:`phi_swap_loop`: one cross-referencing back-edge arm is a value COMPUTED in the
+    body (``a + x``), not another phi. The pure swap cannot catch an install-placement (ordering) regression, because
+    both of its latch installs have phi sources and land on one placement PC, staying parallel however they are placed;
+    here the latch mixes a phi-sourced install with a computed-source install, whose placements are derived differently,
+    so it pins the LIR-level invariant that no tail install may fire after a sibling install has overwritten its source
+    register. The model and the RTL replay the same LIR, so the Python reference (not interp==model) is the oracle.
+    With integer-valued inputs every output is exact in the format.
+    """
+    a = 0.0
+    b = 1.0
+    i = n
+    while i > 0.0:
+        a, b = b, a + x
+        i = i - 1.0
+    return a * 2.0 + b
+
+
+def bool_phi_swap_computed_loop(x: bool, n: float) -> tuple[bool, bool]:
+    """
+    The boolean-bank twin of :func:`phi_swap_computed_loop`: the same cross-referencing loop-header phis with one
+    computed back-edge arm, carried in the 1-bit bank so the latch installs are ``BoolWrite``s rather than
+    ``FloatCopy``s. The two banks derive install placement through the same helpers but emit through separate paths,
+    so each needs its own pin.
+    """
+    a = False
+    b = True
+    i = n
+    while i > 0.0:
+        a, b = b, a or x
+        i = i - 1.0
+    return a, b
+
+
+def branchy_swap_mixed_arm_loop(x: float, d: float, n: float) -> tuple[float, float]:
+    """
+    A loop whose header phis mix arm kinds across a real in-body branch (the unspeculatable division keeps it a
+    branch): one diamond arm carries computed values, the other a phi-sourced pair. Once phi sources are resident, a
+    block's push classification narrows after its computed arm coalesces, and the next allocation round's coalescing
+    holds that arm TRANSIENTLY de-coalesced -- its install past the shortened boundary -- so this kernel pins that the
+    interference residence tolerates the transient (the failure mode is a loud residence assert at build time, not a
+    value divergence). The pin/latch regrowth backstops in the same fixpoint remain analytically motivated with no
+    known witness kernel.
+    """
+    a = 1.0
+    b = 2.0
+    i = n
+    while i > 0.0:
+        if x > 0.0:
+            a, b = a - 1.0, a / d
+        else:
+            a, b = -b, b + a
+        i = i - 1.0
+    return a, b
+
+
 def overlap_drained_passthrough_kernel(x: float, y: float, z: float) -> float:
     """
     A wide chain ``w`` computed in the overlapping entry block spills past the shrunk terminator into a then arm that

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -156,10 +156,10 @@ def _from_polar_kernel() -> Callable[..., object]:
 # One measured CORDIC config per polar kernel closes all three flows, so the three per-flow rows share it (unlike the
 # per-flow stage knobs elsewhere in the matrix).
 _TO_POLAR_FATAN2 = FAtan2Operator(F_e6m18, unroll100=50, stage_pack=1, stage_normalize=2, stage_product=3)
-_FROM_POLAR_FSINCOS = FSincosOperator(F_e6m18, stage_pack=1, stage_product=2, stage_normalize=1)
+_FROM_POLAR_FSINCOS = FSincosOperator(F_e6m18, stage_pack=1, stage_product=2, stage_normalize=2)
 # kepler's fsincos (coalesced sin+cos per Newton iteration) dominates timing, so its measured closure coincides with
 # from_polar's -- the same operator -- and one config closes all three flows.
-_KEPLER_FSINCOS = FSincosOperator(F_e6m18, stage_pack=1, stage_product=2, stage_normalize=1)
+_KEPLER_FSINCOS = FSincosOperator(F_e6m18, stage_pack=1, stage_product=2, stage_normalize=2)
 
 
 TARGETS: list[SynthTarget] = [
@@ -330,6 +330,7 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
+            fmul=FMulOperator(F_e6m18, stage_pack=1),
             fexp2=FExp2Operator(F_e6m18, stage_reduce=1, stage_product=2),
             flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=2, stage_pack=1),
         ),
@@ -350,6 +351,7 @@ TARGETS: list[SynthTarget] = [
         150,
         op_config(
             F_e6m18,
+            fadd=FAddOperator(F_e6m18, stage_normalize=1),
             fexp2=FExp2Operator(F_e6m18, stage_product=2),
             flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=1, stage_pack=1),
         ),
@@ -547,7 +549,7 @@ TARGETS: list[SynthTarget] = [
         kernel=_from_polar_kernel,
         flow=FlowId.VIVADO_ARTIX7,
         target_frequency_MHz=150,
-        ops=op_config(F_e6m18, fsincos=_FROM_POLAR_FSINCOS),
+        ops=op_config(F_e6m18, fmul=FMulOperator(F_e6m18, stage_input=1), fsincos=_FROM_POLAR_FSINCOS),
         name="from_polar_e6m18",
     ),
     # kepler: fsincos inside a data-dependent Newton back-edge loop -- the only II>1 operator in a loop in the matrix.

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -330,7 +330,7 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fexp2=FExp2Operator(F_e6m18, stage_product=2),
+            fexp2=FExp2Operator(F_e6m18, stage_reduce=1, stage_product=2),
             flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=1, stage_pack=1),
         ),
     ),

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -331,7 +331,7 @@ TARGETS: list[SynthTarget] = [
         op_config(
             F_e6m18,
             fexp2=FExp2Operator(F_e6m18, stage_reduce=1, stage_product=2),
-            flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=1, stage_pack=1),
+            flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=2, stage_pack=1),
         ),
     ),
     for_example(

--- a/tests/hdl/hdl_integer_oracle.py
+++ b/tests/hdl/hdl_integer_oracle.py
@@ -1,0 +1,16 @@
+def signed(bits: int, width: int) -> int:
+    sign = 1 << (width - 1)
+    return bits - (1 << width) if bits & sign else bits
+
+
+def ashift(a_bits: int, b_bits: int, width: int) -> int:
+    mask = (1 << width) - 1
+    b = signed(b_bits, width)
+    if b >= 0:
+        if b >= width:
+            return 0
+        return (a_bits << b) & mask
+    a = signed(a_bits, width)
+    if b <= -width:
+        return mask if a < 0 else 0
+    return (a >> -b) & mask

--- a/tests/hdl/holoso_support_fn_tb.v
+++ b/tests/hdl/holoso_support_fn_tb.v
@@ -4,6 +4,17 @@
 
 `default_nettype none
 
+module holoso_ashiftc_tb #(parameter W = 24) (
+    input  wire signed [W-1:0] x,
+    input  wire signed [W-1:0] shamt,
+    output wire signed [W-1:0] y
+);
+    localparam WEXP = 1;
+    localparam WMAN = W - WEXP;
+    `include "holoso_support_inline.vh"
+    assign y = holoso_ashiftc(x, shamt);
+endmodule
+
 module holoso_fisfinite_tb #(parameter WEXP = 6, parameter WMAN = 18) (
     input  wire [WEXP+WMAN-1:0] x,
     output wire                 y

--- a/tests/hdl/test_ashiftc.py
+++ b/tests/hdl/test_ashiftc.py
@@ -1,0 +1,69 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import Timer
+from cocotb_tools.runner import get_runner
+
+from .hdl_float_oracle import HDL_DIR, REPO_ROOT, SIMULATORS, build_args, sources
+from .hdl_integer_oracle import ashift
+
+
+@cocotb.test()
+async def holoso_ashiftc_cocotb(dut: Any) -> None:
+    width = int(os.environ["HOLOSO_INTEGER_WIDTH"])
+    mask = (1 << width) - 1
+
+    async def check(a: int, b: int) -> None:
+        dut.x.value = a
+        dut.shamt.value = b
+        await Timer(1, unit="ns")
+        actual = int(dut.y.value) & mask
+        expected = ashift(a, b, width)
+        assert actual == expected, f"W={width} a=0x{a:x} b=0x{b:x}: got 0x{actual:x}, want 0x{expected:x}"
+
+    if width <= 6:
+        for a in range(1 << width):
+            for b in range(1 << width):
+                await check(a, b)
+    else:
+        minimum = 1 << (width - 1)
+        values = (0, 1, 2, minimum - 1, minimum, minimum + 1, mask - 1, mask)
+        shifts = tuple(value & mask for value in (0, 1, -1, width - 1, 1 - width, width, -width, width + 1, -width - 1))
+        for a in values:
+            for b in shifts:
+                await check(a, b)
+        rng = np.random.default_rng(12345)
+        for _ in range(1000):
+            await check(
+                int(rng.integers(0, 1 << width, dtype=np.uint64)),
+                int(rng.integers(0, 1 << width, dtype=np.uint64)),
+            )
+
+
+@pytest.mark.parametrize("width", (2, 3, 4, 5, 6, 24, 44), ids=lambda width: f"w{width}")
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_holoso_ashiftc(sim: str, width: int) -> None:
+    runner = get_runner(sim)
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"ashiftc_w{width}"
+    runner.build(
+        sources=[*sources(), Path(__file__).resolve().parent / "holoso_support_fn_tb.v"],
+        includes=[HDL_DIR],
+        hdl_toplevel="holoso_ashiftc_tb",
+        parameters={"W": width},
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="holoso_ashiftc_tb",
+        test_module="tests.hdl.test_ashiftc",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={"HOLOSO_INTEGER_WIDTH": str(width)},
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_ffromint.py
+++ b/tests/hdl/test_ffromint.py
@@ -1,0 +1,183 @@
+"""Direct HDL tests for the independent-width signed-integer-to-ZKF-float wrapper."""
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_tools.runner import get_runner
+from zkf import FromIntModel, ZkfFormat
+
+from .hdl_float_oracle import (
+    HDL_DIR,
+    PipelineScoreboard,
+    REPO_ROOT,
+    SGNOP_OPS,
+    SIMULATORS,
+    apply_sgnop,
+    build_args,
+    drive_reset,
+    get_random_count,
+    get_seed,
+    sources,
+    start_clock,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Config:
+    wexp: int
+    wman: int
+    wint: int
+    stage_input: int = 0
+    stage_normalize: int = 0
+    stage_pack: int = 0
+    stage_output: int = 0
+    default_latency: bool = False
+
+    @property
+    def model(self) -> FromIntModel:
+        return FromIntModel(
+            ZkfFormat(self.wexp, self.wman),
+            wint=self.wint,
+            stage_input=self.stage_input,
+            stage_normalize=self.stage_normalize,
+            stage_pack=self.stage_pack,
+            stage_output=self.stage_output,
+        )
+
+    @property
+    def label(self) -> str:
+        return (
+            f"e{self.wexp}m{self.wman}_i{self.wint}_"
+            f"i{self.stage_input}n{self.stage_normalize}p{self.stage_pack}o{self.stage_output}"
+            f"_default{int(self.default_latency)}"
+        )
+
+
+_CONFIGS = (
+    _Config(6, 18, 44),
+    _Config(6, 18, 44, stage_input=1, default_latency=True),
+    _Config(6, 18, 44, stage_normalize=1),
+    _Config(6, 18, 44, stage_pack=1),
+    _Config(6, 18, 44, stage_output=1),
+    _Config(6, 18, 44, stage_input=1, stage_normalize=1, stage_pack=1, stage_output=1),
+    _Config(8, 36, 24),
+    _Config(3, 4, 12),
+)
+
+
+def _signed_values(wman: int, wint: int) -> list[int]:
+    int_min = -(1 << (wint - 1))
+    int_max = (1 << (wint - 1)) - 1
+    values = {int_min, int_min + 1, -1, 0, 1, int_max - 1, int_max}
+    for shift in range(wint - 1):
+        values.update((-(1 << shift), 1 << shift))
+    for boundary in (1 << (wman - 1), 1 << wman, 1 << (wman + 1)):
+        for delta in (-3, -1, 0, 1, 3):
+            values.update((boundary + delta, -boundary - delta))
+    return sorted(value for value in values if int_min <= value <= int_max)
+
+
+@cocotb.test()
+async def holoso_ffromint_cocotb(dut: Any) -> None:
+    wexp = int(os.environ["HOLOSO_WEXP"])
+    wman = int(os.environ["HOLOSO_WMAN"])
+    wint = int(os.environ["HOLOSO_WINT"])
+    latency = int(os.environ["HOLOSO_EXPECTED_LATENCY"])
+    wfull = wexp + wman
+    fmt = ZkfFormat(wexp, wman)
+    int_mask = (1 << wint) - 1
+
+    assert len(dut.y) == wfull
+    await start_clock(dut)
+    await drive_reset(dut)
+
+    sb = PipelineScoreboard(dut, [("y", "y")], latency=latency)
+    rng = np.random.default_rng(get_seed())
+
+    async def step_idle() -> None:
+        dut.in_valid.value = 0
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        sb.sample()
+
+    async def step(a: int, y_sgnop: int) -> None:
+        expected = apply_sgnop(fmt.from_int(wint, a).bits, y_sgnop, wfull)
+        dut.a.value = a & int_mask
+        dut.y_sgnop.value = y_sgnop
+        dut.in_valid.value = 1
+        sb.push({"y": expected, "_desc": f"a={a} y_sgnop={y_sgnop}"})
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        sb.sample()
+
+    values = _signed_values(wman, wint)
+    for a in values:
+        await step(a, 0)
+    await sb.drain()
+
+    for y_sgnop in SGNOP_OPS:
+        for a in values:
+            await step(a, y_sgnop)
+    await sb.drain()
+
+    for _ in range(get_random_count()):
+        if rng.random() < 0.2:
+            await step_idle()
+        else:
+            await step(int(rng.integers(-(1 << (wint - 1)), 1 << (wint - 1))), int(rng.integers(0, 4)))
+    await sb.drain()
+
+    if latency > 1:
+        dut.a.value = 1
+        dut.y_sgnop.value = 0
+        dut.in_valid.value = 1
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert int(dut.out_valid.value) == 0
+        sb.queue.clear()
+
+    await drive_reset(dut)
+    for _ in range(latency + 2):
+        dut.in_valid.value = 0
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert int(dut.out_valid.value) == 0
+
+
+@pytest.mark.parametrize("config", _CONFIGS, ids=lambda config: config.label)
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_holoso_ffromint(sim: str, config: _Config) -> None:
+    model = config.model
+    parameters = dict(model.params)
+    if config.default_latency:
+        del parameters["LATENCY"]
+    runner = get_runner(sim)
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"ffromint_{config.label}"
+    runner.build(
+        sources=sources(),
+        includes=[HDL_DIR],
+        hdl_toplevel="holoso_ffromint",
+        parameters=parameters,
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="holoso_ffromint",
+        test_module="tests.hdl.test_ffromint",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={
+            "HOLOSO_WEXP": str(config.wexp),
+            "HOLOSO_WMAN": str(config.wman),
+            "HOLOSO_WINT": str(config.wint),
+            "HOLOSO_EXPECTED_LATENCY": str(model.latency),
+        },
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_fmul_ilog2.py
+++ b/tests/hdl/test_fmul_ilog2.py
@@ -1,0 +1,225 @@
+"""Direct HDL tests for the independent-width runtime ZKF power-of-two scaler."""
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_tools.runner import get_runner
+from zkf import MulIlog2Model, ZkfFormat
+
+from .hdl_float_oracle import (
+    HDL_DIR,
+    PipelineScoreboard,
+    REPO_ROOT,
+    SGNOP_OPS,
+    SIMULATORS,
+    apply_sgnop,
+    build_args,
+    drive_reset,
+    get_random_count,
+    get_seed,
+    sources,
+    start_clock,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Config:
+    wexp: int
+    wman: int
+    wint: int
+    stage_input: int = 0
+    stage_decode: int = 0
+
+    @property
+    def model(self) -> MulIlog2Model:
+        return MulIlog2Model(
+            ZkfFormat(self.wexp, self.wman),
+            wk=self.wint,
+            stage_input=self.stage_input,
+            stage_decode=self.stage_decode,
+        )
+
+    @property
+    def label(self) -> str:
+        return f"e{self.wexp}m{self.wman}_k{self.wint}_i{self.stage_input}d{self.stage_decode}"
+
+
+_CONFIGS = (
+    _Config(6, 18, 44),
+    _Config(6, 18, 44, stage_input=1),
+    _Config(6, 18, 44, stage_decode=1),
+    _Config(6, 18, 44, stage_input=1, stage_decode=1),
+    _Config(8, 36, 24),
+    _Config(5, 8, 3),
+)
+
+_DEFAULT_CONFIG = _Config(6, 18, 24, stage_input=1)
+
+
+def _directed_values(fmt: ZkfFormat) -> list[int]:
+    return [
+        fmt.zero().bits,
+        fmt.inf(0).bits,
+        fmt.inf(1).bits,
+        fmt.encode(-fmt.max).bits,
+        fmt.encode(-fmt.lowest).bits,
+        fmt.encode(-1).bits,
+        fmt.encode(1).bits,
+        fmt.encode(fmt.lowest).bits,
+        fmt.encode(fmt.max).bits,
+    ]
+
+
+def _shift_values(fmt: ZkfFormat, wint: int) -> list[int]:
+    int_min = -(1 << (wint - 1))
+    int_max = (1 << (wint - 1)) - 1
+    if wint <= 3:
+        return list(range(int_min, int_max + 1))
+    values = {
+        int_min,
+        -fmt.exp_inf,
+        -fmt.bias,
+        -2,
+        -1,
+        0,
+        1,
+        2,
+        fmt.bias,
+        fmt.exp_inf,
+        int_max,
+    }
+    return sorted(value for value in values if int_min <= value <= int_max)
+
+
+@cocotb.test()
+async def holoso_fmul_ilog2_cocotb(dut: Any) -> None:
+    wexp = int(os.environ["HOLOSO_WEXP"])
+    wman = int(os.environ["HOLOSO_WMAN"])
+    wint = int(os.environ["HOLOSO_WINT"])
+    latency = int(os.environ["HOLOSO_EXPECTED_LATENCY"])
+    wfull = wexp + wman
+    fmt = ZkfFormat(wexp, wman)
+    k_mask = (1 << wint) - 1
+
+    assert len(dut.y) == wfull
+    assert len(dut.k) == wint
+    await start_clock(dut)
+    await drive_reset(dut)
+
+    sb = PipelineScoreboard(dut, [("y", "y")], latency=latency)
+    rng = np.random.default_rng(get_seed())
+
+    async def step_idle() -> None:
+        dut.in_valid.value = 0
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        sb.sample()
+
+    async def step(a: int, k: int, a_sgnop: int, y_sgnop: int) -> None:
+        a_eff = apply_sgnop(a, a_sgnop, wfull)
+        expected = apply_sgnop(fmt.wrap(a_eff).mul_ilog2(k).bits, y_sgnop, wfull)
+        dut.a.value = a
+        dut.k.value = k & k_mask
+        dut.a_sgnop.value = a_sgnop
+        dut.y_sgnop.value = y_sgnop
+        dut.in_valid.value = 1
+        sb.push({"y": expected, "_desc": f"a=0x{a:x} k={k} ops=a{a_sgnop}y{y_sgnop}"})
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        sb.sample()
+
+    values = _directed_values(fmt)
+    shifts = _shift_values(fmt, wint)
+    for a in values:
+        for k in shifts:
+            await step(a, k, 0, 0)
+    await sb.drain()
+
+    for index, a_sgnop in enumerate(SGNOP_OPS):
+        for y_sgnop in SGNOP_OPS:
+            for offset, a in enumerate(values):
+                await step(a, shifts[(index + offset + y_sgnop) % len(shifts)], a_sgnop, y_sgnop)
+    await sb.drain()
+
+    int_min = -(1 << (wint - 1))
+    int_max = (1 << (wint - 1)) - 1
+    for _ in range(get_random_count()):
+        if rng.random() < 0.2:
+            await step_idle()
+        else:
+            a = fmt.wrap(int(rng.integers(0, 1 << wfull, dtype=np.uint64))).canonicalize().bits
+            await step(
+                a,
+                int(rng.integers(int_min, int_max + 1)),
+                int(rng.integers(0, 4)),
+                int(rng.integers(0, 4)),
+            )
+    await sb.drain()
+
+    if latency > 1:
+        dut.a.value = fmt.encode(1).bits
+        dut.k.value = 0
+        dut.a_sgnop.value = 0
+        dut.y_sgnop.value = 0
+        dut.in_valid.value = 1
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert int(dut.out_valid.value) == 0
+        sb.queue.clear()
+
+    await drive_reset(dut)
+    for _ in range(latency + 2):
+        dut.in_valid.value = 0
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert int(dut.out_valid.value) == 0
+
+
+@pytest.mark.parametrize("config", _CONFIGS, ids=lambda config: config.label)
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_holoso_fmul_ilog2(sim: str, config: _Config) -> None:
+    model = config.model
+    parameters = {name: value for name, value in model.params.items() if name != "WK"}
+    parameters["WINT"] = config.wint
+    _run(sim, config, model, parameters, config.label)
+
+
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_holoso_fmul_ilog2_defaults(sim: str) -> None:
+    config = _DEFAULT_CONFIG
+    model = config.model
+    parameters = {name: value for name, value in model.params.items() if name not in {"WK", "LATENCY"}}
+    _run(sim, config, model, parameters, "e6m18_defaults_i1d0")
+
+
+def _run(sim: str, config: _Config, model: MulIlog2Model, parameters: dict[str, int], label: str) -> None:
+    runner = get_runner(sim)
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fmul_ilog2_{label}"
+    runner.build(
+        sources=sources(),
+        includes=[HDL_DIR],
+        hdl_toplevel="holoso_fmul_ilog2",
+        parameters=parameters,
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="holoso_fmul_ilog2",
+        test_module="tests.hdl.test_fmul_ilog2",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={
+            "HOLOSO_WEXP": str(config.wexp),
+            "HOLOSO_WMAN": str(config.wman),
+            "HOLOSO_WINT": str(config.wint),
+            "HOLOSO_EXPECTED_LATENCY": str(model.latency),
+        },
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_ftoint.py
+++ b/tests/hdl/test_ftoint.py
@@ -1,0 +1,195 @@
+"""Direct HDL tests for the independent-width saturating ZKF-float-to-integer wrapper."""
+
+import os
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Any
+
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_tools.runner import get_runner
+from zkf import ToIntModel, ZkfFormat
+
+from .hdl_float_oracle import (
+    HDL_DIR,
+    PipelineScoreboard,
+    REPO_ROOT,
+    ROUND_MODES,
+    SGNOP_OPS,
+    SIMULATORS,
+    apply_sgnop,
+    build_args,
+    drive_reset,
+    get_random_count,
+    get_seed,
+    sources,
+    start_clock,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Config:
+    wexp: int
+    wman: int
+    wint: int
+    stage_input: int = 0
+
+    @property
+    def model(self) -> ToIntModel:
+        return ToIntModel(ZkfFormat(self.wexp, self.wman), wint=self.wint, stage_input=self.stage_input)
+
+    @property
+    def label(self) -> str:
+        return f"e{self.wexp}m{self.wman}_i{self.wint}_s{self.stage_input}"
+
+
+_CONFIGS = (_Config(6, 18, 44), _Config(6, 18, 44, 1), _Config(8, 36, 24), _Config(8, 36, 24, 1))
+
+
+def _directed_values(fmt: ZkfFormat, wint: int) -> list[int]:
+    int_min = -(1 << (wint - 1))
+    int_max = (1 << (wint - 1)) - 1
+    fractions = (
+        Fraction(-5, 2),
+        Fraction(-3, 2),
+        Fraction(-1, 2),
+        Fraction(-1, 4),
+        Fraction(0),
+        Fraction(1, 4),
+        Fraction(1, 2),
+        Fraction(3, 2),
+        Fraction(5, 2),
+        Fraction(int_min - 1),
+        Fraction(int_min) - Fraction(1, 2),
+        Fraction(int_min),
+        Fraction(int_min + 1),
+        Fraction(int_max - 1),
+        Fraction(int_max),
+        Fraction(int_max) + Fraction(1, 2),
+        Fraction(int_max + 1),
+        Fraction(int_max + 2),
+        -fmt.max,
+        -fmt.lowest,
+        fmt.lowest,
+        fmt.max,
+    )
+    values = {fmt.encode(value).bits for value in fractions}
+    values.update((fmt.inf(0).bits, fmt.inf(1).bits))
+    return sorted(values)
+
+
+def _integer_oracle(fmt: ZkfFormat, a: int, a_sgnop: int, round_mode: int, wint: int) -> int:
+    value = fmt.wrap(apply_sgnop(a, a_sgnop, fmt.wfull))
+    if round_mode == 0:
+        result = value.round_int(wint)
+    elif round_mode == 1:
+        result = value.floor_int(wint)
+    elif round_mode == 2:
+        result = value.ceil_int(wint)
+    else:
+        assert round_mode == 3
+        result = value.trunc_int(wint)
+    return result & ((1 << wint) - 1)
+
+
+@cocotb.test()
+async def holoso_ftoint_cocotb(dut: Any) -> None:
+    wexp = int(os.environ["HOLOSO_WEXP"])
+    wman = int(os.environ["HOLOSO_WMAN"])
+    wint = int(os.environ["HOLOSO_WINT"])
+    latency = int(os.environ["HOLOSO_EXPECTED_LATENCY"])
+    wfull = wexp + wman
+    fmt = ZkfFormat(wexp, wman)
+    assert len(dut.y) == wint
+    assert len(dut.round_mode) == 2
+    await start_clock(dut)
+    await drive_reset(dut)
+
+    sb = PipelineScoreboard(dut, [("y", "y")], latency=latency)
+    rng = np.random.default_rng(get_seed())
+
+    async def step_idle() -> None:
+        dut.in_valid.value = 0
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        sb.sample()
+
+    async def step(a: int, a_sgnop: int, round_mode: int) -> None:
+        expected = _integer_oracle(fmt, a, a_sgnop, round_mode, wint)
+        dut.a.value = a
+        dut.a_sgnop.value = a_sgnop
+        dut.round_mode.value = round_mode
+        dut.in_valid.value = 1
+        sb.push({"y": expected, "_desc": f"a=0x{a:x} a_sgnop={a_sgnop} round_mode={round_mode}"})
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        sb.sample()
+
+    values = _directed_values(fmt, wint)
+    for a in values:
+        for round_mode in ROUND_MODES:
+            await step(a, 0, round_mode)
+    await sb.drain()
+
+    for a_sgnop in SGNOP_OPS:
+        for round_mode in ROUND_MODES:
+            for a in values:
+                await step(a, a_sgnop, round_mode)
+    await sb.drain()
+
+    for _ in range(get_random_count()):
+        if rng.random() < 0.2:
+            await step_idle()
+        else:
+            a = fmt.wrap(int(rng.integers(0, 1 << wfull, dtype=np.uint64))).canonicalize().bits
+            await step(a, int(rng.integers(0, 4)), int(rng.integers(0, 4)))
+    await sb.drain()
+
+    dut.a.value = fmt.encode(1).bits
+    dut.a_sgnop.value = 0
+    dut.round_mode.value = 3
+    dut.in_valid.value = 1
+    await RisingEdge(dut.clk)
+    await Timer(1, unit="ns")
+    assert int(dut.out_valid.value) == 0
+    sb.queue.clear()
+
+    await drive_reset(dut)
+    for _ in range(latency + 2):
+        dut.in_valid.value = 0
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert int(dut.out_valid.value) == 0
+
+
+@pytest.mark.parametrize("config", _CONFIGS, ids=lambda config: config.label)
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_holoso_ftoint(sim: str, config: _Config) -> None:
+    model = config.model
+    runner = get_runner(sim)
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"ftoint_{config.label}"
+    runner.build(
+        sources=sources(),
+        includes=[HDL_DIR],
+        hdl_toplevel="holoso_ftoint",
+        parameters=model.params,
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="holoso_ftoint",
+        test_module="tests.hdl.test_ftoint",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={
+            "HOLOSO_WEXP": str(config.wexp),
+            "HOLOSO_WMAN": str(config.wman),
+            "HOLOSO_WINT": str(config.wint),
+            "HOLOSO_EXPECTED_LATENCY": str(model.latency),
+        },
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_idiv_radix4_step.py
+++ b/tests/hdl/test_idiv_radix4_step.py
@@ -1,0 +1,53 @@
+import os
+from typing import Any
+
+import cocotb
+import pytest
+from cocotb.triggers import Timer
+from cocotb_tools.runner import get_runner
+
+from .hdl_float_oracle import HDL_DIR, REPO_ROOT, SIMULATORS, build_args, sources
+
+
+@cocotb.test()
+async def idiv_radix4_step_cocotb(dut: Any) -> None:
+    width = int(os.environ["HOLOSO_IDIV_STEP_WIDTH"])
+    for den in range(1, 1 << width):
+        dut.den.value = den
+        dut.den3.value = 3 * den
+        for partial_rem in range(den):
+            dut.partial_rem.value = partial_rem
+            for next_bits in range(4):
+                dut.next_bits.value = next_bits
+                await Timer(1, unit="ns")
+                candidate = 4 * partial_rem + next_bits
+                expected_digit = candidate // den
+                expected_remainder = candidate % den
+                assert expected_digit <= 3
+                assert int(dut.digit.value) == expected_digit
+                assert int(dut.rem_next.value) == expected_remainder
+
+
+@pytest.mark.parametrize("width", range(2, 7), ids=lambda width: f"w{width}")
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_idiv_radix4_step(sim: str, width: int) -> None:
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"holoso_idiv_radix4_step_w{width}"
+    runner = get_runner(sim)
+    runner.build(
+        sources=sources(),
+        includes=[HDL_DIR],
+        hdl_toplevel="_holoso_idiv_radix4_step",
+        parameters={"W": width},
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="_holoso_idiv_radix4_step",
+        test_module="tests.hdl.test_idiv_radix4_step",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={"HOLOSO_IDIV_STEP_WIDTH": str(width)},
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_idivs.py
+++ b/tests/hdl/test_idivs.py
@@ -1,0 +1,175 @@
+import os
+from typing import Any
+
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_tools.runner import get_runner
+
+from .hdl_float_oracle import (
+    HDL_DIR,
+    REPO_ROOT,
+    SIMULATORS,
+    PipelineScoreboard,
+    build_args,
+    drive_reset,
+    sources,
+    start_clock,
+)
+from .hdl_integer_oracle import signed
+
+
+def _expected(num_bits: int, den_bits: int, width: int, quotient_floor: bool) -> dict[str, int | str]:
+    mask = (1 << width) - 1
+    minimum = -(1 << (width - 1))
+    maximum = (1 << (width - 1)) - 1
+    num = signed(num_bits, width)
+    den = signed(den_bits, width)
+    if den == 0:
+        quotient = minimum if num < 0 else maximum
+        remainder = num
+        saturated = 1
+        div0 = 1
+    elif num == minimum and den == -1:
+        quotient = maximum
+        remainder = 0
+        saturated = 1
+        div0 = 0
+    else:
+        if quotient_floor:
+            quotient = num // den
+        else:
+            quotient_magnitude = abs(num) // abs(den)
+            quotient = -quotient_magnitude if (num < 0) != (den < 0) else quotient_magnitude
+        remainder = num - den * quotient
+        saturated = 0
+        div0 = 0
+        assert num == den * quotient + remainder
+        assert abs(remainder) < abs(den)
+        if remainder:
+            assert (remainder < 0) == ((den if quotient_floor else num) < 0)
+    return {
+        "quo": quotient & mask,
+        "rem": remainder & mask,
+        "saturated": saturated,
+        "div0": div0,
+    }
+
+
+def _directed(width: int) -> list[int]:
+    minimum = -(1 << (width - 1))
+    maximum = (1 << (width - 1)) - 1
+    return sorted(
+        {
+            value & ((1 << width) - 1)
+            for value in (
+                minimum,
+                minimum + 1,
+                -3,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                3,
+                maximum - 1,
+                maximum,
+            )
+        }
+    )
+
+
+@cocotb.test()
+async def idivs_cocotb(dut: Any) -> None:
+    width = int(os.environ["HOLOSO_IDIVS_WIDTH"])
+    quotient_floor = bool(int(os.environ["HOLOSO_IDIVS_QUOTIENT_FLOOR"]))
+    latency = 2 + (width + 1) // 2
+    mask = (1 << width) - 1
+    scoreboard = PipelineScoreboard(
+        dut,
+        (("quo", "quo"), ("rem", "rem"), ("saturated", "saturated"), ("div0", "div0")),
+        latency=latency,
+    )
+    await start_clock(dut)
+    await drive_reset(dut)
+
+    async def step(num: int, den: int, valid: bool = True) -> None:
+        num &= mask
+        den &= mask
+        dut.num.value = num
+        dut.den.value = den
+        dut.in_valid.value = valid
+        if valid:
+            expected = _expected(num, den, width, quotient_floor)
+            expected["_desc"] = (
+                f"W={width} floor={int(quotient_floor)} num={signed(num, width)} den={signed(den, width)}"
+            )
+            scoreboard.push(expected)
+        await RisingEdge(dut.clk)
+        dut.num.value = (~num) & mask
+        dut.den.value = (~den) & mask
+        await Timer(1, unit="ns")
+        scoreboard.sample()
+
+    if width <= 6:
+        for num in range(1 << width):
+            for den in range(1 << width):
+                await step(num, den)
+    else:
+        directed = _directed(width)
+        for num in directed:
+            for den in directed:
+                await step(num, den)
+        rng = np.random.default_rng(int(os.environ.get("HOLOSO_TEST_SEED", "12345")))
+        for _ in range(int(os.environ.get("HOLOSO_IDIVS_RANDOM", "1000"))):
+            num = int(rng.integers(0, 1 << width, dtype=np.uint64))
+            den = int(rng.integers(0, 1 << width, dtype=np.uint64))
+            if rng.random() < 0.1:
+                den = int(rng.choice(np.array(_directed(width), dtype=np.uint64)))
+            await step(num, den, bool(rng.random() >= 0.2))
+
+    await scoreboard.drain()
+    for value in range(latency):
+        dut.num.value = value & mask
+        dut.den.value = (value + 1) & mask
+        dut.in_valid.value = 1
+        await RisingEdge(dut.clk)
+    dut.rst.value = 1
+    await RisingEdge(dut.clk)
+    dut.rst.value = 0
+    dut.in_valid.value = 0
+    for _ in range(latency + 2):
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert not int(dut.out_valid.value)
+
+
+@pytest.mark.parametrize("width", (*range(2, 7), 24, 44), ids=lambda width: f"w{width}")
+@pytest.mark.parametrize("quotient_floor", (0, 1), ids=lambda mode: "trunc" if mode == 0 else "floor")
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_idivs(sim: str, width: int, quotient_floor: int) -> None:
+    latency = 2 + (width + 1) // 2
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"holoso_idivs_w{width}_f{quotient_floor}"
+    runner = get_runner(sim)
+    runner.build(
+        sources=sources(),
+        includes=[HDL_DIR],
+        hdl_toplevel="holoso_idivs",
+        parameters={"W": width, "QUOTIENT_FLOOR": quotient_floor, "LATENCY": latency},
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="holoso_idivs",
+        test_module="tests.hdl.test_idivs",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={
+            "HOLOSO_IDIVS_WIDTH": str(width),
+            "HOLOSO_IDIVS_QUOTIENT_FLOOR": str(quotient_floor),
+        },
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_idivs_ooc_wrapper.py
+++ b/tests/hdl/test_idivs_ooc_wrapper.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from typing import Any
+
+import cocotb
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_tools.runner import get_runner
+
+from synth.test_integer_ooc import _render_divider_wrapper
+
+from .hdl_float_oracle import HDL_DIR, REPO_ROOT, build_args, drive_reset, sources, start_clock
+
+_WIDTH = 24
+_LATENCY = 14
+
+
+@cocotb.test()
+async def idivs_ooc_wrapper_cocotb(dut: Any) -> None:
+    await start_clock(dut)
+    await drive_reset(dut)
+    dut.out_sel.value = 0
+    dut.in_sel.value = 0
+    dut.io_in.value = 4
+    dut.in_valid.value = 0
+    await RisingEdge(dut.clk)
+    dut.in_sel.value = 1
+    dut.io_in.value = 3
+    await RisingEdge(dut.clk)
+
+    expected = [2, 3, 4, 5]
+    for numerator in (7, 10, 13, 16):
+        dut.in_sel.value = 0
+        dut.io_in.value = numerator
+        dut.in_valid.value = 1
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        if int(dut.out_valid.value):
+            assert int(dut.io_out.value) == expected.pop(0)
+
+    dut.in_valid.value = 0
+    for _ in range(_LATENCY + 6):
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        if int(dut.out_valid.value):
+            assert int(dut.io_out.value) == expected.pop(0)
+        if not expected:
+            return
+    assert not expected
+
+
+def test_idivs_ooc_wrapper_payload_alignment() -> None:
+    top = "holoso_idivs_ooc_wrapper_tb"
+    build_dir = REPO_ROOT / "build" / "cocotb" / "icarus" / top
+    wrapper = REPO_ROOT / "build" / "ooc_wrapper_sources" / f"{top}.v"
+    wrapper.parent.mkdir(parents=True, exist_ok=True)
+    wrapper.write_text(_render_divider_wrapper(top, _WIDTH, _LATENCY, 1), encoding="utf-8")
+    runner = get_runner("icarus")
+    runner.build(
+        sources=[*sources(), Path(wrapper)],
+        includes=[HDL_DIR],
+        hdl_toplevel=top,
+        build_args=build_args("icarus"),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel=top,
+        test_module="tests.hdl.test_idivs_ooc_wrapper",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_imuls.py
+++ b/tests/hdl/test_imuls.py
@@ -1,0 +1,149 @@
+import math
+import os
+from typing import Any
+
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_tools.runner import get_runner
+
+from .hdl_float_oracle import (
+    HDL_DIR,
+    REPO_ROOT,
+    SIMULATORS,
+    PipelineScoreboard,
+    build_args,
+    drive_reset,
+    sources,
+    start_clock,
+)
+from .hdl_integer_oracle import signed
+
+
+def _expected(a_bits: int, b_bits: int, width: int) -> dict[str, int | str]:
+    minimum = -(1 << (width - 1))
+    maximum = (1 << (width - 1)) - 1
+    exact = signed(a_bits, width) * signed(b_bits, width)
+    clamped = min(max(exact, minimum), maximum)
+    return {"y": clamped & ((1 << width) - 1), "saturated": int(clamped != exact)}
+
+
+def _directed(width: int) -> list[int]:
+    minimum = -(1 << (width - 1))
+    maximum = (1 << (width - 1)) - 1
+    root = math.isqrt(maximum)
+    values = {
+        minimum,
+        minimum + 1,
+        -(root + 1),
+        -root,
+        -2,
+        -1,
+        0,
+        1,
+        2,
+        root,
+        root + 1,
+        maximum - 1,
+        maximum,
+    }
+    return sorted(value & ((1 << width) - 1) for value in values)
+
+
+@cocotb.test()
+async def imuls_cocotb(dut: Any) -> None:
+    width = int(os.environ["HOLOSO_IMULS_WIDTH"])
+    stage_product = int(os.environ["HOLOSO_IMULS_STAGE_PRODUCT"])
+    latency = 2 + stage_product
+    mask = (1 << width) - 1
+    scoreboard = PipelineScoreboard(dut, (("y", "y"), ("saturated", "saturated")), latency=latency)
+    await start_clock(dut)
+    await drive_reset(dut)
+
+    async def step(a: int, b: int, valid: bool = True) -> None:
+        dut.a.value = a & mask
+        dut.b.value = b & mask
+        dut.in_valid.value = valid
+        if valid:
+            expected = _expected(a & mask, b & mask, width)
+            expected["_desc"] = (
+                f"W={width} stage={stage_product} a={signed(a & mask, width)} b={signed(b & mask, width)}"
+            )
+            scoreboard.push(expected)
+        await RisingEdge(dut.clk)
+        dut.a.value = (~a) & mask
+        dut.b.value = (~b) & mask
+        await Timer(1, unit="ns")
+        scoreboard.sample()
+
+    if width <= 6:
+        for a in range(1 << width):
+            for b in range(1 << width):
+                await step(a, b)
+    else:
+        directed = _directed(width)
+        for a in directed:
+            for b in directed:
+                await step(a, b)
+        rng = np.random.default_rng(int(os.environ.get("HOLOSO_TEST_SEED", "12345")))
+        for _ in range(int(os.environ.get("HOLOSO_IMULS_RANDOM", "512"))):
+            a = int(rng.integers(0, 1 << width, dtype=np.uint64))
+            b = int(rng.integers(0, 1 << width, dtype=np.uint64))
+            await step(a, b, bool(rng.random() >= 0.2))
+
+    await scoreboard.drain()
+
+    for value in range(latency):
+        dut.a.value = value & mask
+        dut.b.value = (value + 1) & mask
+        dut.in_valid.value = 1
+        await RisingEdge(dut.clk)
+    dut.rst.value = 1
+    await RisingEdge(dut.clk)
+    dut.rst.value = 0
+    dut.in_valid.value = 0
+    for _ in range(latency + 2):
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert not int(dut.out_valid.value)
+
+
+_CONFIGURATIONS = tuple((width, stage) for width in (*range(2, 7), 24, 44) for stage in range(5))
+
+
+@pytest.mark.parametrize(
+    ("width", "stage_product"),
+    _CONFIGURATIONS,
+    ids=lambda value: str(value),
+)
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_imuls(sim: str, width: int, stage_product: int) -> None:
+    runner = get_runner(sim)
+    tag = f"holoso_imuls_w{width}_s{stage_product}"
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / tag
+    runner.build(
+        sources=sources(),
+        includes=[HDL_DIR],
+        hdl_toplevel="holoso_imuls",
+        parameters={
+            "W": width,
+            "STAGE_PRODUCT": stage_product,
+            "LATENCY": 2 + stage_product,
+        },
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="holoso_imuls",
+        test_module="tests.hdl.test_imuls",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={
+            "HOLOSO_IMULS_WIDTH": str(width),
+            "HOLOSO_IMULS_STAGE_PRODUCT": str(stage_product),
+        },
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/hdl/test_integer.py
+++ b/tests/hdl/test_integer.py
@@ -1,0 +1,154 @@
+import os
+from typing import Any
+
+import cocotb
+import numpy as np
+import pytest
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_tools.runner import get_runner
+
+from .hdl_float_oracle import (
+    HDL_DIR,
+    REPO_ROOT,
+    SIMULATORS,
+    PipelineScoreboard,
+    build_args,
+    drive_reset,
+    sources,
+    start_clock,
+)
+from .hdl_integer_oracle import ashift, signed
+
+_OPERATORS = ("holoso_iadds", "holoso_isubs", "holoso_iabss", "holoso_icmp", "holoso_ashift")
+_UNARY = frozenset(("holoso_iabss",))
+
+
+def _expected(operator: str, a_bits: int, b_bits: int, width: int) -> dict[str, int | str]:
+    modulus = 1 << width
+    minimum = -(1 << (width - 1))
+    maximum = (1 << (width - 1)) - 1
+    a = signed(a_bits, width)
+    b = signed(b_bits, width)
+    if operator == "holoso_icmp":
+        return {"a_gt_b": int(a > b), "a_eq_b": int(a == b), "a_lt_b": int(a < b)}
+    if operator == "holoso_ashift":
+        return {"y": ashift(a_bits, b_bits, width)}
+    exact = {
+        "holoso_iadds": a + b,
+        "holoso_isubs": a - b,
+        "holoso_iabss": abs(a),
+    }[operator]
+    clamped = min(max(exact, minimum), maximum)
+    return {"y": clamped & (modulus - 1), "saturated": int(clamped != exact)}
+
+
+@cocotb.test()
+async def integer_operator_cocotb(dut: Any) -> None:
+    operator = os.environ["HOLOSO_INTEGER_OPERATOR"]
+    width = int(os.environ["HOLOSO_INTEGER_WIDTH"])
+    if operator == "holoso_icmp":
+        outputs = [("a_gt_b", "a_gt_b"), ("a_eq_b", "a_eq_b"), ("a_lt_b", "a_lt_b")]
+    elif operator == "holoso_ashift":
+        outputs = [("y", "y")]
+    else:
+        outputs = [("y", "y"), ("saturated", "saturated")]
+    scoreboard = PipelineScoreboard(dut, outputs, latency=2)
+    await start_clock(dut)
+    await drive_reset(dut)
+
+    async def step(a: int, b: int = 0, valid: bool = True) -> None:
+        if operator == "holoso_ashift":
+            dut.x.value = a
+            dut.shamt.value = b
+        elif operator == "holoso_iabss":
+            dut.x.value = a
+        else:
+            dut.a.value = a
+        if operator not in _UNARY and operator != "holoso_ashift":
+            dut.b.value = b
+        dut.in_valid.value = valid
+        if valid:
+            expected = _expected(operator, a, b, width)
+            expected["_desc"] = f"{operator} W={width} a=0x{a:x} b=0x{b:x}"
+            scoreboard.push(expected)
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        scoreboard.sample()
+
+    if width <= 6:
+        for a in range(1 << width):
+            if operator in _UNARY:
+                await step(a)
+            else:
+                for b in range(1 << width):
+                    await step(a, b)
+    else:
+        mask = (1 << width) - 1
+        minimum = 1 << (width - 1)
+        directed = [0, 1, 2, minimum - 1, minimum, minimum + 1, mask - 1, mask]
+        for a in directed:
+            if operator in _UNARY:
+                await step(a)
+            else:
+                operands_b = directed
+                if operator == "holoso_ashift":
+                    operands_b = [
+                        value & mask for value in (0, 1, -1, width - 1, 1 - width, width, -width, width + 1, -width - 1)
+                    ]
+                for b in operands_b:
+                    await step(a, b)
+        rng = np.random.default_rng(int(os.environ.get("HOLOSO_TEST_SEED", "12345")))
+        for _ in range(int(os.environ.get("HOLOSO_INTEGER_RANDOM", "1000"))):
+            b = int(rng.integers(0, 1 << width, dtype=np.uint64))
+            if operator == "holoso_ashift" and rng.random() < 0.5:
+                b = int(rng.integers(-width - 2, width + 3)) & mask
+            await step(int(rng.integers(0, 1 << width, dtype=np.uint64)), b, bool(rng.random() >= 0.2))
+
+    await scoreboard.drain()
+    mask = (1 << width) - 1
+    for value in range(4):
+        if operator == "holoso_ashift":
+            dut.x.value = value & mask
+            dut.shamt.value = (value + 1) & mask
+        elif operator == "holoso_iabss":
+            dut.x.value = value & mask
+        else:
+            dut.a.value = value & mask
+        if operator not in _UNARY and operator != "holoso_ashift":
+            dut.b.value = (value + 1) & mask
+        dut.in_valid.value = 1
+        await RisingEdge(dut.clk)
+    dut.rst.value = 1
+    await RisingEdge(dut.clk)
+    dut.rst.value = 0
+    dut.in_valid.value = 0
+    for _ in range(4):
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+        assert not int(dut.out_valid.value)
+
+
+@pytest.mark.parametrize("width", (2, 3, 4, 5, 6, 24, 44), ids=lambda width: f"w{width}")
+@pytest.mark.parametrize("operator", _OPERATORS)
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_integer_operator(sim: str, operator: str, width: int) -> None:
+    runner = get_runner(sim)
+    build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"{operator}_w{width}"
+    runner.build(
+        sources=sources(),
+        includes=[HDL_DIR],
+        hdl_toplevel=operator,
+        parameters={"W": width, "LATENCY": 2},
+        build_args=build_args(sim),
+        build_dir=build_dir,
+        clean=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel=operator,
+        test_module="tests.hdl.test_integer",
+        test_dir=REPO_ROOT,
+        build_dir=build_dir,
+        extra_env={"HOLOSO_INTEGER_OPERATOR": operator, "HOLOSO_INTEGER_WIDTH": str(width)},
+        results_xml=str(build_dir / "results.xml"),
+    )

--- a/tests/test_cosim.py
+++ b/tests/test_cosim.py
@@ -38,6 +38,7 @@ from ._modelref import (
     overlap_dead_arm_spill_kernel,
     overlap_div_err_kernel,
     overlap_spill_kernel,
+    phi_swap_computed_loop,
 )
 from .hdl.hdl_float_oracle import HDL_DIR, REPO_ROOT, SIMULATORS, build_args, sources
 
@@ -742,3 +743,15 @@ def test_cosim_tan_pole_latches_no_error(sim: str) -> None:
         {"x": fmt.encode(0.5)},
     ]
     run_cosim(sim, kernel, fmt, "cs_tan_pole", vectors=vectors)
+
+
+@pytest.mark.parametrize("sim", SIMULATORS)
+def test_cosim_phi_swap_computed_arm(sim: str) -> None:
+    # The RTL leg of the computed-arm swap regression (see test_interpret): the DUT replays the same LIR as the model,
+    # so this pins the emitted install words against the bench's bit-exact model across multi-trip loop executions.
+    # Explicit vectors keep the while trip count small; the bench's own sweep would draw huge counts.
+    fmt = FloatFormat(6, 18)
+    vectors: list[Mapping[str, int]] = [
+        {"x": fmt.encode(x), "n": fmt.encode(n)} for x in (1.0, 2.0, -1.5) for n in (1.0, 2.0, 4.0)
+    ]
+    run_cosim(sim, phi_swap_computed_loop, fmt, "cs_phi_swap_computed", vectors=vectors)

--- a/tests/test_install_landing.py
+++ b/tests/test_install_landing.py
@@ -72,13 +72,17 @@ def test_resident_register_source_install_is_inline_class() -> None:
     The generalization beyond literal constants: uart_rx installs the rx INPUT directly (b2 <- rx, b4 <- ~rx). A
     register source resident at block entry has nothing to read-first, so the install is classified inline-class
     (``resident_source``) and fires one cycle earlier than a computed-source copy -- exactly like a constant. Pin that
-    such a non-const resident-source install is present and so classified; a build that reverted inputs (or any entry-
-    resident value) to copy-class would leave this empty. The recovered cycles are pinned end-to-end by the uart_rx
-    freeze (127); here we pin that the input path is what is being exercised.
+    an INPUT-sourced install is present and so classified, matched by its source register against the input loads --
+    phi-sourced installs are also resident, so a resident-and-non-const filter alone could pass through a phi while the
+    input path regressed. The recovered cycles are pinned end-to-end by the uart_rx freeze (127); here we pin that the
+    input path is what is being exercised.
     """
     lir = _build(next(s for s in SPECS if s.name == "uart_rx"))
-    resident_non_const = [x for b in lir.blocks for x in _phi_arm_installs(b) if x.resident_source and not x.is_const]
-    assert resident_non_const, "uart_rx lost its non-const resident-source (input) install, or the predicate regressed"
+    input_regs = {load.dst for load in lir.inputs}
+    input_sourced = [
+        x for b in lir.blocks for x in _phi_arm_installs(b) if x.resident_source and x.source.source in input_regs
+    ]
+    assert input_sourced, "uart_rx lost its input-sourced resident install, or the predicate regressed"
 
 
 def test_computed_copy_not_last_work_fits_at_work_makespan() -> None:

--- a/tests/test_interpret.py
+++ b/tests/test_interpret.py
@@ -31,7 +31,9 @@ from ._modelref import (
     SlotSwap,
     Vector,
     assert_model_equals_interpreter,
+    bool_phi_swap_computed_loop,
     branch_boundary_kernel,
+    branchy_swap_mixed_arm_loop,
     build_model_and_interpreter,
     const_branch_kernel,
     default_ops,
@@ -41,6 +43,7 @@ from ._modelref import (
     overlap_drained_passthrough_kernel,
     overlap_livein_branch_arm_kernel,
     overlap_spill_kernel,
+    phi_swap_computed_loop,
     phi_swap_loop,
     random_legal_bits,
     staged_ops,
@@ -138,6 +141,64 @@ def test_loop_header_phi_swap_resolves_in_parallel() -> None:
             assert (
                 float(model_out[0]) == reference
             ), f"model != python at x={x} n={n}: {float(model_out[0])} vs {reference}"
+
+
+def test_loop_header_phi_swap_with_computed_arm_resolves_in_parallel() -> None:
+    """
+    The computed-arm swap (``a, b = b, a + x``): the latch mixes a phi-sourced install with a computed-source install,
+    so a placement that fires one tail install after a sibling has overwritten its source register miscompiles even
+    though the pure swap (same-placement installs) stays correct. Python is the oracle; the model and the RTL replay
+    the same LIR, and interp==model is asserted so a divergence localizes the guilty layer.
+    """
+    fmt = FloatFormat(6, 18)
+    model, interpreter = build_model_and_interpreter(phi_swap_computed_loop, default_ops(fmt), "phi_swap_computed")
+    for x in (1.0, 2.0, -1.5):
+        for n in (1.0, 2.0, 3.0, 4.0):
+            vector = [FloatValue.from_float(fmt, x), FloatValue.from_float(fmt, n)]
+            model_out = model.run(*vector)
+            interp_out = interpreter.run(*vector)
+            reference = phi_swap_computed_loop(x, n)
+            assert (
+                float(interp_out[0]) == reference
+            ), f"interp != python at x={x} n={n}: {float(interp_out[0])} vs {reference}"
+            assert model_out == interp_out, f"interp != model at x={x} n={n}"
+
+
+def test_bool_loop_header_phi_swap_with_computed_arm_resolves_in_parallel() -> None:
+    """The boolean-bank twin of the computed-arm swap: the latch installs are BoolWrites, not FloatCopys."""
+    fmt = FloatFormat(6, 18)
+    model, interpreter = build_model_and_interpreter(
+        bool_phi_swap_computed_loop, default_ops(fmt), "bool_phi_swap_computed"
+    )
+    for x in (False, True):
+        for n in (1.0, 2.0, 3.0, 4.0):
+            vector: Vector = [x, FloatValue.from_float(fmt, n)]
+            model_out = model.run(*vector)
+            interp_out = interpreter.run(*vector)
+            reference = bool_phi_swap_computed_loop(x, n)
+            assert (
+                bool(interp_out[0]),
+                bool(interp_out[1]),
+            ) == reference, f"interp != python at x={x} n={n}: {interp_out} vs {reference}"
+            assert model_out == interp_out, f"interp != model at x={x} n={n}"
+
+
+def test_mixed_arm_swap_diamond_builds_and_matches_python() -> None:
+    """
+    Pins transient tolerance in the install fixpoint: under a narrowing classification with a strict interference
+    residence bound this kernel does not even BUILD (the boundary shrinks below a transiently de-coalesced computed
+    arm's install and the residence assert trips), so the value grid is secondary to synthesis itself.
+    """
+    fmt = FloatFormat(6, 18)
+    model, interpreter = build_model_and_interpreter(branchy_swap_mixed_arm_loop, default_ops(fmt), "mixed_arm_swap")
+    for x in (1.0, -1.0):
+        for n in (1.0, 2.0, 3.0):
+            vector = [FloatValue.from_float(fmt, x), FloatValue.from_float(fmt, 4.0), FloatValue.from_float(fmt, n)]
+            model_out = model.run(*vector)
+            interp_out = interpreter.run(*vector)
+            reference = branchy_swap_mixed_arm_loop(x, 4.0, n)
+            assert (float(interp_out[0]), float(interp_out[1])) == reference, f"interp != python at x={x} n={n}"
+            assert model_out == interp_out, f"interp != model at x={x} n={n}"
 
 
 def test_state_slot_swap_writeback_is_parallel() -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -170,15 +170,15 @@ def _measure(name: str) -> Metrics:
 #   NOT-folding (a semantic NOT is a free consumer-side inversion), and cross-block software pipelining. Bool-phi
 #   if-conversion runs both arms unconditionally, so it can RAISE min_ii (the shortest static path) while LOWERING
 #   realized per-transaction latency -- the true goal, guarded by test_cycle_model. A converted diamond keeps both
-#   arms' values simultaneously live, so it can need an extra register -- the cost of the mux. Coalescing is
-#   layout-neutral and does not move min_ii.
+#   arms' values simultaneously live, so it can need an extra register -- the cost of the mux. Coalescing never
+#   changes behavior, but the surviving copy set feeds the drain/push classification, so min_ii can move with it.
 # - bnreg reflects exact per-consumer boolean read steps and phi coalescing: a condition consumed mid-block frees
 #   its register for a later value in the same block, and a boolean phi merging onto its arms drops its own register.
 # - last_pc and max_block_span are the stage-count guards. They reflect the per-block drain tightener: the
 #   coalesced-install fixpoint -- a phi-arm predecessor whose every arm coalesces installs nothing, so its
 #   +1 install drain is dropped. The drained boundary is the latest value LANDING per op: every op -- inline (a
 #   select or a bool->float cast) or pooled -- lands at the same uniform per-op landing, and an install reading a
-#   block-entry-RESIDENT source (constant, input, or state read) fires at the
+#   block-entry-RESIDENT source (``value_resident_at_entry``) fires at the
 #   combinational step and drops its +1 install drain. last_pc tiles every block's span (a per-block drain regression
 #   anywhere inflates it); max_block_span localizes it to one block. These timing rules move the schedule-length
 #   guards but not nreg/bnreg/steering/copies; signal_window carries a deliberately-loosened steering arm (one freed

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -84,6 +84,7 @@ from ._modelref import (
     PIPELINE_OP_CASES,
     SelectHold,
     branch_boundary_kernel,
+    build_model_and_interpreter,
     const_branch_kernel,
     default_ops,
     diamond_then_loop_kernel,
@@ -2694,3 +2695,80 @@ def _assert_two_firings_at_minimal_ii(lir: Lir, mnemonic: str) -> None:
     # Spacing must be EXACTLY the II: under-spacing drops a transaction, over-spacing means the scheduler failed to
     # pack the second issue at the re-accept boundary -- both are regressions.
     assert firings[1].issue_cycle - firings[0].issue_cycle == operator.initiation_interval
+
+
+def test_forced_install_regrowth_pins_and_stays_correct(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    White-box: no known kernel reaches the install fixpoint's pin backstop (regrowth is analytically motivated by the
+    non-monotone greedy coalescing, with no natural witness), so the first classification round is faked as fully
+    narrowed -- the real recomputation then reads as regrowth against it, driving the pin path -- and the converged
+    build must still match Python and the MIR interpreter. White-box is warranted because a black-box witness does
+    not exist; if one ever appears, it must replace this fake.
+    """
+    from holoso._lir import _build
+    from holoso._lir._bankalloc import actual_install_blocks as real_installs
+
+    def kernel(x: float, n: float) -> float:
+        a = 0.0
+        b = 1.0
+        i = n
+        while i > 0.0:
+            a, b = b, a + x * i  # the fadd is the block's last work, so the b-arm install genuinely pushes
+            i = i - 1.0
+        return a * 2.0 + b
+
+    calls = {"n": 0}
+
+    def fake_installs(*args: object) -> dict[int, bool]:
+        calls["n"] += 1
+        real = real_installs(*args)  # type: ignore[arg-type]
+        return {b: False for b in real} if calls["n"] == 1 else real
+
+    monkeypatch.setattr(_build, "actual_install_blocks", fake_installs)
+    fmt = FloatFormat(6, 18)
+    with caplog.at_level("INFO", logger="holoso._lir._build"):
+        model, interpreter = build_model_and_interpreter(kernel, default_ops(fmt), "forced_pin")
+    assert any("pinning regrown block" in r.message for r in caplog.records), "the faked narrowing did not pin"
+    for x in (1.0, -2.0):
+        for n in (1.0, 3.0):
+            vector = [FloatValue.from_float(fmt, x), FloatValue.from_float(fmt, n)]
+            model_out = model.run(*vector)
+            assert float(model_out[0]) == kernel(x, n), f"model != python at x={x} n={n}"
+            assert model_out == interpreter.run(*vector), f"interp != model at x={x} n={n}"
+
+
+def test_forced_state_copy_regrowth_latches_and_stays_correct(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The state-copy latch twin of the forced-pin test: a chained-copy kernel whose charge is faked away once."""
+    from holoso._lir import _build
+
+    class Delay2:
+        def __init__(self) -> None:
+            self.x0 = 0.0
+            self.x1 = 0.0
+
+        def __call__(self, x: float) -> float:
+            out = self.x1
+            self.x1 = self.x0
+            self.x0 = x
+            return out
+
+    real_state = _build._has_state_copy
+    calls = {"n": 0}
+
+    def fake_state(*args: object) -> bool:
+        calls["n"] += 1
+        return False if calls["n"] == 1 else real_state(*args)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(_build, "_has_state_copy", fake_state)
+    fmt = FloatFormat(8, 36)
+    with caplog.at_level("INFO", logger="holoso._lir._build"):
+        model, _interpreter = build_model_and_interpreter(Delay2().__call__, default_ops(fmt), "forced_latch")
+    assert any("latching the state-copy charge" in r.message for r in caplog.records), "the fake did not latch"
+    reference = Delay2()
+    for raw in (1.0, 2.0, 3.0, 4.0, 5.0):
+        x = fmt.decode(fmt.encode(raw))
+        assert float(model.run(x)[0]) == reference(x)

--- a/tests/test_synth_examples.py
+++ b/tests/test_synth_examples.py
@@ -15,7 +15,7 @@ import shutil
 import pytest
 
 import holoso
-from synth._synth import BUILD_ROOT
+from synth._synth import BUILD_ROOT, build_compiler_ooc_design
 from synth.flows import make_flow
 
 from ._synth_targets import TARGETS, SynthTarget
@@ -46,7 +46,7 @@ def test_target_closes_timing(target: SynthTarget) -> None:
     result = holoso.synthesize(target.kernel(), target.ops, name=target.name)
     directory = BUILD_ROOT / "examples" / target.label
     shutil.rmtree(directory, ignore_errors=True)
-    report = flow.prepare(result).synthesize(directory)
+    report = flow.prepare(build_compiler_ooc_design(result)).synthesize(directory)
 
     assert report.fmax_MHz >= target.target_frequency_MHz, (
         f"{target.label}: f_max {report.fmax_MHz:.2f} MHz < target {target.target_frequency_MHz:.2f} MHz "

--- a/tools/synth_compare.py
+++ b/tools/synth_compare.py
@@ -33,6 +33,7 @@ from holoso._frontend import lower  # noqa: E402
 from holoso._hir import optimize  # noqa: E402
 from holoso._lir import build  # noqa: E402
 from holoso._mir import lower as lower_to_mir  # noqa: E402
+from synth import build_compiler_ooc_design  # noqa: E402
 from synth.flows import make_flow  # noqa: E402
 from tests._synth_targets import TARGETS  # noqa: E402
 
@@ -71,7 +72,7 @@ def capture(out_path: str) -> None:
                 result = holoso.synthesize(target.kernel(), target.ops, name=target.name)
                 directory = REPO / "build" / "synth_compare" / target.label
                 shutil.rmtree(directory, ignore_errors=True)
-                report = flow.prepare(result).synthesize(directory)
+                report = flow.prepare(build_compiler_ooc_design(result)).synthesize(directory)
                 row["fmax_MHz"] = report.fmax_MHz
                 row["slack_ns"] = report.slack_ns
                 row["resources"] = {n: {"used": r.used, "available": r.available} for n, r in report.resources.items()}


### PR DESCRIPTION
Adds a native signed-integer datapath to Holoso and fixes a silent loop-carried-phi miscompilation.

## Integer arithmetic

- The Verilog support library is split into two hand-written operator catalogues, `holoso_int.v` and `holoso_float.v`, assembled together into the shipped `holoso_support.v`.
- New integer operators: signed multiply, radix-4 signed divide, constant and variable arithmetic shift (`holoso_ashiftc`), and float↔int conversions (`ftoint`, `ffromint`).
- Extensive verification: cocotb HDL testbenches for each operator, an integer oracle, and out-of-context synthesis tests (`synth/test_integer_ooc.py`, `tests/hdl/test_integer.py`, and per-operator benches).

## Loop-carried phi swap fix

- Fixes the silent miscompilation of two loop-carried variables that read each other in one step (e.g. `a, b = b, a + x`, or a hand-rolled swap through a temporary), previously tracked in `TODO.md`.
- The tail-install drain/push classification is reworked (`_ir.py`, `_build.py`, `_mir_facts.py`, `_bankalloc.py`) so phi sources stay unpushed and same-step parallel install bundles read all sources before any write lands, keeping cross-referencing loop-header phis correct.

`DESIGN.md` and `TODO.md` are updated to match.
