### PR TITLE
Configuration API refactor: one Options struct, no public operators

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -165,8 +165,8 @@ identity stem, so the fully specified operator instance is itself the resource-s
 time-share one module. Per-node-parameterized operators are factories that instantiate a concrete operator.
 
 Every operator is optional, so presence is a semantic choice as well as an area one
-(`ffma` enables FMA contraction, `fsort` enables min/max); an unconfigured one is refused at MIR lowering.
-The float format drives HIR-to-MIR lowering. Latency-tuning knobs are named after the HDL parameters.
+(`ffma` enables FMA contraction, `fsort` enables min/max); what a kernel cannot reach through the operators
+it was given is refused at MIR lowering.
 An operator may declare per-firing microcode-driven immediate inputs, and declares a per-instance
 initiation interval (most are II=1, fully pipelined).
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -138,7 +138,7 @@ survives into HIR, so keeping their canonical text is what makes a front-end dec
 the compiler explaining itself, next to what it produced.
 
 A plain function synthesizes to a stateless module. A stateful module is requested by passing a bound method of a
-constructed instance, e.g. `synthesize(filt.update, ops)`: the instance's attribute snapshot seeds the reset state,
+constructed instance, e.g. `synthesize(filt.update, options)`: the instance's attribute snapshot seeds the reset state,
 and its method is the analyzed body; the constructor runs in plain Python, its arguments frozen into the build. The
 root package re-exports only the supported public API. A future second mode -- several methods sharing one state
 behind a runtime selector port -- is deferred.
@@ -164,11 +164,11 @@ float ones delegate to the external ZKF library. Each hardware operator owns its
 identity stem, so the fully specified operator instance is itself the resource-sharing key and equal operators
 time-share one module. Per-node-parameterized operators are factories that instantiate a concrete operator.
 
-Operators are chosen by a single `OpConfig`, constructed explicitly by the user and passed into `synthesize`; there is
-no implicit default. Its float format is verified consistent across the configured operators and drives HIR-to-MIR
-lowering; thereafter the format is derived from selected MIR. Latency-tuning knobs are named after the HDL parameters;
-some operators are optional. An operator may declare per-firing microcode-driven immediate inputs, and declares a
-per-instance initiation interval (most are II=1, fully pipelined).
+Every operator is optional, so presence is a semantic choice as well as an area one
+(`ffma` enables FMA contraction, `fsort` enables min/max); an unconfigured one is refused at MIR lowering.
+The float format drives HIR-to-MIR lowering. Latency-tuning knobs are named after the HDL parameters.
+An operator may declare per-firing microcode-driven immediate inputs, and declares a per-instance
+initiation interval (most are II=1, fully pipelined).
 
 ## Front-end
 
@@ -458,8 +458,8 @@ Why read-first plus a +1 dependency cycle, not write-through forwarding? Write-t
 forwarding muxes cost `O(NRD*NWR)` across many ports -- unsustainable; read-first plus the +1, hidden under pipelined
 overlap, is the better trade.
 
-Each operator instance carries its own Holoso-exposed parameters and float format, fixed at construction from the
-`OpConfig`; every instantiation lists every hardware parameter explicitly, turning a param-name mismatch into a loud
+Each operator instance carries its own options and float format, fixed at construction from the user's `Options`;
+every instantiation lists every hardware parameter explicitly, turning a param-name mismatch into a loud
 elaboration error. The auxiliary HDL ships as one self-contained `holoso_support.v`, assembled in memory from
 hand-written operator catalogues plus included external RTL, so the end application adds a single file to the
 synthesis input. The control word and datapath skeleton are the only ZISC-specific part -- LIR itself is

--- a/README.md
+++ b/README.md
@@ -115,21 +115,25 @@ The full configuration might look as follows:
 ```python
 import holoso
 
-# Select the floating-point format you wish to use.
-# Ideally, wman (mantissa width) should be a multiple of DSP tile operand width.
-fmt_f = holoso.FloatFormat(wexp=6, wman=18)
-
-# Define the numerical operators. This is where you can configure additional stages to close timings.
-operators = holoso.OpConfig(
-    holoso.FAddOperator(fmt_f, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1, stage_output=1),
-    holoso.FMulOperator(fmt_f, stage_input=1, stage_product=1, stage_pack=1, stage_output=1),
-    holoso.FDivOperator(fmt_f, stage_input=1, stage_pack=1, stage_output=1),
-    holoso.FMulILog2OperatorFamily(fmt_f),
-    holoso.FCmpOperator(fmt_f),
+options = holoso.Options(
+    # Define the numerical operators. This is where you can configure additional stages to close timings.
+    holoso.OperatorOptions(
+        fadd=holoso.FAddOptions(stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1, stage_output=1),
+        fmul=holoso.FMulOptions(stage_input=1, stage_product=1, stage_pack=1, stage_output=1),
+        fdiv=holoso.FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
+        fmul_ilog2=holoso.FMulILog2Options(),
+        fcmp=holoso.FCmpOptions(),
+    ),
+    # Select the floating-point format you wish to use.
+    # Ideally, wman (mantissa width) should be a multiple of DSP tile operand width.
+    ffmt=holoso.FloatFormat(wexp=6, wman=18),
 )
 ```
 
-Optional operators such as `fexp2` etc. are supplied the same way.
+You only need to set the options for the operators that the kernel actually uses.
+If the kernel needs an unconfigured operator, the behavior depends on whether Holoso can express the missing
+operator in terms of the configured ones. If it can, it will do so silently; if not, it will raise an error.
+For example, the fused multiply-add operator (`ffma`) is entirely optional, but `fadd` is not substitutable.
 
 How does one actually obtain the optimal staging configuration? Empirically.
 Start with the default configuration (all stages disabled) and see if it achieves timing closure at the target frequency.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ pid = PID(kp=0.5, ki=0.0625, kd=0.25, limit=4.0)
 # Run Holoso -- construct the machine and schedule the microcode.
 # The results are returned in-memory; you can write them to disk where you want.
 # They include the generated Verilog module, the fixed holoso_support.v, testbench, and the reports.
-result = holoso.synthesize(pid.update, operators)
+result = holoso.synthesize(pid.update, options)
 
 # Write the files -- this is usually what you want.
 out = result.write("outputs")

--- a/examples/biquad.py
+++ b/examples/biquad.py
@@ -32,15 +32,18 @@ class Biquad:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(Biquad().__call__, ops)
+    result = holoso.synthesize(Biquad().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/cordic_sincos.py
+++ b/examples/cordic_sincos.py
@@ -36,15 +36,18 @@ class CordicSinCos:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(CordicSinCos(iterations=12).__call__, ops)
+    result = holoso.synthesize(CordicSinCos(iterations=12).__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/ekf1_stateful.py
+++ b/examples/ekf1_stateful.py
@@ -48,7 +48,7 @@ class Ekf1:
 def main() -> None:
     # The values stored in the object at the time of synthesize() become its reset values; here the dataclass defaults.
     filt = Ekf1()
-    # The kernel is float-format-agnostic, but each scalar width wants its own operator pipelining, so the OpConfig is
+    # The kernel is float-format-agnostic, but each scalar width wants its own operator pipelining, so the configuration is
     # built per float format. The narrow 24-bit default (e6/m18) closes single-cycle, so its operators take no extra
     # stages; the wide 44-bit datapath (e8/m36) needs deeper operator pipelines to close timing.
     narrow = holoso.FloatFormat(wexp=6, wman=18)

--- a/examples/ekf1_stateful.py
+++ b/examples/ekf1_stateful.py
@@ -54,25 +54,31 @@ def main() -> None:
     narrow = holoso.FloatFormat(wexp=6, wman=18)
     wide = holoso.FloatFormat(wexp=8, wman=36)
     configs = [
-        holoso.OpConfig(
-            holoso.FAddOperator(narrow),
-            holoso.FMulOperator(narrow),
-            holoso.FDivOperator(narrow),
-            holoso.FMulILog2OperatorFamily(narrow),
-            holoso.FCmpOperator(narrow),
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(),
+                fmul=holoso.FMulOptions(),
+                fdiv=holoso.FDivOptions(),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+            ),
+            ffmt=narrow,
         ),
-        holoso.OpConfig(
-            holoso.FAddOperator(wide, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
-            holoso.FMulOperator(wide, stage_input=1, stage_product=1, stage_pack=1),
-            holoso.FDivOperator(wide, stage_input=1, stage_pack=1, stage_output=1),
-            holoso.FMulILog2OperatorFamily(wide),
-            holoso.FCmpOperator(wide),
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
+                fmul=holoso.FMulOptions(stage_input=1, stage_product=1, stage_pack=1),
+                fdiv=holoso.FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+            ),
+            ffmt=wide,
         ),
     ]
     base = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    for ops in configs:
-        label = f"e{ops.float_format.wexp}m{ops.float_format.wman}"
-        result = holoso.synthesize(filt.update, ops=ops)
+    for options in configs:
+        label = f"e{options.ffmt.wexp}m{options.ffmt.wman}"
+        result = holoso.synthesize(filt.update, options)
         for filename, path in result.write(base / label).items():
             print(f"{label}/{filename}: {path}")
 

--- a/examples/ekf1_stateless.py
+++ b/examples/ekf1_stateless.py
@@ -133,25 +133,31 @@ def main() -> None:
     narrow = holoso.FloatFormat(wexp=6, wman=18)
     wide = holoso.FloatFormat(wexp=8, wman=36)
     configs = [
-        holoso.OpConfig(
-            holoso.FAddOperator(narrow),
-            holoso.FMulOperator(narrow),
-            holoso.FDivOperator(narrow),
-            holoso.FMulILog2OperatorFamily(narrow),
-            holoso.FCmpOperator(narrow),
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(),
+                fmul=holoso.FMulOptions(),
+                fdiv=holoso.FDivOptions(),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+            ),
+            ffmt=narrow,
         ),
-        holoso.OpConfig(
-            holoso.FAddOperator(wide, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
-            holoso.FMulOperator(wide, stage_input=1, stage_product=1, stage_pack=1),
-            holoso.FDivOperator(wide, stage_input=1, stage_pack=1, stage_output=1),
-            holoso.FMulILog2OperatorFamily(wide),
-            holoso.FCmpOperator(wide),
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
+                fmul=holoso.FMulOptions(stage_input=1, stage_product=1, stage_pack=1),
+                fdiv=holoso.FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+            ),
+            ffmt=wide,
         ),
     ]
     base = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    for ops in configs:
-        label = f"e{ops.float_format.wexp}m{ops.float_format.wman}"
-        result = holoso.synthesize(update_x_P, ops=ops)
+    for options in configs:
+        label = f"e{options.ffmt.wexp}m{options.ffmt.wman}"
+        result = holoso.synthesize(update_x_P, options)
         for filename, path in result.write(base / label).items():
             print(f"{label}/{filename}: {path}")
 

--- a/examples/ekf1_stateless.py
+++ b/examples/ekf1_stateless.py
@@ -129,7 +129,7 @@ def update_x_P(
 
 
 def main() -> None:
-    # Each scalar width wants its own operator pipelining to close timings, so the OpConfig is built per float format.
+    # Each scalar width wants its own operator pipelining to close timings, so the configuration is built per float format.
     narrow = holoso.FloatFormat(wexp=6, wman=18)
     wide = holoso.FloatFormat(wexp=8, wman=36)
     configs = [

--- a/examples/equal_temperament.py
+++ b/examples/equal_temperament.py
@@ -23,17 +23,20 @@ def equal_temperament(note: float) -> tuple[float, float]:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
-        fexp2=holoso.FExp2Operator(float_format),
-        flog2=holoso.FLog2Operator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+            fexp2=holoso.FExp2Options(),
+            flog2=holoso.FLog2Options(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(equal_temperament, ops)
+    result = holoso.synthesize(equal_temperament, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/fir.py
+++ b/examples/fir.py
@@ -32,15 +32,18 @@ class Fir4:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(Fir4().__call__, ops)
+    result = holoso.synthesize(Fir4().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/iir1_lpf.py
+++ b/examples/iir1_lpf.py
@@ -28,15 +28,18 @@ class IIR1LPF:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(IIR1LPF().__call__, ops)
+    result = holoso.synthesize(IIR1LPF().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/imu_frame_transform.py
+++ b/examples/imu_frame_transform.py
@@ -40,44 +40,56 @@ def main() -> None:
     # pipeline depths -- this script only elaborates and writes RTL/reports, so the knobs are illustrative rather than
     # timing-closed; the wide FMA multiplicand exceeds one DSP tile, hence its STAGE_PRODUCT split.
     configs = [
-        holoso.OpConfig(
-            holoso.FAddOperator(narrow),
-            holoso.FMulOperator(narrow),
-            holoso.FDivOperator(narrow),
-            holoso.FMulILog2OperatorFamily(narrow),
-            holoso.FCmpOperator(narrow),
-        ),
-        holoso.OpConfig(
-            holoso.FAddOperator(narrow, stage_input=1, stage_decode=1, stage_pack=1),
-            holoso.FMulOperator(narrow, stage_product=1),
-            holoso.FDivOperator(narrow),
-            holoso.FMulILog2OperatorFamily(narrow),
-            holoso.FCmpOperator(narrow),
-            ffma=holoso.FFmaOperator(narrow, stage_product=1, stage_decode=1, stage_normalize=1, stage_pack=1),
-        ),
-        holoso.OpConfig(
-            holoso.FAddOperator(wide, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
-            holoso.FMulOperator(wide, stage_input=1, stage_product=1, stage_pack=1),
-            holoso.FDivOperator(wide, stage_input=1, stage_pack=1, stage_output=1),
-            holoso.FMulILog2OperatorFamily(wide),
-            holoso.FCmpOperator(wide),
-        ),
-        holoso.OpConfig(
-            holoso.FAddOperator(wide, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
-            holoso.FMulOperator(wide, stage_input=1, stage_product=1, stage_pack=1),
-            holoso.FDivOperator(wide, stage_input=1, stage_pack=1, stage_output=1),
-            holoso.FMulILog2OperatorFamily(wide),
-            holoso.FCmpOperator(wide),
-            ffma=holoso.FFmaOperator(
-                wide, stage_input=1, stage_product=2, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(),
+                fmul=holoso.FMulOptions(),
+                fdiv=holoso.FDivOptions(),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
             ),
+            ffmt=narrow,
+        ),
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(stage_input=1, stage_decode=1, stage_pack=1),
+                fmul=holoso.FMulOptions(stage_product=1),
+                fdiv=holoso.FDivOptions(),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+                ffma=holoso.FFmaOptions(stage_product=1, stage_decode=1, stage_normalize=1, stage_pack=1),
+            ),
+            ffmt=narrow,
+        ),
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
+                fmul=holoso.FMulOptions(stage_input=1, stage_product=1, stage_pack=1),
+                fdiv=holoso.FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+            ),
+            ffmt=wide,
+        ),
+        holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
+                fmul=holoso.FMulOptions(stage_input=1, stage_product=1, stage_pack=1),
+                fdiv=holoso.FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+                ffma=holoso.FFmaOptions(
+                    stage_input=1, stage_product=2, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1
+                ),
+            ),
+            ffmt=wide,
         ),
     ]
     base = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     flat_inputs = [float(x) for x in np.concatenate([a.flatten() for a in args])]
-    for ops in configs:
-        label = f"e{ops.float_format.wexp}m{ops.float_format.wman}" + ("_fma" if ops.ffma is not None else "")
-        result = holoso.synthesize(transform, ops=ops)
+    for options in configs:
+        label = f"e{options.ffmt.wexp}m{options.ffmt.wman}" + ("_fma" if options.operator.ffma is not None else "")
+        result = holoso.synthesize(transform, options)
         world = [float(v) for v in result.numerical_model.elaborate().run(*flat_inputs)]
         print(f"{label}: p_world/a_world/p_recovered = {world}")
         for filename, path in result.write(base / label).items():

--- a/examples/kepler.py
+++ b/examples/kepler.py
@@ -22,16 +22,19 @@ def eccentric_anomaly(mean_anomaly: float, eccentricity: float) -> float:
 
 def main() -> None:
     fmt = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(fmt),
-        holoso.FMulOperator(fmt),
-        holoso.FDivOperator(fmt),
-        holoso.FMulILog2OperatorFamily(fmt),
-        holoso.FCmpOperator(fmt),
-        fsincos=holoso.FSincosOperator(fmt),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+            fsincos=holoso.FSincosOptions(),
+        ),
+        ffmt=fmt,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(eccentric_anomaly, ops=ops)
+    result = holoso.synthesize(eccentric_anomaly, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
     model = result.numerical_model.elaborate()

--- a/examples/latching_fault_register.py
+++ b/examples/latching_fault_register.py
@@ -26,17 +26,7 @@ class LatchingFaultRegister:
 
 
 def main() -> None:
-    float_format = holoso.FloatFormat(wexp=8, wman=36)
-    options = holoso.Options(
-        holoso.OperatorOptions(
-            fadd=holoso.FAddOptions(),
-            fmul=holoso.FMulOptions(),
-            fdiv=holoso.FDivOptions(),
-            fmul_ilog2=holoso.FMulILog2Options(),
-            fcmp=holoso.FCmpOptions(),
-        ),
-        ffmt=float_format,
-    )
+    options = holoso.Options(holoso.OperatorOptions())  # purely boolean: no float operator, no float format
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     result = holoso.synthesize(LatchingFaultRegister().__call__, options)
     for filename, path in result.write(out_dir).items():

--- a/examples/latching_fault_register.py
+++ b/examples/latching_fault_register.py
@@ -27,15 +27,18 @@ class LatchingFaultRegister:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(LatchingFaultRegister().__call__, ops)
+    result = holoso.synthesize(LatchingFaultRegister().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/madd.py
+++ b/examples/madd.py
@@ -15,15 +15,18 @@ def madd(a: float, b: float, c: float) -> float:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=6, wman=18)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(madd, ops=ops)
+    result = holoso.synthesize(madd, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/majority_voter.py
+++ b/examples/majority_voter.py
@@ -58,15 +58,18 @@ def main() -> None:
     # This kernel is purely boolean and emits no float arithmetic, so the float format is immaterial; the default wide
     # format is used only because OpConfig requires a complete operator set. This may be improved in the future.
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(MajorityVoter().__call__, ops)
+    result = holoso.synthesize(MajorityVoter().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/majority_voter.py
+++ b/examples/majority_voter.py
@@ -55,19 +55,7 @@ class MajorityVoter:
 
 
 def main() -> None:
-    # This kernel is purely boolean and emits no float arithmetic, so the float format is immaterial; the default wide
-    # format is used only because OpConfig requires a complete operator set. This may be improved in the future.
-    float_format = holoso.FloatFormat(wexp=8, wman=36)
-    options = holoso.Options(
-        holoso.OperatorOptions(
-            fadd=holoso.FAddOptions(),
-            fmul=holoso.FMulOptions(),
-            fdiv=holoso.FDivOptions(),
-            fmul_ilog2=holoso.FMulILog2Options(),
-            fcmp=holoso.FCmpOptions(),
-        ),
-        ffmt=float_format,
-    )
+    options = holoso.Options(holoso.OperatorOptions())  # purely boolean: no float operator, no float format
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     result = holoso.synthesize(MajorityVoter().__call__, options)
     for filename, path in result.write(out_dir).items():

--- a/examples/octave_index.py
+++ b/examples/octave_index.py
@@ -32,15 +32,18 @@ def octave_index(x: float) -> float:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(octave_index, ops)
+    result = holoso.synthesize(octave_index, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/phase_frequency_detector.py
+++ b/examples/phase_frequency_detector.py
@@ -41,15 +41,18 @@ class PhaseFrequencyDetector:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(PhaseFrequencyDetector().__call__, ops)
+    result = holoso.synthesize(PhaseFrequencyDetector().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/phase_frequency_detector.py
+++ b/examples/phase_frequency_detector.py
@@ -40,17 +40,7 @@ class PhaseFrequencyDetector:
 
 
 def main() -> None:
-    float_format = holoso.FloatFormat(wexp=8, wman=36)
-    options = holoso.Options(
-        holoso.OperatorOptions(
-            fadd=holoso.FAddOptions(),
-            fmul=holoso.FMulOptions(),
-            fdiv=holoso.FDivOptions(),
-            fmul_ilog2=holoso.FMulILog2Options(),
-            fcmp=holoso.FCmpOptions(),
-        ),
-        ffmt=float_format,
-    )
+    options = holoso.Options(holoso.OperatorOptions())  # purely boolean: no float operator, no float format
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     result = holoso.synthesize(PhaseFrequencyDetector().__call__, options)
     for filename, path in result.write(out_dir).items():

--- a/examples/pid.py
+++ b/examples/pid.py
@@ -40,15 +40,18 @@ class PID:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(PID().__call__, ops)
+    result = holoso.synthesize(PID().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/polar.py
+++ b/examples/polar.py
@@ -27,18 +27,21 @@ def main() -> None:
     base = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     for fmt in (holoso.FloatFormat(wexp=6, wman=18), holoso.FloatFormat(wexp=8, wman=36)):
         label = f"e{fmt.wexp}m{fmt.wman}"
-        ops = holoso.OpConfig(
-            holoso.FAddOperator(fmt),
-            holoso.FMulOperator(fmt),
-            holoso.FDivOperator(fmt),
-            holoso.FMulILog2OperatorFamily(fmt),
-            holoso.FCmpOperator(fmt),
-            fsincos=holoso.FSincosOperator(fmt),
-            fatan2=holoso.FAtan2Operator(fmt),
+        options = holoso.Options(
+            holoso.OperatorOptions(
+                fadd=holoso.FAddOptions(),
+                fmul=holoso.FMulOptions(),
+                fdiv=holoso.FDivOptions(),
+                fmul_ilog2=holoso.FMulILog2Options(),
+                fcmp=holoso.FCmpOptions(),
+                fsincos=holoso.FSincosOptions(),
+                fatan2=holoso.FAtan2Options(),
+            ),
+            ffmt=fmt,
         )
         models = {}
         for fn in (to_polar, from_polar):
-            result = holoso.synthesize(fn, ops=ops)
+            result = holoso.synthesize(fn, options)
             models[fn.__name__] = result.numerical_model.elaborate()
             for filename, path in result.write(base / label / fn.__name__).items():
                 print(f"{label}/{fn.__name__}/{filename}: {path}")

--- a/examples/poly3.py
+++ b/examples/poly3.py
@@ -17,15 +17,18 @@ def poly3(x: float, c0: float, c1: float, c2: float, c3: float) -> float:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=6, wman=18)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(poly3, ops=ops)
+    result = holoso.synthesize(poly3, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/quadrature_encoder.py
+++ b/examples/quadrature_encoder.py
@@ -34,15 +34,18 @@ class QuadratureEncoder:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(QuadratureEncoder().__call__, ops)
+    result = holoso.synthesize(QuadratureEncoder().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/quadrature_encoder.py
+++ b/examples/quadrature_encoder.py
@@ -33,17 +33,7 @@ class QuadratureEncoder:
 
 
 def main() -> None:
-    float_format = holoso.FloatFormat(wexp=8, wman=36)
-    options = holoso.Options(
-        holoso.OperatorOptions(
-            fadd=holoso.FAddOptions(),
-            fmul=holoso.FMulOptions(),
-            fdiv=holoso.FDivOptions(),
-            fmul_ilog2=holoso.FMulILog2Options(),
-            fcmp=holoso.FCmpOptions(),
-        ),
-        ffmt=float_format,
-    )
+    options = holoso.Options(holoso.OperatorOptions())  # purely boolean: no float operator, no float format
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     result = holoso.synthesize(QuadratureEncoder().__call__, options)
     for filename, path in result.write(out_dir).items():

--- a/examples/recip_newton.py
+++ b/examples/recip_newton.py
@@ -29,15 +29,18 @@ class NewtonReciprocal:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(NewtonReciprocal().__call__, ops)
+    result = holoso.synthesize(NewtonReciprocal().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/remainder.py
+++ b/examples/remainder.py
@@ -47,15 +47,18 @@ def remainder(x: float, y: float) -> float:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(remainder, ops)
+    result = holoso.synthesize(remainder, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/schmitt_trigger.py
+++ b/examples/schmitt_trigger.py
@@ -25,15 +25,18 @@ class SchmittTrigger:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(SchmittTrigger().__call__, ops)
+    result = holoso.synthesize(SchmittTrigger().__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/signal_window.py
+++ b/examples/signal_window.py
@@ -15,7 +15,7 @@ return tuple ``(float, bool, bool, bool, float)``):
   (comparison -> bool -> float cast -> float multiply) that the bool->float result must feed on time.
 
 The two ternary arms of ``clamped`` if-convert to selects, leaving a single straight-line block; the comparisons,
-connectives, and casts are combinational ops within it, so the kernel has no branch and no phi.
+connectives, and casts are combinational options within it, so the kernel has no branch and no phi.
 """
 
 from pathlib import Path
@@ -34,15 +34,18 @@ def signal_window(x: float, lo: float, hi: float) -> tuple[float, bool, bool, bo
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
-    result = holoso.synthesize(signal_window, ops)
+    result = holoso.synthesize(signal_window, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/trapezoidal_leaky_streaming_integrator.py
+++ b/examples/trapezoidal_leaky_streaming_integrator.py
@@ -55,19 +55,22 @@ class TrapezoidalLeakyStreamingIntegrator:
 
 def main() -> None:
     float_format = holoso.FloatFormat(wexp=8, wman=36)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_format),
-        holoso.FMulOperator(float_format),
-        holoso.FDivOperator(float_format),
-        holoso.FMulILog2OperatorFamily(float_format),
-        holoso.FCmpOperator(float_format),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_format,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
 
     # Construct the instance with the desired constructor arguments, then pass the bound method to synthesize: its
     # __self__ snapshot seeds the reset state, and __func__ is the analyzed method.
     integrator = TrapezoidalLeakyStreamingIntegrator(k=2**-22)
-    result = holoso.synthesize(integrator.__call__, ops)
+    result = holoso.synthesize(integrator.__call__, options)
     for filename, path in result.write(out_dir).items():
         print(f"{filename}: {path}")
 

--- a/examples/uart.py
+++ b/examples/uart.py
@@ -179,19 +179,22 @@ def main() -> None:
     # (largest finite magnitude 255).
     # TODO this is temporary until we have integer support.
     float_fmt = holoso.FloatFormat(wexp=4, wman=8)
-    ops = holoso.OpConfig(
-        holoso.FAddOperator(float_fmt),
-        holoso.FMulOperator(float_fmt),
-        holoso.FDivOperator(float_fmt),
-        holoso.FMulILog2OperatorFamily(float_fmt),
-        holoso.FCmpOperator(float_fmt),
+    options = holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=float_fmt,
     )
     out_dir = Path(__file__).resolve().parent / "build" / Path(__file__).stem
     for label, target in (
         ("uart_tx", UartTx(parity=False).__call__),  # 8E1: even parity
         ("uart_rx", UartRx(parity=False).__call__),
     ):
-        result = holoso.synthesize(target, ops, name=label)
+        result = holoso.synthesize(target, options, name=label)
         for filename, path in result.write(out_dir / label).items():
             print(f"{filename}: {path}")
 

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -33,10 +33,7 @@ from ._errors import (
 
 from ._backend.cocotb import CocotbOutput as CocotbOutput
 from ._backend.html import HtmlOutput as HtmlOutput
-from ._backend.numerical import (
-    NumericalModel as NumericalModel,
-    NumericalSimulator as NumericalSimulator,
-)
+from ._backend.numerical import NumericalModel as NumericalModel, NumericalSimulator as NumericalSimulator
 from ._backend.verilog import VerilogOutput as VerilogOutput
 
 from . import _operators

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -1,6 +1,11 @@
 """Holoso: a narrow Python-to-Verilog synthesizer for numeric kernels."""
 
-from ._api import synthesize as synthesize, SynthesisResult as SynthesisResult
+from ._api import (
+    OperatorOptions as OperatorOptions,
+    Options as Options,
+    SynthesisResult as SynthesisResult,
+    synthesize as synthesize,
+)
 from ._lir import (
     ControlInputPort as ControlInputPort,
     ControlOutputPort as ControlOutputPort,
@@ -34,21 +39,22 @@ from ._backend.numerical import (
 )
 from ._backend.verilog import VerilogOutput as VerilogOutput
 
-from ._operators import (
-    FAddOperator as FAddOperator,
-    FAtan2Operator as FAtan2Operator,
-    FDivOperator as FDivOperator,
-    FExp2Operator as FExp2Operator,
-    FLog2Operator as FLog2Operator,
-    FMulILog2OperatorFamily as FMulILog2OperatorFamily,
-    FMulOperator as FMulOperator,
-    FCmpOperator as FCmpOperator,
-    FFmaOperator as FFmaOperator,
-    FRoundOperator as FRoundOperator,
-    FSincosOperator as FSincosOperator,
-    FSortOperator as FSortOperator,
-    OpConfig as OpConfig,
-)
+from . import _operators
+
+# The user names an operator's knobs without naming the operator type, which is not part of the public API.
+FAddOptions = _operators.FAddOperator.Options
+FAtan2Options = _operators.FAtan2Operator.Options
+FCmpOptions = _operators.FCmpOperator.Options
+FDivOptions = _operators.FDivOperator.Options
+FExp2Options = _operators.FExp2Operator.Options
+FFmaOptions = _operators.FFmaOperator.Options
+FLog2Options = _operators.FLog2Operator.Options
+FMulILog2Options = _operators.FMulILog2Operator.Options
+FMulOptions = _operators.FMulOperator.Options
+FRoundOptions = _operators.FRoundOperator.Options
+FSincosOptions = _operators.FSincosOperator.Options
+FSortOptions = _operators.FSortOperator.Options
+IMulOptions = _operators.IMulOperator.Options
 
 __version__ = "0.2.0"
 __url__ = "https://holoso.digital"

--- a/holoso/_api.py
+++ b/holoso/_api.py
@@ -211,7 +211,7 @@ def synthesize(target: Target, /, options: Options, *, name: str | None = None) 
     hir = optimize(frontend.hir)
     _logger.info("HIR:\n\tinputs=%s\n\toutputs=%s\n\thir_nodes=%d", hir.input_ids, hir.outputs, len(hir.nodes))
 
-    mir = lower_to_mir(hir, _build_op_config(options))
+    mir = lower_to_mir(hir, _build_op_config(options), options.ffmt)
     lir = build(
         mir,
         module_name,

--- a/holoso/_api.py
+++ b/holoso/_api.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 import inspect
 import logging
+import os
 import re
 
 from ._backend.cocotb import generate as generate_testbench, CocotbOutput
@@ -15,9 +16,26 @@ from ._backend.verilog import generate as generate_verilog, VerilogOutput
 
 from ._eel import lower as lower_frontend
 from ._hir import optimize
-from ._lir import ControlPort, DataInputPort, DataOutputPort, Port, build
+from ._lir import ControlPort, DataInputPort, DataOutputPort, Port, RegallocTuning, build
 from ._mir import lower as lower_to_mir
-from ._operators import OpConfig
+from ._operators import (
+    FAddOperator,
+    FAtan2Operator,
+    FCmpOperator,
+    FDivOperator,
+    FExp2Operator,
+    FFmaOperator,
+    FLog2Operator,
+    FMulILog2Operator,
+    FMulILog2OperatorFamily,
+    FMulOperator,
+    FRoundOperator,
+    FSincosOperator,
+    FSortOperator,
+    IMulOperator,
+    OpConfig,
+)
+from ._type import FloatFormat
 
 type Target = Callable[..., Any]
 """
@@ -77,28 +95,133 @@ class SynthesisResult:
         return written
 
 
-def synthesize(target: Target, /, ops: OpConfig, *, name: str | None = None) -> SynthesisResult:
+@dataclass(frozen=True, slots=True)
+class OperatorOptions:
+    """
+    ``None`` is not built, and a kernel needing it is refused by name; a configured but unused operator costs nothing.
+    Integer operators are always available, so only their knobs appear here.
+    """
+
+    fadd: FAddOperator.Options | None = None
+    fmul: FMulOperator.Options | None = None
+    fdiv: FDivOperator.Options | None = None
+    fmul_ilog2: FMulILog2Operator.Options | None = None
+    fcmp: FCmpOperator.Options | None = None
+    fround: FRoundOperator.Options | None = None
+    ffma: FFmaOperator.Options | None = None
+    fsort: FSortOperator.Options | None = None
+    fexp2: FExp2Operator.Options | None = None
+    flog2: FLog2Operator.Options | None = None
+    fsincos: FSincosOperator.Options | None = None
+    fatan2: FAtan2Operator.Options | None = None
+
+    imul: IMulOperator.Options = IMulOperator.Options()
+
+
+@dataclass(frozen=True, slots=True)
+class Options:
+    """Everything configurable that controls how the ZISC machine and its microcode are built."""
+
+    operator: OperatorOptions
+
+    ffmt: FloatFormat = FloatFormat(6, 18)
+    """wexp is usually 6..11 bits; wman is usually a multiple of the DSP tile operand width, 18 bits on most FPGAs."""
+
+    wint: int = 33
+    """
+    The native integer width. Integers are signed and saturating: the range is `[-(2**(wint-1)), 2**(wint-1)-1]`.
+    The wide regfile is shared for integers and floats, and the register width is therefore `max(wint, ffmt.width)`.
+    """
+
+    wmultiplier: int | None = None
+    """
+    The native DSP slice width, if known: lets the RTL split wide products along it rather than into equal halves,
+    usually saving DSP tiles and timing margin.
+    """
+
+    ucode_fetch_stages: int = 3
+    """Controller fmax/latency trade-off: a deeper fetch raises fmax but costs idle refills on a mispredicted branch."""
+
+    regalloc_effort: int = int(os.getenv("HOLOSO_REGALLOC_EFFORT", "5000"))
+    """How hard to search for the best register allocation. Better machines take longer to build."""
+
+    regalloc_reuse_write_cap: int = int(os.getenv("HOLOSO_REG_REUSE_WRITE_CAP", "2"))
+    """
+    How wide a per-register write select the regfile compaction may build: more compact register file, larger and
+    slower steering fabric. A penalty rather than a hard cap, since some registers need an irreducibly wider select.
+    """
+
+    regalloc_register_price: float = float(os.getenv("HOLOSO_REG_PRICE", "2.0"))
+    """What one register is worth in steering mux arms. Greater values buy fewer registers with heavier steering."""
+
+    def __post_init__(self) -> None:
+        if self.wint < 2:
+            raise ValueError(f"wint must be >= 2, got {self.wint}")
+        if self.wmultiplier is not None and self.wmultiplier < 2:
+            raise ValueError(f"wmultiplier must be >= 2 when set, got {self.wmultiplier}")
+        if self.ucode_fetch_stages < 1:
+            raise ValueError(f"ucode_fetch_stages must be >= 1, got {self.ucode_fetch_stages}")
+        if self.regalloc_effort < 0:
+            raise ValueError(f"regalloc_effort must be >= 0, got {self.regalloc_effort}")
+        if self.regalloc_reuse_write_cap < 1:
+            raise ValueError(f"regalloc_reuse_write_cap must be >= 1, got {self.regalloc_reuse_write_cap}")
+        if self.regalloc_register_price <= 0:
+            raise ValueError(f"regalloc_register_price must be > 0, got {self.regalloc_register_price}")
+
+
+def _build_op_config(options: Options) -> OpConfig:
+    """The one place the user's configuration becomes hardware."""
+    fmt, wmul, op = options.ffmt, options.wmultiplier or 0, options.operator
+    return OpConfig(
+        fadd=FAddOperator(fmt, op.fadd) if op.fadd is not None else None,
+        fmul=FMulOperator(fmt, op.fmul, wmul) if op.fmul is not None else None,
+        fdiv=FDivOperator(fmt, op.fdiv) if op.fdiv is not None else None,
+        fmul_ilog2=FMulILog2OperatorFamily(fmt, op.fmul_ilog2) if op.fmul_ilog2 is not None else None,
+        fcmp=FCmpOperator(fmt, op.fcmp) if op.fcmp is not None else None,
+        fround=FRoundOperator(fmt, op.fround) if op.fround is not None else None,
+        ffma=FFmaOperator(fmt, op.ffma, wmul) if op.ffma is not None else None,
+        fsort=FSortOperator(fmt, op.fsort) if op.fsort is not None else None,
+        fexp2=FExp2Operator(fmt, op.fexp2, wmul) if op.fexp2 is not None else None,
+        flog2=FLog2Operator(fmt, op.flog2, wmul) if op.flog2 is not None else None,
+        fsincos=FSincosOperator(fmt, op.fsincos, wmul) if op.fsincos is not None else None,
+        fatan2=FAtan2Operator(fmt, op.fatan2, wmul) if op.fatan2 is not None else None,
+    )
+
+
+def synthesize(target: Target, /, options: Options, *, name: str | None = None) -> SynthesisResult:
     """
     Synthesize ``target`` (a plain function or a bound method of a constructed instance) into RTL.
-    ``ops`` is the operator configuration, constructed explicitly by the caller: each field fixes one operator's
-    float format and parameters, including any pipeline-stage knobs that lengthen its latency to ease timing closure.
-    ``name`` overrides the generated module name (inferred from target by default).
+    ``options`` configures the machine; ``name`` overrides the generated module name (inferred from target by default).
     """
     logging.basicConfig(level=logging.INFO, format="%(levelname)-5.5s %(name)s: %(message)s")  # no-op if already setup
     module_name: str = name or _default_module_name(target)
     _validate_module_name(module_name)
     _logger.info("Synthesis start: module=%r target=%r", module_name, target)
-    _logger.info("Configured operators:")
-    for field in fields(ops):
-        _logger.info("\t%s: %s", field.name, getattr(ops, field.name))
+    _logger.info("Options:")
+    for field in fields(options):
+        value = getattr(options, field.name)
+        if field.name == "operator":
+            for op_field in fields(value):
+                if (configured := getattr(value, op_field.name)) is not None:
+                    _logger.info("\toperator.%s: %s", op_field.name, configured)
+        else:
+            _logger.info("\t%s: %s", field.name, value)
 
     frontend = lower_frontend(target)
     hir = optimize(frontend.hir)
     _logger.info("HIR:\n\tinputs=%s\n\toutputs=%s\n\thir_nodes=%d", hir.input_ids, hir.outputs, len(hir.nodes))
 
-    mir = lower_to_mir(hir, ops)
-
-    lir = build(mir, module_name, fetch_stages=3)  # fetch_stages will be made configurable soon
+    mir = lower_to_mir(hir, _build_op_config(options))
+    lir = build(
+        mir,
+        module_name,
+        options.ucode_fetch_stages,
+        RegallocTuning(
+            effort=options.regalloc_effort,
+            reuse_write_cap=options.regalloc_reuse_write_cap,
+            register_price=options.regalloc_register_price,
+        ),
+    )
     _logger.info("LIR ports:\n\t%s", "\n\t".join(f"{port}" for port in lir.ports))
 
     verilog_output = generate_verilog(lir)

--- a/holoso/_hir/_copy.py
+++ b/holoso/_hir/_copy.py
@@ -8,20 +8,7 @@ from typing import assert_never
 
 from ._const import Const
 from .._util import BlockId, ValueId
-from ._ir import (
-    Branch,
-    Hir,
-    HirBuilder,
-    InPort,
-    Jump,
-    Node,
-    Operation,
-    Phi,
-    Ret,
-    StateRead,
-    Terminator,
-    successors,
-)
+from ._ir import Branch, Hir, HirBuilder, InPort, Jump, Node, Operation, Phi, Ret, StateRead, Terminator, successors
 
 # A pass supplies one of these to rebuild each value into the target builder; it returns the new value id and may fold
 # an operation into a constant. The builder is already positioned at the value's block.

--- a/holoso/_hir/_thread_merges.py
+++ b/holoso/_hir/_thread_merges.py
@@ -25,17 +25,7 @@ by repeating to a fixpoint, innermost-reachable first.
 import logging
 
 from .._util import BlockId, ValueId
-from ._ir import (
-    Block,
-    Branch,
-    Hir,
-    Jump,
-    Operation,
-    Phi,
-    predecessors,
-    renumber,
-    validate_phi_predecessors,
-)
+from ._ir import Block, Branch, Hir, Jump, Operation, Phi, predecessors, renumber, validate_phi_predecessors
 
 _logger = logging.getLogger(__name__)
 

--- a/holoso/_lir/__init__.py
+++ b/holoso/_lir/__init__.py
@@ -1,6 +1,7 @@
 """Thin API for the low-level IR consumer contract."""
 
 from ._build import build as build
+from ._regalloc import RegallocTuning as RegallocTuning
 from ._ir import Lir as Lir
 from ._ir import (
     BoolConstRef as BoolConstRef,

--- a/holoso/_lir/_bankalloc.py
+++ b/holoso/_lir/_bankalloc.py
@@ -28,14 +28,7 @@ from ._mir_facts import const_branch_conditions, mir_rpo, phi_arm_out, succ_map,
 from ._liveness import BankLiveness, compute_interference
 from ._schedule import Schedule
 from ._regalloc import Producer, RegallocTuning
-from ._build_base import (
-    Allocation,
-    BoolArmInstall,
-    ColorObjective,
-    FloatArmInstall,
-    OverlapLayout,
-    PooledConst,
-)
+from ._build_base import Allocation, BoolArmInstall, ColorObjective, FloatArmInstall, OverlapLayout, PooledConst
 from ._construct import build_const_pool
 from ._coalesce import coalescable_arms, coalesce_and_color
 from ._layout import schedule_with_overlap

--- a/holoso/_lir/_bankalloc.py
+++ b/holoso/_lir/_bankalloc.py
@@ -27,7 +27,7 @@ from ._ir import *
 from ._mir_facts import const_branch_conditions, mir_rpo, phi_arm_out, succ_map, value_resident_at_entry
 from ._liveness import BankLiveness, compute_interference
 from ._schedule import Schedule
-from ._regalloc import Producer
+from ._regalloc import Producer, RegallocTuning
 from ._build_base import (
     Allocation,
     BoolArmInstall,
@@ -73,6 +73,7 @@ def layout_and_allocate(
     has_install_blocks: Mapping[int, bool],
     has_state_copy: bool,
     fetch_lag: int,
+    tuning: RegallocTuning,
 ) -> _LayoutAllocation:
     overlap = schedule_with_overlap(mir, float_mir, bool_mir, pool, has_install_blocks, has_state_copy, fetch_lag)
     block_sched = overlap.block_sched
@@ -94,6 +95,7 @@ def layout_and_allocate(
         overlap.block_term_offset,
         overlap.block_inflight,
         fetch_lag,
+        tuning,
     )
     return _LayoutAllocation(overlap, inst_of, instances, consts, const_pool, alloc)
 
@@ -456,6 +458,7 @@ def _allocate_bank(
     block_term_offset: dict[int, int],
     block_inflight: dict[int, dict[ValueId, int]],
     fetch_lag: int,
+    tuning: RegallocTuning,
 ) -> _BankAlloc:
     """
     Color one physical register bank across the CFG. The bank descriptor supplies the conditioner,
@@ -616,7 +619,7 @@ def _allocate_bank(
             pinned,
             {slot_reg[s.name] for s in slots if s.name not in coalesced},
             lambda residual: interference.build(boundary_final, reads_final, residual),
-            ColorObjective(movable, obj_terms.consumer_ports, obj_terms.producer_key, fresh_start),
+            ColorObjective(movable, obj_terms.consumer_ports, obj_terms.producer_key, fresh_start, tuning),
         )
         if conflict is not None:
             demoted = slot_by_reg.get(conflict)
@@ -652,6 +655,7 @@ def _allocate(
     block_term_offset: dict[int, int],
     block_inflight: dict[int, dict[ValueId, int]],
     fetch_lag: int,
+    tuning: RegallocTuning,
 ) -> Allocation:
     """
     Assign wide and boolean registers across the CFG. Both banks are colored by hardware-frame liveness, reusing
@@ -672,10 +676,19 @@ def _allocate(
         for bid, spills in block_inflight.items()
     }
     float_alloc = _allocate_bank(
-        _WIDE, mir, float_mir, block_sched, inst_of, block_makespan, block_term_offset, float_inflight, fetch_lag
+        _WIDE,
+        mir,
+        float_mir,
+        block_sched,
+        inst_of,
+        block_makespan,
+        block_term_offset,
+        float_inflight,
+        fetch_lag,
+        tuning,
     )
     bool_alloc = _allocate_bank(
-        _BOOL, mir, bool_mir, block_sched, inst_of, block_makespan, block_term_offset, bool_inflight, fetch_lag
+        _BOOL, mir, bool_mir, block_sched, inst_of, block_makespan, block_term_offset, bool_inflight, fetch_lag, tuning
     )
 
     # A phi arm coalesced onto the merged register needs no install copy: the arm value already resides in the phi's

--- a/holoso/_lir/_build.py
+++ b/holoso/_lir/_build.py
@@ -26,6 +26,7 @@ from ._portassign import assign_commutative_ports
 from ._schedule import resolve_pool
 from ._bankalloc import actual_install_blocks, install_source_commit, layout_and_allocate
 from ._build_base import Allocation, PooledConst
+from ._regalloc import RegallocTuning
 from ._construct import (
     bool_operand,
     build_inline_op,
@@ -42,15 +43,17 @@ from ._layout import install_inclusive_makespan, layout_blocks
 _logger = logging.getLogger(__name__)
 
 
-def build(mir: Mir, module_name: str, fetch_stages: int) -> Lir:
+def build(mir: Mir, module_name: str, fetch_stages: int, tuning: RegallocTuning) -> Lir:
     """
     Schedule, bind, and register-allocate selected MIR into a pipelined microprogram. A straight-line kernel is the
     degenerate single-``Ret``-block control-flow graph, so there is one build path for every kernel. ``fetch_stages``
     is the control-fetch pipeline depth; the datapath lags the fetch by one less than it, the lag threaded throughout.
     """
+    if fetch_stages != 3:
+        raise ValueError(f"only the 3-stage control fetch is implemented, got {fetch_stages}")
     if not mir.outputs:
         raise UnsupportedConstruct("Synthesized kernel must produce at least one output value")
-    lir = _build_program(mir, module_name, fetch_stages - 1)
+    lir = _build_program(mir, module_name, fetch_stages - 1, tuning)
     names = [port.name for port in lir.ports]
     duplicates = sorted({name for name in names if names.count(name) > 1})
     if duplicates:
@@ -122,7 +125,7 @@ def _has_state_copy(
     )
 
 
-def _build_program(mir: Mir, module_name: str, fetch_lag: int) -> Lir:
+def _build_program(mir: Mir, module_name: str, fetch_lag: int, tuning: RegallocTuning) -> Lir:
     """
     Build the microprogram for any kernel (a straight-line kernel is the degenerate single-``Ret``-block graph):
     schedule each block independently, pool operator instances across the mutually-exclusive blocks, color both register
@@ -188,7 +191,9 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int) -> Lir:
     pinned_push: set[int] = set()
     state_copy_latched = False
     for round_index in range(3 * len(mir.blocks) + 4):
-        result = layout_and_allocate(mir, float_mir, bool_mir, pool, has_install_blocks, has_state_copy, fetch_lag)
+        result = layout_and_allocate(
+            mir, float_mir, bool_mir, pool, has_install_blocks, has_state_copy, fetch_lag, tuning
+        )
         raw = actual_install_blocks(result.alloc, float_mir, bool_mir, result.overlap.block_sched)
         # The two derivations of install-bearing -- the CFG-shape seed and the post-allocation copies -- must agree on
         # the key universe: a block outside the seed can never install, so a wider ``raw`` means the derivations

--- a/holoso/_lir/_build_base.py
+++ b/holoso/_lir/_build_base.py
@@ -11,7 +11,7 @@ from .._operators import BoolInversion, FloatSignControl
 from .._util import ValueId
 from ._ir import ReadPort
 from ._schedule import Schedule
-from ._regalloc import Producer
+from ._regalloc import Producer, RegallocTuning
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,11 +72,12 @@ class OverlapLayout:
 class ColorObjective:
     """
     One bank's steering inputs to quotient coloring, beyond the interference graph and pins: the deterministic movable
-    order, the per-value consumer read ports and producers (the write-select objective), and the first freely
-    assignable register. Threaded together because the colorer consumes them as a unit.
+    order, the per-value consumer read ports and producers (the write-select objective), the first freely assignable
+    register, and the allocator tuning. Threaded together because the colorer consumes them as a unit.
     """
 
     movable: list[ValueId]
     consumer_ports: dict[ValueId, set[ReadPort]]
     producer_key: dict[ValueId, frozenset[Producer]]
     fresh_start: int
+    tuning: RegallocTuning

--- a/holoso/_lir/_coalesce.py
+++ b/holoso/_lir/_coalesce.py
@@ -177,6 +177,7 @@ def _color_quotient(
             consumer_ports=q_ports,
             producer_key={head: frozenset(producers) for head, producers in q_producers.items()},
             fresh_start=objective.fresh_start,
+            tuning=objective.tuning,
         )
     )
     assign = {vid: q_assign[lead(vid)] for vid in interferes}

--- a/holoso/_lir/_regalloc.py
+++ b/holoso/_lir/_regalloc.py
@@ -18,9 +18,9 @@ write port fans into one place.
 
 Register count is a bounded *secondary* objective. A register costs flip-flops but no steering, so it is worth shedding
 only when doing so widens a write select modestly: the allocator colors twice -- once reach-minimal, once compacting
-into shared registers up to a write-select cap -- and keeps whichever minimizes ``reach + _REG_PRICE * registers`` (see
-those constants). The reach-minimal coloring is always a candidate, so trading for fewer registers never raises steering
-by more than the price paid per register freed.
+into shared registers up to a write-select cap -- and keeps whichever minimizes ``reach + price * registers`` (see
+:class:`RegallocTuning`). The reach-minimal coloring is always a candidate, so trading for fewer registers never raises
+steering by more than the price paid per register freed.
 
 The allocator is a port-affinity-biased graph coloring (each value takes the same-interference-free register of least
 marginal mux growth), refined by simulated annealing. Pinned values (input ports on the low load lanes, state live-ins
@@ -31,7 +31,6 @@ simply opens a new register.
 
 from collections import Counter
 from dataclasses import dataclass
-import os
 
 import numpy as np
 from scipy.optimize import dual_annealing
@@ -43,27 +42,21 @@ from ._ir import OperatorInstance, ReadPort
 # the write-select fan-in objective. The read-port identity ``ReadPort`` lives in ``_ir`` beside its enumerator.
 type Producer = OperatorInstance | str
 
-
-# Budget for the SciPy dual-annealing refinement. It only polishes an already-valid greedy seed (and is a no-op when
-# the seed is already at the reach floor), so the function-evaluation cap keeps build time bounded; raise it to trade
-# build time for a deeper search. The environment override is for testing only; eventually we might add an API handle.
-_REFINE_MAXITER = int(os.getenv("HOLOSO_REGALLOC_EFFORT", "5000"))
-
-# Balance of reach against register count, layered on the hardware-accurate liveness. ``_REG_REUSE_WRITE_CAP`` bounds
-# how wide a per-register write select the compaction may build (the ":1" of the select -- the number of distinct
-# producers sharing a register); reuse never widens a read mux beyond a fresh register, so the write select is the only
-# mux a compacted coloring can grow. ``_REG_PRICE`` is what one freed register is worth in mux-arm units: the allocator
-# keeps whichever coloring minimizes ``reach + _REG_PRICE * registers``. The price bounds the spectrum -- price 0 stays
-# reach-minimal (registers only break a reach tie), price -> inf takes every register the cap can free, and a fractional
-# price compacts only when a register comes near reach-free. The default 2.0 sheds one register off each bundled small
-# kernel with f_max held and selects no wider than 2:1.
-#
-# These two are EXPERIMENTAL / ADVANCED knobs with no user-facing surface; they are read once from the environment for
-# tuning and may be promoted to proper parameters if a real need arises.
-_REG_REUSE_WRITE_CAP = int(os.getenv("HOLOSO_REG_REUSE_WRITE_CAP", "2"))
-_REG_PRICE = float(os.getenv("HOLOSO_REG_PRICE", "2.0"))
 _NO_CAP = 1 << 30  # an effectively unbounded write-select budget, used for the reach-minimal coloring
 _INFEASIBLE_COST = 1e18  # annealing penalty for an undecodable point (far above any real mux-fan-in objective)
+
+
+@dataclass(frozen=True, slots=True)
+class RegallocTuning:
+    """
+    ``effort`` is the annealing function-evaluation budget, ``reuse_write_cap`` bounds the per-register write select
+    the compaction may build, and ``register_price`` is what one freed register is worth in mux-arm units: the
+    allocator minimizes ``reach + register_price * registers``.
+    """
+
+    effort: int
+    reuse_write_cap: int
+    register_price: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,6 +87,7 @@ class ColoringProblem:
     consumer_ports: dict[ValueId, set[ReadPort]]
     producer_key: dict[ValueId, frozenset[Producer]]
     fresh_start: int
+    tuning: RegallocTuning
 
 
 def color(problem: ColoringProblem) -> tuple[dict[ValueId, int], int]:
@@ -102,7 +96,7 @@ def color(problem: ColoringProblem) -> tuple[dict[ValueId, int], int]:
     cheaper of the two by ``reach + price * registers``, refined by simulated annealing. Reduces to the straight-line
     coloring on a single block because the interference graph there is exactly the interval-overlap graph.
     """
-    cap, price = _REG_REUSE_WRITE_CAP, _REG_PRICE
+    cap, price = problem.tuning.reuse_write_cap, problem.tuning.register_price
 
     def greedy_seed(compact: bool, budget: int) -> tuple[dict[ValueId, int], int]:
         seed = _color_greedy(problem, compact, budget)
@@ -233,7 +227,8 @@ def _color_refine(problem: ColoringProblem, seed: dict[ValueId, int], nreg: int,
             writers[chosen].update(problem.producer_key[vid])
         return assign
 
-    if _REFINE_MAXITER <= 0:
+    effort = problem.tuning.effort
+    if effort <= 0:
         return seed
     best = seed
     best_cost = _objective(seed, problem.consumer_ports, problem.producer_key)
@@ -252,7 +247,7 @@ def _color_refine(problem: ColoringProblem, seed: dict[ValueId, int], nreg: int,
 
     x0 = np.array([float(seed[vid]) for vid in order])
     bounds = [(0.0, nreg - 1e-6)] * len(order)
-    dual_annealing(cost, bounds, x0=x0, seed=0, maxiter=_REFINE_MAXITER, maxfun=_REFINE_MAXITER, no_local_search=True)
+    dual_annealing(cost, bounds, x0=x0, seed=0, maxiter=effort, maxfun=effort, no_local_search=True)
     return best
 
 

--- a/holoso/_mir/_lower.py
+++ b/holoso/_mir/_lower.py
@@ -383,7 +383,8 @@ class _LoweringContext:
     def __init__(self, hir: Hir, ops: OpConfig) -> None:
         self.hir = hir
         self.ops = ops
-        self.builder = MirBuilder(ops.float_format)
+        self.float_format = ops.float_format
+        self.builder = MirBuilder(self.float_format)
         self.remap: dict[ValueId, ValueId] = {}
         self.fma_plans = _plan_fma_fusions(hir, ops)
         self.fused_muls = {plan.mul for plan in self.fma_plans.values()}
@@ -465,7 +466,7 @@ class _LoweringContext:
     def _phi_scalar_type(self, node: Phi) -> ScalarType:
         match node.type:
             case HirFloatType():
-                return ScalarFloatType(self.ops.float_format)
+                return ScalarFloatType(self.float_format)
             case HirBoolType():
                 return ScalarBoolType()
             case _:
@@ -507,9 +508,9 @@ class _LoweringContext:
                 # into the same pooled fcmp operator and can fuse into one firing.
                 base_a, sign_a = _collapse_signs(self.hir.nodes, a)
                 base_b, sign_b = _collapse_signs(self.hir.nodes, b)
-                port, inversion = self.ops.fcmp.tap_of(_FCMP_RELATION[type(semantic)])
+                port, inversion = self.ops.require("fcmp").tap_of(_FCMP_RELATION[type(semantic)])
                 self.remap[old_id] = self.builder.operation(
-                    _select_hardware(semantic, self.ops.fcmp),
+                    _select_hardware(semantic, self.ops.require("fcmp")),
                     [self.remap[base_a], self.remap[base_b]],
                     [sign_a, sign_b],
                     output_port=port,
@@ -546,7 +547,7 @@ class _LoweringContext:
                 # writes the boolean bank, like the comparison but with an inline exponent reduction in place of fcmp.
                 base, sign = _collapse_signs(self.hir.nodes, a)
                 self.remap[old_id] = self.builder.operation(
-                    _select_hardware(semantic, FloatToBoolOperator(self.ops.float_format)), [self.remap[base]], [sign]
+                    _select_hardware(semantic, FloatToBoolOperator(self.float_format)), [self.remap[base]], [sign]
                 )
                 return True
             case _:
@@ -602,7 +603,7 @@ class _LoweringContext:
 class _FloatLowerer:
     def __init__(self, context: _LoweringContext) -> None:
         self.context = context
-        self.float_type = ScalarFloatType(context.ops.float_format)
+        self.float_type = ScalarFloatType(context.float_format)
 
     def lower_node(self, old_id: ValueId, node: Node) -> bool:
         match node:
@@ -644,9 +645,9 @@ class _FloatLowerer:
 
     def lower_directional_inf(self, plan: _DirectionalInfPlan) -> ValueId:
         operator: FloatClassificationOperator = (
-            FloatIsPosInfOperator(self.context.ops.float_format)
+            FloatIsPosInfOperator(self.context.float_format)
             if isinstance(plan.semantic, FloatIsPosInf)
-            else FloatIsNegInfOperator(self.context.ops.float_format)
+            else FloatIsNegInfOperator(self.context.float_format)
         )
         return self.context.builder.operation(
             _select_hardware(plan.semantic, operator), [self.context.remap[plan.operand]], [plan.sign]
@@ -655,11 +656,11 @@ class _FloatLowerer:
     def _lower_operation(self, node: Operation) -> ValueId | None:
         match node:
             case Operation(operator=FloatAdd() as semantic, operands=(a, b)):
-                return self._lower_binary_float(semantic, self.context.ops.fadd, a, b)
+                return self._lower_binary_float(semantic, self.context.ops.require("fadd"), a, b)
             case Operation(operator=FloatMul() as semantic, operands=(a, b)):
-                return self._lower_binary_float(semantic, self.context.ops.fmul, a, b)
+                return self._lower_binary_float(semantic, self.context.ops.require("fmul"), a, b)
             case Operation(operator=FloatDiv() as semantic, operands=(a, b)):
-                return self._lower_binary_float(semantic, self.context.ops.fdiv, a, b)
+                return self._lower_binary_float(semantic, self.context.ops.require("fdiv"), a, b)
             case Operation(operator=FloatMulPow2(k=k) as semantic, operands=(a,)):
                 return self._lower_float_mul_pow2(semantic, a, k)
             case Operation(
@@ -667,9 +668,9 @@ class _FloatLowerer:
             ):
                 return self._lower_round(semantic, a)
             case Operation(operator=FloatExp2() as semantic, operands=(a,)):
-                return self._lower_unary_pooled(semantic, self.context.ops.fexp2, "fexp2", a)
+                return self._lower_unary_pooled(semantic, self.context.ops.require("fexp2"), a)
             case Operation(operator=FloatLog2() as semantic, operands=(a,)):
-                return self._lower_unary_pooled(semantic, self.context.ops.flog2, "flog2", a)
+                return self._lower_unary_pooled(semantic, self.context.ops.require("flog2"), a)
             case Operation(operator=(FloatSin() | FloatCos()) as semantic, operands=(a,)):
                 return self._lower_sincos(semantic, a)
             case Operation(operator=FloatSqrt() as semantic, operands=(a,)):
@@ -688,7 +689,7 @@ class _FloatLowerer:
                 # operand conditioner.
                 base, inversion = _collapse_bool_inversions(self.context.hir.nodes, a)
                 return self.context.builder.operation(
-                    _select_hardware(semantic, BoolToFloatOperator(self.context.ops.float_format)),
+                    _select_hardware(semantic, BoolToFloatOperator(self.context.float_format)),
                     [self.context.remap[base]],
                     [inversion],
                 )
@@ -699,19 +700,12 @@ class _FloatLowerer:
                 base_a, sign_a = _collapse_signs(self.context.hir.nodes, a)
                 base_b, sign_b = _collapse_signs(self.context.hir.nodes, b)
                 return self.context.builder.operation(
-                    _select_hardware(semantic, SelectOperator(self.context.ops.float_format)),
+                    _select_hardware(semantic, SelectOperator(self.context.float_format)),
                     [self.context.remap[base_c], self.context.remap[base_a], self.context.remap[base_b]],
                     [inv_c, sign_a, sign_b],
                 )
             case _:
                 return None
-
-    def _require(self, operator: FloatHardwareOperator | None, semantic: Operator, field: str) -> FloatHardwareOperator:
-        if operator is None:
-            raise UnsupportedConstruct(
-                f"the kernel uses {semantic.mnemonic!r} but no {field!r} operator is configured; add it to OpConfig"
-            )
-        return operator
 
     def _lower_binary_float(
         self, semantic: Operator, hardware: FloatHardwareOperator, a: ValueId, b: ValueId, output_port: int = 0
@@ -735,11 +729,7 @@ class _FloatLowerer:
         absolute onto both (|a*b| = |a||b|) -- composed with each operand's own folded chain; c keeps its own.
         The raise fires only for explicit math.fma, since a contraction plan exists only when ffma is configured.
         """
-        operator = self.context.ops.ffma
-        if operator is None:
-            raise UnsupportedConstruct(
-                "the kernel uses math.fma but no 'ffma' operator is configured; add it to OpConfig"
-            )
+        operator = self.context.ops.require("ffma")
         base_a, sign_a = _collapse_signs(self.context.hir.nodes, a)
         base_b, sign_b = _collapse_signs(self.context.hir.nodes, b)
         base_c, sign_c = _collapse_signs(self.context.hir.nodes, c)
@@ -758,20 +748,19 @@ class _FloatLowerer:
             FloatCeil: FRoundOperator.Mode.CEIL,
             FloatTrunc: FRoundOperator.Mode.TRUNC,
         }[type(semantic)]
-        return self._lower_unary_pooled(semantic, self.context.ops.fround, "fround", a, immediates=(int(mode),))
+        return self._lower_unary_pooled(semantic, self.context.ops.require("fround"), a, immediates=(int(mode),))
 
     def _lower_unary_pooled(
         self,
         semantic: Operator,
-        operator: FloatHardwareOperator | None,
-        config_field: str,
+        operator: FloatHardwareOperator,
         a: ValueId,
         immediates: tuple[int, ...] = (),
     ) -> ValueId:
         # Sign chain folds onto the operand (applied before the op): floor(-x)/exp2(-x) feed -x, not -floor(x)/-exp2(x).
         base, sign = _collapse_signs(self.context.hir.nodes, a)
         return self.context.builder.operation(
-            _select_hardware(semantic, self._require(operator, semantic, config_field)),
+            _select_hardware(semantic, operator),
             [self.context.remap[base]],
             [sign],
             immediates=immediates,
@@ -779,7 +768,7 @@ class _FloatLowerer:
 
     def _lower_minmax(self, semantic: FloatMin | FloatMax, a: ValueId, b: ValueId) -> ValueId:
         # min taps the low output port, max the high one; a min and a max over one pair fuse into one sorter firing.
-        operator = self._require(self.context.ops.fsort, semantic, "fsort")
+        operator = self.context.ops.require("fsort")
         return self._lower_binary_float(
             semantic, operator, a, b, output_port=0 if isinstance(semantic, FloatMin) else 1
         )
@@ -788,11 +777,11 @@ class _FloatLowerer:
         # The turn-native zkf_sincos is fed radians/(2*pi) via a VISIBLE fmul -- its rounding is part of the model<->RTL
         # contract and must not hide in the wrapper. The sign folds onto that fmul, so one scaled value serves
         # sin(-x)/cos(-x) and a sin+cos over one argument fuse into one firing.
-        operator = self._require(self.context.ops.fsincos, semantic, "fsincos")
+        operator = self.context.ops.require("fsincos")
         base, sign = _collapse_signs(self.context.hir.nodes, a)
         inv_tau = self._lower_float_const(1.0 / (2.0 * math.pi))
         scaled = self.context.builder.operation(
-            _select_hardware(semantic, self.context.ops.fmul),
+            _select_hardware(semantic, self.context.ops.require("fmul")),
             [self.context.remap[base], inv_tau],
             [sign, FloatSignControl()],
         )
@@ -801,10 +790,10 @@ class _FloatLowerer:
     def _lower_atan2(self, semantic: FloatAtan2, y: ValueId, x: ValueId) -> ValueId:
         # zkf_atan2 returns theta in turns; a visible post-scale by 2*pi gives radians. Its magnitude port is tapped
         # only by a fusible adjacent hypot (intercepted in lower_node).
-        operator = self._require(self.context.ops.fatan2, semantic, "fatan2")
+        operator = self.context.ops.require("fatan2")
         turns = self._lower_binary_float(semantic, operator, y, x)
         tau = self._lower_float_const(2.0 * math.pi)
-        return self._mir_op(semantic, self.context.ops.fmul, [turns, tau])
+        return self._mir_op(semantic, self.context.ops.require("fmul"), [turns, tau])
 
     def _lower_fused_hypot(self, atan2_id: ValueId) -> ValueId:
         # Emitting the fatan2 firing from the ATAN2's own operands/signs makes the two collapse into one CORDIC; the
@@ -823,7 +812,8 @@ class _FloatLowerer:
         The mux keeps those internal divisions finite while the surrounding formula still returns 0 or inf.
         """
         ops = self.context.ops
-        fsort = self._require(ops.fsort, semantic, "fsort")
+        fsort = ops.require("fsort")
+        fmul = ops.require("fmul")
         base_y, sign_y = _collapse_signs(self.context.hir.nodes, y)
         base_x, sign_x = _collapse_signs(self.context.hir.nodes, x)
         my, mx = self.context.remap[base_y], self.context.remap[base_x]
@@ -834,18 +824,17 @@ class _FloatLowerer:
         bypass = self._bool_or(self._float_eq_zero(h, FloatSignControl()), self._float_isinf(h))
         safe_h = self._float_select(bypass, self._lower_float_const(1.0), h)
         xn = self.context.builder.operation(
-            _select_hardware(semantic, ops.fdiv), [mx, safe_h], [sign_x, FloatSignControl()]
+            _select_hardware(semantic, ops.require("fdiv")), [mx, safe_h], [sign_x, FloatSignControl()]
         )
         yn = self.context.builder.operation(
-            _select_hardware(semantic, ops.fdiv), [my, safe_h], [sign_y, FloatSignControl()]
+            _select_hardware(semantic, ops.require("fdiv")), [my, safe_h], [sign_y, FloatSignControl()]
         )
         squares = self._mir_op(
-            semantic, ops.fadd, [self._mir_op(semantic, ops.fmul, [xn, xn]), self._mir_op(semantic, ops.fmul, [yn, yn])]
+            semantic,
+            ops.require("fadd"),
+            [self._mir_op(semantic, fmul, [xn, xn]), self._mir_op(semantic, fmul, [yn, yn])],
         )
-        computed = self._mir_op(
-            semantic, ops.fmul, [h, self._sqrt_via_exp2_log2(semantic, squares, FloatSignControl())]
-        )
-        return computed
+        return self._mir_op(semantic, fmul, [h, self._sqrt_via_exp2_log2(semantic, squares, FloatSignControl())])
 
     def _sqrt_via_exp2_log2(self, semantic: Operator, operand: ValueId, conditioner: FloatSignControl) -> ValueId:
         """
@@ -858,18 +847,18 @@ class _FloatLowerer:
         zero = self._lower_float_const(0.0)
         safe_operand = self._float_select(is_zero, self._lower_float_const(1.0), operand, sign_b=conditioner)
         log = self.context.builder.operation(
-            _select_hardware(semantic, self._require(ops.flog2, semantic, "flog2")),
+            _select_hardware(semantic, ops.require("flog2")),
             [safe_operand],
             [FloatSignControl()],
         )
-        half = self._mir_op(semantic, ops.fmul_ilog2.instantiate(-1), [log])
-        sqrt = self._mir_op(semantic, self._require(ops.fexp2, semantic, "fexp2"), [half])
+        half = self._mir_op(semantic, ops.require("fmul_ilog2").instantiate(-1), [log])
+        sqrt = self._mir_op(semantic, ops.require("fexp2"), [half])
         return self._float_select(is_zero, zero, sqrt)
 
     def classification_lowering(
         self, semantic: FloatIsFinite | FloatIsInf | FloatIsPosInf | FloatIsNegInf
     ) -> tuple[FloatClassificationOperator, BoolInversion]:
-        fmt = self.context.ops.float_format
+        fmt = self.context.float_format
         match semantic:
             case FloatIsFinite():
                 return FloatIsFiniteOperator(fmt), BoolInversion()
@@ -881,9 +870,10 @@ class _FloatLowerer:
                 return FloatIsNegInfOperator(fmt), BoolInversion()
 
     def _float_eq_zero(self, operand: ValueId, conditioner: FloatSignControl) -> ValueId:
-        port, inversion = self.context.ops.fcmp.tap_of(_FCMP_RELATION[FloatEqual])
+        fcmp = self.context.ops.require("fcmp")
+        port, inversion = fcmp.tap_of(_FCMP_RELATION[FloatEqual])
         return self.context.builder.operation(
-            _select_hardware(FloatEqual(), self.context.ops.fcmp),
+            _select_hardware(FloatEqual(), fcmp),
             [operand, self._lower_float_const(0.0)],
             [conditioner, FloatSignControl()],
             output_port=port,
@@ -912,7 +902,7 @@ class _FloatLowerer:
         sign_b: FloatSignControl = FloatSignControl(),
     ) -> ValueId:
         return self.context.builder.operation(
-            _select_hardware(Select(), SelectOperator(self.context.ops.float_format)),
+            _select_hardware(Select(), SelectOperator(self.context.float_format)),
             [cond, a, b],
             [BoolInversion(), sign_a, sign_b],
         )
@@ -930,8 +920,9 @@ class _FloatLowerer:
 
     def _lower_float_mul_pow2(self, semantic: Operator, a: ValueId, k: int) -> ValueId:
         base, sign = _collapse_signs(self.context.hir.nodes, a)
+        family = self.context.ops.require("fmul_ilog2")
         try:
-            operator = _select_hardware(semantic, self.context.ops.fmul_ilog2.instantiate(k))
+            operator = _select_hardware(semantic, family.instantiate(k))
         except ValueError as exc:
             # An out-of-range exponent is rejected rather than lowered to a constant multiply by 2**k: such a k always
             # lies outside the format's representable range, so the fallback multiply would be degenerate.

--- a/holoso/_mir/_lower.py
+++ b/holoso/_mir/_lower.py
@@ -1,7 +1,7 @@
 """Lower optimized HIR to selected MIR."""
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 from .._errors import UnsupportedConstruct
 from .._hir import (
@@ -87,7 +87,7 @@ from .._operators import (
     Relation,
     SelectOperator,
 )
-from .._type import BoolType as ScalarBoolType, FloatType as ScalarFloatType, ScalarType
+from .._type import BoolType as ScalarBoolType, FloatFormat, FloatType as ScalarFloatType, ScalarType
 from ._ir import Mir, MirBuilder
 
 # The seam between the semantic relation and the comparator flag it taps; the two vocabularies meet only here.
@@ -380,11 +380,14 @@ def _plan_hypot_fusions(hir: Hir, ops: OpConfig) -> dict[ValueId, ValueId]:
 
 
 class _LoweringContext:
-    def __init__(self, hir: Hir, ops: OpConfig) -> None:
+    def __init__(self, hir: Hir, ops: OpConfig, float_format: FloatFormat) -> None:
         self.hir = hir
         self.ops = ops
-        self.float_format = ops.float_format
-        self.builder = MirBuilder(self.float_format)
+        self.float_format = float_format
+        assert all(
+            getattr(ops, field.name) is None or getattr(ops, field.name).fmt == float_format for field in fields(ops)
+        ), "every configured operator must be built for the machine's float format"
+        self.builder = MirBuilder(float_format)
         self.remap: dict[ValueId, ValueId] = {}
         self.fma_plans = _plan_fma_fusions(hir, ops)
         self.fused_muls = {plan.mul for plan in self.fma_plans.values()}
@@ -946,7 +949,7 @@ class _FloatLowerer:
         return True
 
 
-def lower(hir: Hir, ops: OpConfig) -> Mir:
+def lower(hir: Hir, ops: OpConfig, float_format: FloatFormat) -> Mir:
     """
     Select hardware operators from the configuration and fold semantic signs onto MIR sign controls.
 
@@ -954,4 +957,4 @@ def lower(hir: Hir, ops: OpConfig) -> Mir:
     ``fmul_ilog2_const`` when supported by the configured float format; unsupported exponents are rejected.
     """
     _reject_integers(hir)
-    return _LoweringContext(hir, ops).run()
+    return _LoweringContext(hir, ops, float_format).run()

--- a/holoso/_operators.py
+++ b/holoso/_operators.py
@@ -6,10 +6,11 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, fields
 from enum import Enum, IntEnum
 from hashlib import blake2s
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import zkf
 
+from ._errors import UnsupportedConstruct
 from ._value import FloatValue
 from ._type import BoolType, FloatFormat, FloatType, ScalarSignature, ScalarType
 
@@ -289,24 +290,28 @@ class FloatParameterizedHardwareOperator(ParameterizedHardwareOperator, ABC):
 
 @dataclass(frozen=True, slots=True)
 class FAddOperator(FloatHardwareOperator):
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0  # takes any count of input register stages (extra stages relieve routing congestion)
+        stage_decode: int = 0
+        stage_align: int = 0
+        stage_normalize: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "fadd"
     swap_output_permutation: ClassVar[tuple[int, ...]] = (0,)  # signed sum: a+b == b+a bit-for-bit
-    stage_input: int = 0  # takes any count of input register stages (extra stages relieve routing congestion)
-    stage_decode: int = 0
-    stage_align: int = 0
-    stage_normalize: int = 0
-    stage_pack: int = 0
-    stage_output: int = 0
+    opt: Options
 
     def __post_init__(self) -> None:
         model = zkf.AddModel(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            stage_input=self.stage_input,
-            stage_decode=self.stage_decode,
-            stage_align=self.stage_align,
-            stage_normalize=self.stage_normalize,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            stage_input=self.opt.stage_input,
+            stage_decode=self.opt.stage_decode,
+            stage_align=self.opt.stage_align,
+            stage_normalize=self.opt.stage_normalize,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -325,20 +330,26 @@ class FAddOperator(FloatHardwareOperator):
 
 @dataclass(frozen=True, slots=True)
 class FMulOperator(FloatHardwareOperator):
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
+        stage_product: int = 0  # splitting the product is rarely useful unless wman exceeds the DSP slice input width
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "fmul"
     swap_output_permutation: ClassVar[tuple[int, ...]] = (0,)  # product: a*b == b*a bit-for-bit
-    stage_input: int = 0
-    stage_product: int = 0
-    stage_pack: int = 0
-    stage_output: int = 0
+    opt: Options
+    wmultiplier: int
 
     def __post_init__(self) -> None:
         model = zkf.MulModel(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            stage_input=self.stage_input,
-            stage_product=self.stage_product,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            wmultiplier=self.wmultiplier,
+            stage_input=self.opt.stage_input,
+            stage_product=self.opt.stage_product,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -357,18 +368,22 @@ class FMulOperator(FloatHardwareOperator):
 
 @dataclass(frozen=True, slots=True)
 class FDivOperator(FloatHardwareOperator):
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "fdiv"
     error_ports: ClassVar[list[str]] = ["div0"]
-    stage_input: int = 0
-    stage_pack: int = 0
-    stage_output: int = 0
+    opt: Options
 
     def __post_init__(self) -> None:
         model = zkf.DivModel(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            stage_input=self.stage_input,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            stage_input=self.opt.stage_input,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -389,17 +404,21 @@ class FDivOperator(FloatHardwareOperator):
 class FMulILog2Operator(FloatHardwareOperator):
     """Exact scaling by a power of two, ``a * 2**k``; the concrete operator the family returns."""
 
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
+        stage_decode: int = 0
+
     mnemonic: ClassVar[str] = "fmul_ilog2_const"
     k: int
-    stage_input: int = 0
-    stage_decode: int = 0
+    opt: Options
 
     def __post_init__(self) -> None:
         model = zkf.MulIlog2ConstModel(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
             k=self.k,
-            stage_input=self.stage_input,
-            stage_decode=self.stage_decode,
+            stage_input=self.opt.stage_input,
+            stage_decode=self.opt.stage_decode,
         )
         object.__setattr__(self, "_model", model)
 
@@ -420,12 +439,11 @@ class FMulILog2Operator(FloatHardwareOperator):
 class FMulILog2OperatorFamily(FloatParameterizedHardwareOperator):
     """The ilog2 family: a factory whose stage knobs are baked into every concrete operator it instantiates."""
 
-    stage_input: int = 0
-    stage_decode: int = 0
+    opt: FMulILog2Operator.Options
 
     def instantiate(self, *params: int) -> FMulILog2Operator:
         (k,) = params
-        return FMulILog2Operator(fmt=self.fmt, k=k, stage_input=self.stage_input, stage_decode=self.stage_decode)
+        return FMulILog2Operator(fmt=self.fmt, k=k, opt=self.opt)
 
 
 @dataclass(frozen=True, slots=True)
@@ -436,6 +454,10 @@ class FCmpOperator(FloatHardwareOperator):
     optional inversion (ZKF has no NaN, so the ordering is total and every relation is one flag or its complement);
     one instance therefore serves every relation, and several relations over the same operands fuse into one firing.
     """
+
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
 
     mnemonic: ClassVar[str] = "fcmp"
     output_hdl_ports: ClassVar[list[str]] = ["a_gt_b", "a_eq_b", "a_lt_b"]
@@ -458,10 +480,10 @@ class FCmpOperator(FloatHardwareOperator):
     # (eq fixed) -- the comparator is commutative under that flag exchange, which lets port assignment orient its
     # operands freely.
     swap_output_permutation: ClassVar[tuple[int, ...]] = (2, 1, 0)
-    stage_input: int = 0
+    opt: Options
 
     def __post_init__(self) -> None:
-        model = zkf.CmpModel(zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman), stage_input=self.stage_input)
+        model = zkf.CmpModel(zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman), stage_input=self.opt.stage_input)
         object.__setattr__(self, "_model", model)
 
     @property
@@ -496,16 +518,21 @@ class FCmpOperator(FloatHardwareOperator):
 class FRoundOperator(FloatHardwareOperator):
     """
     Round a float to an integral-valued float. One pooled instance serves all four modes (nearest-even, floor, ceil,
-    trunc) via the 2-bit ``round_mode`` immediate, as one comparator serves every relation. The zkf core is
-    combinational, so a register stage (``stage_output`` defaults to 1) keeps the pooled latency at least one cycle.
+    trunc) via the 2-bit ``round_mode`` immediate, as one comparator serves every relation.
     """
+
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        """The zkf core is combinational, hence the nonzero default: a pooled operator needs latency >= 1."""
+
+        stage_input: int = 1
+        stage_decode: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
 
     mnemonic: ClassVar[str] = "fround"
     immediate_ports: ClassVar[list[ImmediateField]] = [ImmediateField("round_mode", 2)]
-    stage_input: int = 0
-    stage_decode: int = 0
-    stage_pack: int = 0
-    stage_output: int = 1
+    opt: Options
 
     class Mode(IntEnum):
         """Matches the mode encoding in holoso_fround"""
@@ -525,10 +552,10 @@ class FRoundOperator(FloatHardwareOperator):
     def __post_init__(self) -> None:
         model = zkf.RoundModel(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            stage_input=self.stage_input,
-            stage_decode=self.stage_decode,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            stage_input=self.opt.stage_input,
+            stage_decode=self.opt.stage_decode,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
         if self.latency < 1:
@@ -556,25 +583,31 @@ class FFmaOperator(FloatHardwareOperator):
     explicit ``math.fma`` and the implicit ``a*b+c`` fusion. Not commutative under operand reversal (gives ``c*b+a``).
     """
 
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
+        stage_product: int = 0
+        stage_decode: int = 0
+        stage_align: int = 0
+        stage_normalize: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "ffma"
-    stage_input: int = 0
-    stage_product: int = 0
-    stage_decode: int = 0
-    stage_align: int = 0
-    stage_normalize: int = 0
-    stage_pack: int = 0
-    stage_output: int = 0
+    opt: Options
+    wmultiplier: int
 
     def __post_init__(self) -> None:
         model = zkf.FmaModel(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            stage_input=self.stage_input,
-            stage_product=self.stage_product,
-            stage_decode=self.stage_decode,
-            stage_align=self.stage_align,
-            stage_normalize=self.stage_normalize,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            wmultiplier=self.wmultiplier,
+            stage_input=self.opt.stage_input,
+            stage_product=self.opt.stage_product,
+            stage_decode=self.opt.stage_decode,
+            stage_align=self.opt.stage_align,
+            stage_normalize=self.opt.stage_normalize,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -601,12 +634,16 @@ class FSortOperator(FloatHardwareOperator):
     operand, so swapping operands can flip the sign of a zero result (a -0 conditioned from a zero magnitude).
     """
 
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
+
     mnemonic: ClassVar[str] = "fsort"
     output_hdl_ports: ClassVar[list[str]] = ["min", "max"]
-    stage_input: int = 0
+    opt: Options
 
     def __post_init__(self) -> None:
-        model = zkf.SortModel(zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman), stage_input=self.stage_input)
+        model = zkf.SortModel(zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman), stage_input=self.opt.stage_input)
         object.__setattr__(self, "_model", model)
 
     @property
@@ -632,21 +669,27 @@ class FSortOperator(FloatHardwareOperator):
 
 @dataclass(frozen=True, slots=True)
 class FExp2Operator(FloatHardwareOperator):
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
+        stage_reduce: int = 0
+        stage_product: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "fexp2"
-    stage_input: int = 0
-    stage_reduce: int = 0
-    stage_product: int = 0
-    stage_pack: int = 0
-    stage_output: int = 0
+    opt: Options
+    wmultiplier: int
 
     def __post_init__(self) -> None:
         model = zkf.Exp2Model(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            stage_input=self.stage_input,
-            stage_reduce=self.stage_reduce,
-            stage_product=self.stage_product,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            wmultiplier=self.wmultiplier,
+            stage_input=self.opt.stage_input,
+            stage_reduce=self.opt.stage_reduce,
+            stage_product=self.opt.stage_product,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -665,28 +708,34 @@ class FExp2Operator(FloatHardwareOperator):
 
 @dataclass(frozen=True, slots=True)
 class FLog2Operator(FloatHardwareOperator):
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_input: int = 0
+        stage_decode: int = 0
+        stage_product: int = 0
+        stage_product_final: int = 0
+        stage_normalize: int = 0
+        stage_normalize_output: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "flog2"
     error_ports: ClassVar[list[str]] = ["domain_error", "pole"]
-    stage_input: int = 0
-    stage_decode: int = 0
-    stage_product: int = 0
-    stage_product_final: int = 0
-    stage_normalize: int = 0
-    stage_normalize_output: int = 0
-    stage_pack: int = 0
-    stage_output: int = 0
+    opt: Options
+    wmultiplier: int
 
     def __post_init__(self) -> None:
         model = zkf.Log2Model(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            stage_input=self.stage_input,
-            stage_decode=self.stage_decode,
-            stage_product=self.stage_product,
-            stage_product_final=self.stage_product_final,
-            stage_normalize=self.stage_normalize,
-            stage_normalize_output=self.stage_normalize_output,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            wmultiplier=self.wmultiplier,
+            stage_input=self.opt.stage_input,
+            stage_decode=self.opt.stage_decode,
+            stage_product=self.opt.stage_product,
+            stage_product_final=self.opt.stage_product_final,
+            stage_normalize=self.opt.stage_normalize,
+            stage_normalize_output=self.opt.stage_normalize_output,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -709,13 +758,6 @@ class _FCordicOperator(FloatHardwareOperator, ABC):
     These are NOT throughput-1: the core holds one transaction in flight and re-accepts one cycle after retiring.
     """
 
-    unroll100: int = 100
-    stage_input: int = 0
-    stage_product: int = 0
-    stage_normalize: int = 0
-    stage_pack: int = 0
-    stage_output: int = 0
-
     def render_output(
         self, port: int, conditioner: "PortConditioner", *operands: str, immediates: tuple[int, ...] = ()
     ) -> str:
@@ -725,18 +767,30 @@ class _FCordicOperator(FloatHardwareOperator, ABC):
 
 @dataclass(frozen=True, slots=True)
 class FSincosOperator(_FCordicOperator):
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        unroll100: int = 100
+        stage_input: int = 0
+        stage_product: int = 0
+        stage_normalize: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "fsincos"
     output_hdl_ports: ClassVar[list[str]] = ["sin", "cos"]
+    opt: Options
+    wmultiplier: int
 
     def __post_init__(self) -> None:
         model = zkf.SincosModel(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            unroll100=self.unroll100,
-            stage_input=self.stage_input,
-            stage_product=self.stage_product,
-            stage_normalize=self.stage_normalize,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            wmultiplier=self.wmultiplier,
+            unroll100=self.opt.unroll100,
+            stage_input=self.opt.stage_input,
+            stage_product=self.opt.stage_product,
+            stage_normalize=self.opt.stage_normalize,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -756,18 +810,32 @@ class FSincosOperator(_FCordicOperator):
 
 @dataclass(frozen=True, slots=True)
 class FAtan2Operator(_FCordicOperator):
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        """A nearby hypot over the same operands folds into the magnitude port for free."""
+
+        unroll100: int = 100
+        stage_input: int = 0
+        stage_product: int = 0
+        stage_normalize: int = 0
+        stage_pack: int = 0
+        stage_output: int = 0
+
     mnemonic: ClassVar[str] = "fatan2"
     output_hdl_ports: ClassVar[list[str]] = ["theta", "mag"]
+    opt: Options
+    wmultiplier: int
 
     def __post_init__(self) -> None:
         model = zkf.Atan2Model(
             zkf.ZkfFormat(self.fmt.wexp, self.fmt.wman),
-            unroll100=self.unroll100,
-            stage_input=self.stage_input,
-            stage_product=self.stage_product,
-            stage_normalize=self.stage_normalize,
-            stage_pack=self.stage_pack,
-            stage_output=self.stage_output,
+            wmultiplier=self.wmultiplier,
+            unroll100=self.opt.unroll100,
+            stage_input=self.opt.stage_input,
+            stage_product=self.opt.stage_product,
+            stage_normalize=self.opt.stage_normalize,
+            stage_pack=self.opt.stage_pack,
+            stage_output=self.opt.stage_output,
         )
         object.__setattr__(self, "_model", model)
 
@@ -788,8 +856,8 @@ class FAtan2Operator(_FCordicOperator):
 @dataclass(frozen=True, slots=True)
 class BoolLogicOperator(InlineHardwareOperator, ABC):
     """
-    A boolean-logic operator (AND/OR/XOR): a plain ``& | ^`` gate folded into its boolean register's write. Never
-    added to :class:`OpConfig` -- it has no module and no configuration.
+    A boolean-logic operator (AND/OR/XOR): a plain ``& | ^`` gate folded into its boolean register's write.
+    Never added to :class:`OpConfig` -- it has no module and no configuration.
     """
 
 
@@ -909,12 +977,6 @@ class FloatIsNegInfOperator(FloatClassificationOperator):
 
 @dataclass(frozen=True, slots=True)
 class FloatToBoolOperator(InlineHardwareOperator):
-    """
-    A float->bool cast ``bool(x)``: true iff the operand is nonzero, i.e. its ZKF exponent field is nonzero (sign- and
-    mantissa-agnostic). Folded into the boolean register write as a call to the shared ``holoso_ftobool`` function;
-    never added to :class:`OpConfig`.
-    """
-
     mnemonic: ClassVar[str] = "ftobool"
     fmt: FloatFormat
 
@@ -940,10 +1002,10 @@ class FloatToBoolOperator(InlineHardwareOperator):
 class SelectOperator(InlineHardwareOperator):
     """
     A data mux ``cond ? a : b`` over wide values, folded into the destination register write as a ternary over the
-    operand nets. Produced by HIR if-conversion and by selected MIR composite lowerings; never added to
-    :class:`OpConfig`. Each operand is a dedicated direct (unlatched) register read -- an area/timing characteristic of
-    inline operators; the cost is one mux per merged value, the same order as the per-arm phi-copy installs the branch
-    would otherwise need.
+    operand nets. Produced by HIR if-conversion and by selected MIR composite lowerings.
+    Each operand is a dedicated direct (unlatched) register read -- an area/timing characteristic of inline operators;
+    the cost is one mux per merged value, the same order as the per-arm phi-copy installs the branch would otherwise
+    need.
     """
 
     mnemonic: ClassVar[str] = "select"
@@ -970,12 +1032,6 @@ class SelectOperator(InlineHardwareOperator):
 
 @dataclass(frozen=True, slots=True)
 class BoolSelectOperator(InlineHardwareOperator):
-    """
-    A boolean mux ``cond ? a : b`` over 1-bit values, the dual of :class:`SelectOperator`, folded into the destination
-    boolean register write as a ternary over the operand nets. Format-agnostic (no ``fmt``); produced exclusively by
-    HIR if-conversion of a boolean-phi diamond; never added to :class:`OpConfig`.
-    """
-
     mnemonic: ClassVar[str] = "bool_select"
 
     @property
@@ -998,13 +1054,6 @@ class BoolSelectOperator(InlineHardwareOperator):
 
 @dataclass(frozen=True, slots=True)
 class BoolToFloatOperator(InlineHardwareOperator):
-    """
-    A bool->float cast ``float(cond)``: ZKF ``1.0`` when true, ``+0.0`` when false. Folded into the wide register
-    write as a call to the shared ``holoso_ffrombool`` function; it reads a boolean register and writes a wide
-    register, the one operator that crosses from the boolean bank into the wide bank. Never added to
-    :class:`OpConfig`.
-    """
-
     mnemonic: ClassVar[str] = "ffrombool"
     fmt: FloatFormat
 
@@ -1025,32 +1074,46 @@ class BoolToFloatOperator(InlineHardwareOperator):
         return (FloatValue.from_float(self.fmt, 1.0 if a else 0.0),)
 
 
+class IMulOperator:
+    """Not implemented yet; this placeholder carries only its knobs."""
+
+    @dataclass(frozen=True, slots=True)
+    class Options:
+        stage_product: int = 0
+
+
 @dataclass(frozen=True)
 class OpConfig:
     """
-    The hardware operator configuration threaded into synthesis. Constructed by the user before synthesis.
-    Each field fixes one operator's format and parameters.
-
-    Some operators are optional, configured only by a kernel that uses them.
-    Selecting an unconfigured one is a clear error at MIR lowering.
+    This class only contains operators that are configurable.
+    Operators that don't have tunable parameters can be constructed ad-hoc instead.
     """
 
-    fadd: FAddOperator
-    fmul: FMulOperator
-    fdiv: FDivOperator
-    fmul_ilog2: FMulILog2OperatorFamily
-    fcmp: FCmpOperator
-    fround: FRoundOperator | None = None
-    ffma: FFmaOperator | None = None
-    fsort: FSortOperator | None = None
-    fexp2: FExp2Operator | None = None
-    flog2: FLog2Operator | None = None
-    fsincos: FSincosOperator | None = None
-    fatan2: FAtan2Operator | None = None
+    fadd: FAddOperator | None
+    fmul: FMulOperator | None
+    fdiv: FDivOperator | None
+    fmul_ilog2: FMulILog2OperatorFamily | None
+    fcmp: FCmpOperator | None
+    fround: FRoundOperator | None
+    ffma: FFmaOperator | None
+    fsort: FSortOperator | None
+    fexp2: FExp2Operator | None
+    flog2: FLog2Operator | None
+    fsincos: FSincosOperator | None
+    fatan2: FAtan2Operator | None
+
+    def require(self, name: str) -> Any:
+        """The named operator, or a refusal naming what needs configuring."""
+        operator = getattr(self, name)
+        if operator is None:
+            raise UnsupportedConstruct(f"the kernel needs the {name!r} operator, which is not configured")
+        return operator
 
     @property
     def float_format(self) -> FloatFormat:
         formats = {operator.fmt for field in fields(self) if (operator := getattr(self, field.name)) is not None}
+        if not formats:
+            raise UnsupportedConstruct("no float operator is configured, so the machine has no float format")
         if len(formats) != 1:
             ordered = ", ".join(str(fmt) for fmt in sorted(formats, key=lambda fmt: (fmt.wexp, fmt.wman)))
             raise ValueError(f"all floating-point operators must use the same format; got {ordered}")

--- a/holoso/_operators.py
+++ b/holoso/_operators.py
@@ -3,7 +3,7 @@
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from hashlib import blake2s
 from typing import Any, ClassVar
@@ -1108,14 +1108,3 @@ class OpConfig:
         if operator is None:
             raise UnsupportedConstruct(f"the kernel needs the {name!r} operator, which is not configured")
         return operator
-
-    @property
-    def float_format(self) -> FloatFormat:
-        formats = {operator.fmt for field in fields(self) if (operator := getattr(self, field.name)) is not None}
-        if not formats:
-            raise UnsupportedConstruct("no float operator is configured, so the machine has no float format")
-        if len(formats) != 1:
-            ordered = ", ".join(str(fmt) for fmt in sorted(formats, key=lambda fmt: (fmt.wexp, fmt.wman)))
-            raise ValueError(f"all floating-point operators must use the same format; got {ordered}")
-        (fmt,) = formats
-        return fmt  # type: ignore[no-any-return]

--- a/synth/__main__.py
+++ b/synth/__main__.py
@@ -22,7 +22,12 @@ import types
 from dataclasses import dataclass, fields
 from pathlib import Path
 
-from holoso import synthesize, FloatFormat, OpConfig
+from holoso import (
+    FloatFormat,
+    OperatorOptions,
+    Options,
+    synthesize,
+)
 
 from ._synth import BUILD_ROOT, SynthReport, build_compiler_ooc_design
 from .flows import Flow, FlowId, make_flow
@@ -76,7 +81,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         metavar="FLOW:freq=MHz[,OP.KNOB=VALUE...]",
         help=(
             f"synthesis flow to run; repeatable; supported flows: {', '.join(FlowId)}; "
-            "optional operator knob fields are OP.KNOB, where OP is an OpConfig operator field"
+            "optional operator knob fields are OP.KNOB, where OP is an OperatorOptions field"
         ),
     )
     args = parser.parse_args(argv)
@@ -138,13 +143,12 @@ def _parse_flow_spec(parser: argparse.ArgumentParser, spec: str) -> _FlowRequest
 
 def _parse_op_knob(parser: argparse.ArgumentParser, spec: str, key: str, raw_value: str) -> _OperatorKnob | None:
     operator_name, separator, knob_name = key.partition(".")
-    operator_classes = _op_config_operator_classes()
+    operator_classes = _operator_options_classes()
     if not separator or operator_name not in operator_classes:
         return None
     if not knob_name:
         parser.error(f"knob {key!r} in {spec!r} is missing a name")
-    operator_cls = operator_classes[operator_name]
-    flds = {item.name: item for item in fields(operator_cls)}
+    flds = {item.name: item for item in fields(operator_classes[operator_name])}
     if knob_name not in flds:
         parser.error(f"unknown knob {operator_name}.{knob_name} in {spec!r}")
     try:
@@ -154,23 +158,16 @@ def _parse_op_knob(parser: argparse.ArgumentParser, spec: str, key: str, raw_val
     return _OperatorKnob(operator_name=operator_name, field_name=knob_name, value=value)
 
 
-def _op_config_operator_classes() -> dict[str, type]:
+def _operator_options_classes() -> dict[str, type]:
     classes: dict[str, type] = {}
-    for item in fields(OpConfig):
+    for item in fields(OperatorOptions):
         annotation = item.type
         if isinstance(annotation, types.UnionType):
             (annotation,) = [arg for arg in annotation.__args__ if arg is not type(None)]
         if not isinstance(annotation, type):
-            raise TypeError(f"OpConfig field {item.name!r} has unsupported annotation {item.type!r}")
+            raise TypeError(f"OperatorOptions field {item.name!r} has unsupported annotation {item.type!r}")
         classes[item.name] = annotation
     return classes
-
-
-def _instantiate_operator(operator_cls: type, fmt: FloatFormat, overrides: dict[str, object]) -> object:
-    try:
-        return operator_cls(fmt, **overrides)
-    except TypeError as exc:
-        raise TypeError(f"cannot construct OpConfig operator {operator_cls.__name__}: {exc}") from exc
 
 
 def _load_target(kernel: Path, expression: str) -> object:
@@ -183,16 +180,17 @@ def _load_target(kernel: Path, expression: str) -> object:
     return eval(expression, dict(vars(module)))
 
 
-def _op_config(fmt: FloatFormat, op_knobs: list[_OperatorKnob]) -> OpConfig:
+def _options(fmt: FloatFormat, op_knobs: list[_OperatorKnob]) -> Options:
+    """Every operator is configured except ffma, whose contraction is a numerical choice the caller must request."""
     grouped_overrides: dict[str, dict[str, object]] = {}
     for override in op_knobs:
         grouped_overrides.setdefault(override.operator_name, {})[override.field_name] = override.value
     operators: dict[str, object] = {}
-    for name, operator_cls in _op_config_operator_classes().items():
+    for name, options_cls in _operator_options_classes().items():
         if name == "ffma" and name not in grouped_overrides:
             continue
-        operators[name] = _instantiate_operator(operator_cls, fmt, grouped_overrides.get(name, {}))
-    return OpConfig(**operators)  # type: ignore
+        operators[name] = options_cls(**grouped_overrides.get(name, {}))
+    return Options(OperatorOptions(**operators), ffmt=fmt)  # type: ignore
 
 
 def _select_flows(requests: list[_FlowRequest]) -> tuple[list[_SelectedFlow], list[FlowId]]:
@@ -209,13 +207,13 @@ def _select_flows(requests: list[_FlowRequest]) -> tuple[list[_SelectedFlow], li
 
 def _run_flow(
     flow: Flow,
-    ops: OpConfig,
+    options: Options,
     target: Any,
     name: str,
     directory: Path,
 ) -> SynthReport | _Failure:
     try:
-        result = synthesize(target, ops=ops, name=name)
+        result = synthesize(target, options, name=name)
         result.write(directory / "holoso_result")
         return flow.prepare(build_compiler_ooc_design(result)).synthesize(directory)
     except Exception as exc:  # one tool's failure must not stop the others
@@ -264,17 +262,16 @@ def main() -> int:
         for selected in flows:
             flow = selected.flow
             directory = out_dir / type(flow).__name__
-            ops = _op_config(fmt, selected.request.op_knobs)
+            options = _options(fmt, selected.request.op_knobs)
             print(
                 f"🛠️ Synthesizing {args.kernel}::{args.expression} as {name} "
                 f"using {flow.__class__.__name__} in {directory}"
             )
             print("⚙ Operators:")
-            for field in fields(ops):
-                operator = getattr(ops, field.name)
-                print(f"    {field.name:12}: {operator}")
+            for field in fields(options.operator):
+                print(f"    {field.name:12}: {getattr(options.operator, field.name)}")
             print(flush=True)
-            futures[executor.submit(_run_flow, flow, ops, target, name, directory)] = flow
+            futures[executor.submit(_run_flow, flow, options, target, name, directory)] = flow
 
         for future in as_completed(futures):
             outcomes.append(future.result())

--- a/synth/__main__.py
+++ b/synth/__main__.py
@@ -22,12 +22,7 @@ import types
 from dataclasses import dataclass, fields
 from pathlib import Path
 
-from holoso import (
-    FloatFormat,
-    OperatorOptions,
-    Options,
-    synthesize,
-)
+from holoso import FloatFormat, OperatorOptions, Options, synthesize
 
 from ._synth import BUILD_ROOT, SynthReport, build_compiler_ooc_design
 from .flows import Flow, FlowId, make_flow

--- a/synth/_ooc.py
+++ b/synth/_ooc.py
@@ -16,10 +16,7 @@ registers are reset-unconditional.
 
 from dataclasses import dataclass
 
-from holoso import (
-    Port,
-    SynthesisResult,
-)
+from holoso import Port, SynthesisResult
 
 # Marks the boundary flops so synthesis keeps them as real register-to-register IO boundaries.
 KEEP_ATTR = '(* keep = "true", syn_preserve = "true", dont_touch = "true" *)'

--- a/synth/_ooc.py
+++ b/synth/_ooc.py
@@ -16,7 +16,10 @@ registers are reset-unconditional.
 
 from dataclasses import dataclass
 
-from holoso import Port, SynthesisResult
+from holoso import (
+    Port,
+    SynthesisResult,
+)
 
 # Marks the boundary flops so synthesis keeps them as real register-to-register IO boundaries.
 KEEP_ATTR = '(* keep = "true", syn_preserve = "true", dont_touch = "true" *)'

--- a/synth/_synth.py
+++ b/synth/_synth.py
@@ -8,9 +8,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from holoso import (
-    SynthesisResult,
-)
+from holoso import SynthesisResult
 
 from ._flow_id import FlowId
 from ._ooc import build_ooc_wrapper

--- a/synth/_synth.py
+++ b/synth/_synth.py
@@ -8,7 +8,9 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from holoso import SynthesisResult
+from holoso import (
+    SynthesisResult,
+)
 
 from ._flow_id import FlowId
 from ._ooc import build_ooc_wrapper

--- a/synth/test_ooc.py
+++ b/synth/test_ooc.py
@@ -3,8 +3,18 @@ from pathlib import Path
 
 import pytest
 
-from holoso import synthesize, SynthesisResult, FloatFormat
-from holoso import FAddOperator, FCmpOperator, FDivOperator, FMulILog2OperatorFamily, FMulOperator, OpConfig
+from holoso import (
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
+    FloatFormat,
+    OperatorOptions,
+    Options,
+    SynthesisResult,
+    synthesize,
+)
 
 from synth import OocDesign, SourceFile, SynthReport, build_compiler_ooc_design, build_ooc_wrapper
 from synth.flows import FlowId
@@ -30,15 +40,14 @@ def bool_gate(a: bool, b: bool) -> bool:
     return a and b
 
 
-OPS = OpConfig(
-    fadd=FAddOperator(FMT),
-    fmul=FMulOperator(FMT),
-    fdiv=FDivOperator(FMT),
-    fmul_ilog2=FMulILog2OperatorFamily(FMT),
-    fcmp=FCmpOperator(FMT),
+OPS = Options(
+    OperatorOptions(
+        fadd=FAddOptions(), fmul=FMulOptions(), fdiv=FDivOptions(), fmul_ilog2=FMulILog2Options(), fcmp=FCmpOptions()
+    ),
+    ffmt=FMT,
 )
-KERN: SynthesisResult = synthesize(kern, ops=OPS, name="kern")
-WIDE: SynthesisResult = synthesize(wide, ops=OPS, name="wide")
+KERN: SynthesisResult = synthesize(kern, OPS, name="kern")
+WIDE: SynthesisResult = synthesize(wide, OPS, name="wide")
 
 requires_diamond = pytest.mark.skipif(not DiamondEcp5Flow().available(), reason="Lattice Diamond not found")
 requires_vivado = pytest.mark.skipif(not VivadoArtix7Flow().available(), reason="Vivado not found")
@@ -91,7 +100,7 @@ def test_wrapper_buses_single_bit_input_word() -> None:
     # Regression: an all-boolean-input kernel makes io_in 1 bit wide. The wrapper still bit-slices io_in in the input
     # load, so io_in must be declared as a vector -- a collapsed scalar wire is rejected by strict elaborators
     # (Diamond/Vivado: "cannot index into non-array io_in"), though lenient Yosys accepts it.
-    wrapper = build_ooc_wrapper(synthesize(bool_gate, ops=OPS, name="bool_gate"))
+    wrapper = build_ooc_wrapper(synthesize(bool_gate, OPS, name="bool_gate"))
     assert wrapper.io_in_width == 1
     assert re.search(r"input\s+wire\s+\[\d+:0\]\s+io_in", wrapper.verilog), "io_in must be declared as a vector"
     assert "io_in[0:0]" in wrapper.verilog  # the load slice that requires io_in to be indexable

--- a/tests/_cosim.py
+++ b/tests/_cosim.py
@@ -2,13 +2,16 @@
 
 from collections.abc import Callable, Mapping
 
-from holoso import FloatFormat, OpConfig
+from holoso import (
+    FloatFormat,
+)
 from holoso._backend.cocotb import generate as generate_testbench
 from holoso._backend.numerical import generate
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import build
+from ._modelref import build_lir
+from holoso._operators import OpConfig
 from holoso._mir import lower as lower_to_mir
 from cocotb_tools.runner import get_runner
 
@@ -29,7 +32,7 @@ def run_cosim(
     sequence (each maps an input-port name to its ZKF bits); when omitted the bench draws its own fixed-seed sweep.
     """
     ops = default_ops(fmt) if ops is None else ops
-    lir = build(lower_to_mir(optimize(lower(fn).hir), ops), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(fn).hir), ops), name)
     model = generate(lir)
     # Generated sources live outside the cocotb build dir, which the runner wipes on clean=True.
     gen_dir = REPO_ROOT / "build" / "holoso_gen" / f"{name}_w{fmt.wexp}_{fmt.wman}"

--- a/tests/_cosim.py
+++ b/tests/_cosim.py
@@ -2,9 +2,7 @@
 
 from collections.abc import Callable, Mapping
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._backend.cocotb import generate as generate_testbench
 from holoso._backend.numerical import generate
 from holoso._backend.verilog import generate as generate_verilog
@@ -32,7 +30,7 @@ def run_cosim(
     sequence (each maps an input-port name to its ZKF bits); when omitted the bench draws its own fixed-seed sweep.
     """
     ops = default_ops(fmt) if ops is None else ops
-    lir = build_lir(lower_to_mir(optimize(lower(fn).hir), ops), name)
+    lir = build_lir(lower_to_mir(optimize(lower(fn).hir), ops, fmt), name)
     model = generate(lir)
     # Generated sources live outside the cocotb build dir, which the runner wipes on clean=True.
     gen_dir = REPO_ROOT / "build" / "holoso_gen" / f"{name}_w{fmt.wexp}_{fmt.wman}"

--- a/tests/_examples.py
+++ b/tests/_examples.py
@@ -15,9 +15,7 @@ from pathlib import Path
 
 import numpy as np
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from ._modelref import (
     bounded,
     encode_inputs,

--- a/tests/_examples.py
+++ b/tests/_examples.py
@@ -16,13 +16,7 @@ from pathlib import Path
 import numpy as np
 
 from holoso import FloatFormat
-from ._modelref import (
-    bounded,
-    encode_inputs,
-    format_edge_bits,
-    log_uniform_positive,
-    spd_matrix,
-)
+from ._modelref import bounded, encode_inputs, format_edge_bits, log_uniform_positive, spd_matrix
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
 import ekf1_stateful as ekf1_stateful  # noqa: E402

--- a/tests/_examples.py
+++ b/tests/_examples.py
@@ -15,7 +15,9 @@ from pathlib import Path
 
 import numpy as np
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from ._modelref import (
     bounded,
     encode_inputs,

--- a/tests/_fuzz.py
+++ b/tests/_fuzz.py
@@ -43,7 +43,7 @@ from holoso._backend.numerical import NumericalSimulator, generate
 from holoso._eel import lower as lower_frontend
 from holoso._hir import _if_convert as if_convert_pass
 from holoso._hir import optimize
-from holoso._lir import Branch, Lir, RegRef, ScheduledOp, build, landing_cycle
+from holoso._lir import Branch, Lir, RegRef, ScheduledOp, landing_cycle
 from holoso._lir import operand_read_cycle
 from holoso._mir import Mir, MirBranch, MirInterpreter, MirJump, MirTerminator
 from holoso._mir import lower as lower_to_mir
@@ -52,6 +52,7 @@ from holoso._type import BoolType, FloatFormat
 from holoso._value import FloatValue
 
 from ._modelref import (
+    build_lir,
     Vector,
     default_ops,
     default_tolerance,
@@ -1040,7 +1041,7 @@ def _build_with_lir(
     identical build path.
     """
     mir = lower_to_mir(optimize(lower_frontend(fn).hir), ops)
-    lir = build(mir, name, fetch_stages=3)
+    lir = build_lir(mir, name)
     model = generate(lir).elaborate()
     interpreter = MirInterpreter(mir)
     return mir, lir, model, interpreter

--- a/tests/_fuzz.py
+++ b/tests/_fuzz.py
@@ -1032,7 +1032,7 @@ class CampaignStats:
 
 
 def _build_with_lir(
-    fn: Callable[..., object], ops: OpConfig, name: str
+    fn: Callable[..., object], ops: OpConfig, name: str, fmt: FloatFormat
 ) -> tuple[Mir, Lir, NumericalSimulator, MirInterpreter]:
     """
     Lower the kernel ONCE to MIR/LIR, then build both the numerical model (from that LIR) and the interpreter (from the
@@ -1040,15 +1040,17 @@ def _build_with_lir(
     or touching simulator internals. Shared by the campaign runner and the regression replayer, so both drive the
     identical build path.
     """
-    mir = lower_to_mir(optimize(lower_frontend(fn).hir), ops)
+    mir = lower_to_mir(optimize(lower_frontend(fn).hir), ops, fmt)
     lir = build_lir(mir, name)
     model = generate(lir).elaborate()
     interpreter = MirInterpreter(mir)
     return mir, lir, model, interpreter
 
 
-def _build_all(fn: Callable[..., object], ops: OpConfig, name: str) -> tuple[Mir, NumericalSimulator, MirInterpreter]:
-    mir, _, model, interpreter = _build_with_lir(fn, ops, name)
+def _build_all(
+    fn: Callable[..., object], ops: OpConfig, name: str, fmt: FloatFormat
+) -> tuple[Mir, NumericalSimulator, MirInterpreter]:
+    mir, _, model, interpreter = _build_with_lir(fn, ops, name, fmt)
     return mir, model, interpreter
 
 
@@ -1476,7 +1478,7 @@ def run_kernel(
     reference diverges.
     """
     name = f"{kernel.name}__{op_label}"
-    mir, lir, model, interpreter = _build_with_lir(kernel.callable, ops, name)
+    mir, lir, model, interpreter = _build_with_lir(kernel.callable, ops, name, fmt)
     _assert_danger_survived(kernel, mir, op_label)
     if Shape.RELATION_PAIR in kernel.shapes:
         assert _has_fused_relation_pair(lir), f"{name}: relation-pair kernel did not fuse comparator order-flag taps"
@@ -1545,7 +1547,9 @@ def _armed_dead_arm_kernel(master_seed: int, index: int, fmt: FloatFormat) -> Ge
         assert kernel.dead_arm_chain_depth is not None
         # Verify the chain spills under EVERY op-config the forced batch asserts (``expect_armed``), not just the
         # default -- so a future config under which the chain happens not to spill cannot false-fail the campaign.
-        lirs = (_build_with_lir(kernel.callable, make_ops(fmt), kernel.name)[1] for make_ops in OP_CONFIGS.values())
+        lirs = (
+            _build_with_lir(kernel.callable, make_ops(fmt), kernel.name, fmt)[1] for make_ops in OP_CONFIGS.values()
+        )
         if all(_has_overlap_spill_at_depth(lir, kernel.dead_arm_chain_depth) for lir in lirs):
             return kernel
     raise DangerShapeLost(f"dead-arm generator failed to arm a spill in {_ARM_RETRIES} tries (index {index})")
@@ -1715,7 +1719,7 @@ def replay_case(kernel_callable: Callable[..., object], meta: dict[str, object])
     """
     repro = ReproMeta.from_dict(meta)
     ops = OP_CONFIGS[repro.op_label](repro.fmt)
-    mir, model, interpreter = _build_all(kernel_callable, ops, f"{repro.kernel_name}__replay")
+    mir, model, interpreter = _build_all(kernel_callable, ops, f"{repro.kernel_name}__replay", repro.fmt)
     if [p.name for p in model.inputs] != list(repro.input_names):  # the reference binds by name in port order; pin it
         return (
             False,

--- a/tests/_modelref.py
+++ b/tests/_modelref.py
@@ -9,22 +9,27 @@ from typing import Any
 import numpy as np
 
 from holoso import (
-    FAddOperator,
-    FAtan2Operator,
-    FCmpOperator,
-    FDivOperator,
-    FExp2Operator,
-    FLog2Operator,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    FSincosOperator,
-    OpConfig,
+    FAddOptions,
+    FAtan2Options,
+    FCmpOptions,
+    FDivOptions,
+    FExp2Options,
+    FLog2Options,
+    FMulILog2Options,
+    FMulOptions,
+    FSincosOptions,
+    OperatorOptions,
+    Options,
 )
+from holoso._api import _build_op_config
+from holoso._lir import RegallocTuning
+from holoso._lir import build
+from holoso._operators import FAtan2Operator, FExp2Operator, FLog2Operator, FSincosOperator, OpConfig
 from holoso._backend.numerical import NumericalSimulator, generate as generate
 from holoso._eel import lower as lower_frontend
 from holoso._hir import Hir, Operation, Operator, optimize
-from holoso._lir import Lir, build
-from holoso._mir import MirInterpreter, lower as lower_to_mir
+from holoso._lir import Lir
+from holoso._mir import Mir, MirInterpreter, lower as lower_to_mir
 from holoso._type import FloatFormat
 from holoso._value import FloatValue
 from holoso._eel._names import port_name as port_name
@@ -56,7 +61,7 @@ def build_model_and_interpreter(
     (upstream of ``build``), so the two share everything except the LIR layer.
     """
     mir = lower_to_mir(optimize(lower_frontend(kernel).hir), ops)
-    return build_model(build(mir, name, fetch_stages=3)), MirInterpreter(mir)
+    return build_model(build_lir(mir, name)), MirInterpreter(mir)
 
 
 def arith_count(hir: Hir, op_type: type[Operator]) -> int:
@@ -190,30 +195,66 @@ def format_edge_bits(fmt: FloatFormat) -> list[int]:
     return edges
 
 
-def _optional[T](build: Callable[[], T]) -> T | None:
+def _if_supported[O](operator: Callable[..., object], fmt: FloatFormat, opt: O) -> O | None:
+    """A transcendental without zkf tables for the format is left unconfigured."""
     try:
-        return build()
+        operator(fmt, opt, 0)
     except KeyError:
         return None
+    return opt
+
+
+def build_ops(options: Options) -> OpConfig:
+    """For the white-box tests that drive MIR lowering directly."""
+    return _build_op_config(options)
+
+
+DEFAULT_FETCH_STAGES = 3
+
+# Restated as literals so the frozen metric baselines cannot move with the environment overrides below.
+SHIPPED_TUNING = RegallocTuning(effort=5000, reuse_write_cap=2, register_price=2.0)
+
+
+# What a default-constructed Options asks for, so a white-box build matches what synthesize would do.
+_DEFAULTS = Options(OperatorOptions())
+DEFAULT_TUNING = RegallocTuning(
+    effort=_DEFAULTS.regalloc_effort,
+    reuse_write_cap=_DEFAULTS.regalloc_reuse_write_cap,
+    register_price=_DEFAULTS.regalloc_register_price,
+)
+
+
+def build_lir(mir: Mir, name: str, tuning: RegallocTuning = DEFAULT_TUNING) -> Lir:
+    """The default machine build shared by the white-box tests."""
+    return build(mir, name, DEFAULT_FETCH_STAGES, tuning)
+
+
+def default_options(fmt: FloatFormat) -> Options:
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+            fexp2=_if_supported(FExp2Operator, fmt, FExp2Options()),
+            flog2=_if_supported(FLog2Operator, fmt, FLog2Options()),
+            fsincos=_if_supported(FSincosOperator, fmt, FSincosOptions()),
+            fatan2=_if_supported(FAtan2Operator, fmt, FAtan2Options()),
+        ),
+        ffmt=fmt,
+    )
 
 
 def default_ops(fmt: FloatFormat) -> OpConfig:
-    return OpConfig(
-        FAddOperator(fmt),
-        FMulOperator(fmt),
-        FDivOperator(fmt),
-        FMulILog2OperatorFamily(fmt),
-        FCmpOperator(fmt),
-        fexp2=_optional(lambda: FExp2Operator(fmt)),
-        flog2=_optional(lambda: FLog2Operator(fmt)),
-        fsincos=_optional(lambda: FSincosOperator(fmt)),
-        fatan2=_optional(lambda: FAtan2Operator(fmt)),
-    )
+    return build_ops(default_options(fmt))
 
 
 def fcmp_staged_ops(fmt: FloatFormat, stage_input: int) -> OpConfig:
     """The default config with only the comparator's stage knob varied (latency ``1 + stage_input``)."""
-    return dataclasses.replace(default_ops(fmt), fcmp=FCmpOperator(fmt, stage_input=stage_input))
+    options = default_options(fmt)
+    operator = dataclasses.replace(options.operator, fcmp=FCmpOptions(stage_input=stage_input))
+    return build_ops(dataclasses.replace(options, operator=operator))
 
 
 def fcmp_s1_ops(fmt: FloatFormat) -> OpConfig:
@@ -328,40 +369,50 @@ def overlap_div_err_kernel(x: float, y: float, z: float) -> float:
     return r
 
 
-def staged_ops(fmt: FloatFormat) -> OpConfig:
+def staged_options(fmt: FloatFormat) -> Options:
     """
     A deeply pipelined configuration, distinct enough from the default to exercise the schedule, register allocation,
     and handshake at a longer latency. Deliberately hardcoded -- it is a test fixture chosen for coverage, not a
     derived enumeration of operator knobs, so it stays valid as new (not necessarily stage-shaped) knobs are added.
     """
-    return OpConfig(
-        FAddOperator(
-            fmt, stage_input=1, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1, stage_output=1
-        ),
-        FMulOperator(fmt, stage_input=1, stage_product=1, stage_pack=1, stage_output=1),
-        FDivOperator(fmt, stage_input=1, stage_pack=1, stage_output=1),
-        FMulILog2OperatorFamily(fmt, stage_input=1, stage_decode=1),
-        FCmpOperator(fmt, stage_input=1),
-        fexp2=_optional(
-            lambda: FExp2Operator(fmt, stage_input=1, stage_reduce=1, stage_product=1, stage_pack=1, stage_output=1)
-        ),
-        flog2=_optional(
-            lambda: FLog2Operator(
+    cordic = FSincosOptions(stage_product=1, stage_normalize=1, stage_pack=1)  # bench-verified (tests/hdl)
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(
+                stage_input=1, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1, stage_output=1
+            ),
+            fmul=FMulOptions(stage_input=1, stage_product=1, stage_pack=1, stage_output=1),
+            fdiv=FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
+            fmul_ilog2=FMulILog2Options(stage_input=1, stage_decode=1),
+            fcmp=FCmpOptions(stage_input=1),
+            fexp2=_if_supported(
+                FExp2Operator,
                 fmt,
-                stage_input=1,
-                stage_decode=1,
-                stage_product=1,
-                stage_product_final=1,
-                stage_normalize=1,
-                stage_normalize_output=1,
-                stage_pack=1,
-                stage_output=1,
-            )
+                FExp2Options(stage_input=1, stage_reduce=1, stage_product=1, stage_pack=1, stage_output=1),
+            ),
+            flog2=_if_supported(
+                FLog2Operator,
+                fmt,
+                FLog2Options(
+                    stage_input=1,
+                    stage_decode=1,
+                    stage_product=1,
+                    stage_product_final=1,
+                    stage_normalize=1,
+                    stage_normalize_output=1,
+                    stage_pack=1,
+                    stage_output=1,
+                ),
+            ),
+            fsincos=_if_supported(FSincosOperator, fmt, cordic),
+            fatan2=_if_supported(FAtan2Operator, fmt, FAtan2Options(**dataclasses.asdict(cordic))),
         ),
-        # A bench-verified CORDIC stage combo (tests/hdl/test_f{sincos,atan2}.py), so the latency formula is known-good.
-        fsincos=_optional(lambda: FSincosOperator(fmt, stage_product=1, stage_normalize=1, stage_pack=1)),
-        fatan2=_optional(lambda: FAtan2Operator(fmt, stage_product=1, stage_normalize=1, stage_pack=1)),
+        ffmt=fmt,
     )
+
+
+def staged_ops(fmt: FloatFormat) -> OpConfig:
+    return build_ops(staged_options(fmt))
 
 
 PIPELINE_OP_CASES = (

--- a/tests/_modelref.py
+++ b/tests/_modelref.py
@@ -52,7 +52,7 @@ def build_model(lir: Lir) -> NumericalSimulator:
 
 
 def build_model_and_interpreter(
-    kernel: Callable[..., object], ops: OpConfig, name: str
+    kernel: Callable[..., object], ops: OpConfig, name: str, fmt: FloatFormat
 ) -> tuple[NumericalSimulator, MirInterpreter]:
     """
     Drive one kernel through the internal pipeline and return (numerical model, MIR interpreter) over the SAME MIR --
@@ -60,7 +60,7 @@ def build_model_and_interpreter(
     scheduled/allocated LIR, where the verified bug class lives); the interpreter is taken straight off the MIR
     (upstream of ``build``), so the two share everything except the LIR layer.
     """
-    mir = lower_to_mir(optimize(lower_frontend(kernel).hir), ops)
+    mir = lower_to_mir(optimize(lower_frontend(kernel).hir), ops, fmt)
     return build_model(build_lir(mir, name)), MirInterpreter(mir)
 
 
@@ -375,7 +375,9 @@ def staged_options(fmt: FloatFormat) -> Options:
     and handshake at a longer latency. Deliberately hardcoded -- it is a test fixture chosen for coverage, not a
     derived enumeration of operator knobs, so it stays valid as new (not necessarily stage-shaped) knobs are added.
     """
-    cordic = FSincosOptions(stage_product=1, stage_normalize=1, stage_pack=1)  # bench-verified (tests/hdl)
+    # Bench-verified stage combos (tests/hdl/test_f{sincos,atan2}.py), so the latency formula is known-good.
+    sincos = FSincosOptions(stage_product=1, stage_normalize=1, stage_pack=1)
+    atan2 = FAtan2Options(stage_product=1, stage_normalize=1, stage_pack=1)
     return Options(
         OperatorOptions(
             fadd=FAddOptions(
@@ -404,8 +406,8 @@ def staged_options(fmt: FloatFormat) -> Options:
                     stage_output=1,
                 ),
             ),
-            fsincos=_if_supported(FSincosOperator, fmt, cordic),
-            fatan2=_if_supported(FAtan2Operator, fmt, FAtan2Options(**dataclasses.asdict(cordic))),
+            fsincos=_if_supported(FSincosOperator, fmt, sincos),
+            fatan2=_if_supported(FAtan2Operator, fmt, atan2),
         ),
         ffmt=fmt,
     )

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -4,7 +4,7 @@ operator configuration). This is the single source of truth for what the example
 (test_synth_examples) asserts can close timing.
 
 Deliberately a dumb-simple data table -- literal frequencies, one explicit row per (example, flow), and a full typed
-OpConfig per row; duplication is preferred over indirection here. Catalogued example targets reuse the shared example
+Options per row; duplication is preferred over indirection here. Catalogued example targets reuse the shared example
 registry (_examples.SPECS) so each kernel is constructed once. Off-catalogue regression cores may be added as
 SynthTarget records with example=None.
 
@@ -16,18 +16,19 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from holoso import (
-    FAddOperator,
-    FAtan2Operator,
-    FCmpOperator,
-    FDivOperator,
-    FExp2Operator,
-    FFmaOperator,
+    FAddOptions,
+    FAtan2Options,
+    FCmpOptions,
+    FDivOptions,
+    FExp2Options,
+    FFmaOptions,
+    FLog2Options,
     FloatFormat,
-    FLog2Operator,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    FSincosOperator,
-    OpConfig,
+    FMulILog2Options,
+    FMulOptions,
+    FSincosOptions,
+    OperatorOptions,
+    Options,
 )
 from synth.flows import FlowId
 
@@ -41,57 +42,60 @@ F_e4m8 = FloatFormat(4, 8)  # the narrow uart byte format (per examples/uart.py)
 def op_config(
     fmt: FloatFormat,
     *,
-    fadd: FAddOperator | None = None,
-    fmul: FMulOperator | None = None,
-    fdiv: FDivOperator | None = None,
-    fmul_ilog2: FMulILog2OperatorFamily | None = None,
-    fcmp: FCmpOperator | None = None,
-    ffma: FFmaOperator | None = None,
-    fexp2: FExp2Operator | None = None,
-    flog2: FLog2Operator | None = None,
-    fsincos: FSincosOperator | None = None,
-    fatan2: FAtan2Operator | None = None,
-) -> OpConfig:
+    fadd: FAddOptions | None = None,
+    fmul: FMulOptions | None = None,
+    fdiv: FDivOptions | None = None,
+    fmul_ilog2: FMulILog2Options | None = None,
+    fcmp: FCmpOptions | None = None,
+    ffma: FFmaOptions | None = None,
+    fexp2: FExp2Options | None = None,
+    flog2: FLog2Options | None = None,
+    fsincos: FSincosOptions | None = None,
+    fatan2: FAtan2Options | None = None,
+) -> Options:
     """
-    The OpConfig for fmt; pass a fully-constructed operator to give it stage knobs, else that operator is lean.
+    The Options for fmt; pass an options object to give an operator stage knobs, else that operator is lean.
     ffma/fexp2/flog2/fsincos/fatan2 are absent unless supplied, so MAC chains stay expanded (fmul + fadd) and a
     kernel that uses no transcendental needs no such module.
     """
-    return OpConfig(
-        fadd=fadd or FAddOperator(fmt),
-        fmul=fmul or FMulOperator(fmt),
-        fdiv=fdiv or FDivOperator(fmt),
-        fmul_ilog2=fmul_ilog2 or FMulILog2OperatorFamily(fmt),
-        fcmp=fcmp or FCmpOperator(fmt),
-        ffma=ffma,
-        fexp2=fexp2,
-        flog2=flog2,
-        fsincos=fsincos,
-        fatan2=fatan2,
+    return Options(
+        OperatorOptions(
+            fadd=fadd or FAddOptions(),
+            fmul=fmul or FMulOptions(),
+            fdiv=fdiv or FDivOptions(),
+            fmul_ilog2=fmul_ilog2 or FMulILog2Options(),
+            fcmp=fcmp or FCmpOptions(),
+            ffma=ffma,
+            fexp2=fexp2,
+            flog2=flog2,
+            fsincos=fsincos,
+            fatan2=fatan2,
+        ),
+        ffmt=fmt,
     )
 
 
-def op_config_staged_output(fmt: FloatFormat) -> OpConfig:
+def op_config_staged_output(fmt: FloatFormat) -> Options:
     """
     op_config(fmt) with an output register stage on the wide arithmetic operators (fadd/fmul/fdiv), enabled locally on
     just the rows whose timing closure needs it. fmul_ilog2 and fcmp have no output stage and stay lean.
     """
     return op_config(
         fmt,
-        fadd=FAddOperator(fmt, stage_output=1),
-        fmul=FMulOperator(fmt, stage_output=1),
-        fdiv=FDivOperator(fmt, stage_output=1),
+        fadd=FAddOptions(stage_output=1),
+        fmul=FMulOptions(stage_output=1),
+        fdiv=FDivOptions(stage_output=1),
     )
 
 
 @dataclass(frozen=True, slots=True)
 class SynthTarget:
-    """One synthesis closure target: a kernel synthesized for one flow under one OpConfig, asserted to meet f_max."""
+    """One synthesis closure target: a kernel synthesized for one flow under one Options, asserted to meet f_max."""
 
     kernel: Callable[[], Callable[..., object]]
     flow: FlowId
     target_frequency_MHz: float
-    ops: OpConfig
+    ops: Options
     name: str  # descriptive module/report label; unique per flow
     example: str | None = None  # the SPECS name this exercises; None for an off-catalogue regression core
 
@@ -107,7 +111,7 @@ def for_example(
     example: str,
     flow: FlowId,
     target_frequency_MHz: float,
-    ops: OpConfig,
+    ops: Options,
     *,
     kernel: Callable[[], Callable[..., object]] | None = None,
     name: str | None = None,
@@ -119,7 +123,7 @@ def for_example(
     rather than the cosim variant.
     """
     spec = _SPEC_BY_NAME[example]  # KeyError guards a typo'd example name
-    fmt = ops.float_format
+    fmt = ops.ffmt
     return SynthTarget(
         kernel=kernel or spec.make_kernel,
         flow=flow,
@@ -155,11 +159,11 @@ def _from_polar_kernel() -> Callable[..., object]:
 
 # One measured CORDIC config per polar kernel closes all three flows, so the three per-flow rows share it (unlike the
 # per-flow stage knobs elsewhere in the matrix).
-_TO_POLAR_FATAN2 = FAtan2Operator(F_e6m18, unroll100=50, stage_pack=1, stage_normalize=2, stage_product=3)
-_FROM_POLAR_FSINCOS = FSincosOperator(F_e6m18, stage_pack=1, stage_product=2, stage_normalize=2)
+_TO_POLAR_FATAN2 = FAtan2Options(unroll100=50, stage_pack=1, stage_normalize=2, stage_product=3)
+_FROM_POLAR_FSINCOS = FSincosOptions(stage_pack=1, stage_product=2, stage_normalize=2)
 # kepler's fsincos (coalesced sin+cos per Newton iteration) dominates timing, so its measured closure coincides with
 # from_polar's -- the same operator -- and one config closes all three flows.
-_KEPLER_FSINCOS = FSincosOperator(F_e6m18, stage_pack=1, stage_product=2, stage_normalize=2)
+_KEPLER_FSINCOS = FSincosOptions(stage_pack=1, stage_product=2, stage_normalize=2)
 
 
 TARGETS: list[SynthTarget] = [
@@ -170,11 +174,11 @@ TARGETS: list[SynthTarget] = [
     for_example("madd", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("poly3", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("poly3", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
-    for_example("poly3", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))),
+    for_example("poly3", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOptions(stage_normalize=1))),
     for_example("signal_window", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("signal_window", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
     for_example("signal_window", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
-    for_example("iir1_lpf", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_output=1))),
+    for_example("iir1_lpf", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18, fadd=FAddOptions(stage_output=1))),
     for_example("iir1_lpf", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
     for_example("iir1_lpf", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example(
@@ -183,14 +187,12 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_output=1),
-            fdiv=FDivOperator(F_e6m18, stage_output=1),
+            fadd=FAddOptions(stage_input=1, stage_output=1),
+            fmul=FMulOptions(stage_output=1),
+            fdiv=FDivOptions(stage_output=1),
         ),
     ),
-    for_example(
-        "pid", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_input=1, stage_output=1))
-    ),
+    for_example("pid", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18, fadd=FAddOptions(stage_input=1, stage_output=1))),
     for_example("pid", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("schmitt_trigger", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("schmitt_trigger", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
@@ -210,13 +212,11 @@ TARGETS: list[SynthTarget] = [
     for_example("recip_newton", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     # Diamond's critical path here is the fmul post-product cone (DSP product register through pack/normalize into
     # the register file), 18 logic levels at 58% route. One pack stage splits it; the other two flows close lean.
-    for_example("recip_newton", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18, fmul=FMulOperator(F_e6m18, stage_pack=1))),
+    for_example("recip_newton", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18, fmul=FMulOptions(stage_pack=1))),
     for_example("recip_newton", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
     for_example("integrator", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("integrator", FlowId.DIAMOND_ECP5, 100, op_config_staged_output(F_e6m18)),
-    for_example(
-        "integrator", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))
-    ),
+    for_example("integrator", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOptions(stage_normalize=1))),
     # Straight-line multiply-accumulate chains; both close lean on all three flows.
     for_example("fir", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example("fir", FlowId.DIAMOND_ECP5, 100, op_config(F_e6m18)),
@@ -236,8 +236,8 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_decode=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_input=1, stage_output=1),
+            fadd=FAddOptions(stage_input=1, stage_decode=1, stage_output=1),
+            fmul=FMulOptions(stage_input=1, stage_output=1),
         ),
     ),
     for_example(
@@ -246,9 +246,9 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_input=1, stage_output=1),
-            fdiv=FDivOperator(F_e6m18, stage_input=1, stage_output=1),
+            fadd=FAddOptions(stage_input=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOptions(stage_input=1, stage_output=1),
+            fdiv=FDivOptions(stage_input=1, stage_output=1),
         ),
     ),
     for_example(
@@ -257,8 +257,8 @@ TARGETS: list[SynthTarget] = [
         150,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_product=1),
+            fadd=FAddOptions(stage_input=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOptions(stage_product=1),
         ),
     ),
     for_example(
@@ -267,8 +267,8 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_decode=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_input=1, stage_output=1),
+            fadd=FAddOptions(stage_input=1, stage_decode=1, stage_output=1),
+            fmul=FMulOptions(stage_input=1, stage_output=1),
         ),
         kernel=_ekf1_stateful_kernel,
     ),
@@ -278,9 +278,9 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_decode=1, stage_normalize=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_pack=1),
-            fdiv=FDivOperator(F_e6m18, stage_input=1, stage_output=1),
+            fadd=FAddOptions(stage_input=1, stage_decode=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOptions(stage_pack=1),
+            fdiv=FDivOptions(stage_input=1, stage_output=1),
         ),
         kernel=_ekf1_stateful_kernel,
     ),
@@ -290,8 +290,8 @@ TARGETS: list[SynthTarget] = [
         150,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1),
-            fmul=FMulOperator(F_e6m18, stage_product=1),
+            fadd=FAddOptions(stage_input=1, stage_normalize=1),
+            fmul=FMulOptions(stage_product=1),
         ),
         kernel=_ekf1_stateful_kernel,
     ),
@@ -301,8 +301,8 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_decode=1),
-            fmul_ilog2=FMulILog2OperatorFamily(F_e6m18, stage_decode=1),
+            fadd=FAddOptions(stage_decode=1),
+            fmul_ilog2=FMulILog2Options(stage_decode=1),
         ),
     ),
     for_example(
@@ -311,13 +311,11 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_decode=1, stage_normalize=1, stage_output=1),
-            fmul_ilog2=FMulILog2OperatorFamily(F_e6m18, stage_decode=1),
+            fadd=FAddOptions(stage_input=1, stage_decode=1, stage_normalize=1, stage_output=1),
+            fmul_ilog2=FMulILog2Options(stage_decode=1),
         ),
     ),
-    for_example(
-        "cordic_sincos", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))
-    ),
+    for_example("cordic_sincos", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOptions(stage_normalize=1))),
     for_example("octave_index", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
     for_example(
         "octave_index",
@@ -325,9 +323,9 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_output=1),
-            fdiv=FDivOperator(F_e6m18, stage_output=1),
+            fadd=FAddOptions(stage_input=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOptions(stage_output=1),
+            fdiv=FDivOptions(stage_output=1),
         ),
     ),
     for_example("octave_index", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18)),
@@ -339,9 +337,9 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fmul=FMulOperator(F_e6m18, stage_pack=1),
-            fexp2=FExp2Operator(F_e6m18, stage_reduce=1, stage_product=2),
-            flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=2, stage_pack=1),
+            fmul=FMulOptions(stage_pack=1),
+            fexp2=FExp2Options(stage_reduce=1, stage_product=2),
+            flog2=FLog2Options(stage_product=2, stage_product_final=2, stage_normalize=2, stage_pack=1),
         ),
     ),
     for_example(
@@ -350,8 +348,8 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fexp2=FExp2Operator(F_e6m18, stage_product=2),
-            flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=1, stage_pack=1),
+            fexp2=FExp2Options(stage_product=2),
+            flog2=FLog2Options(stage_product=2, stage_product_final=2, stage_normalize=1, stage_pack=1),
         ),
     ),
     for_example(
@@ -360,9 +358,9 @@ TARGETS: list[SynthTarget] = [
         150,
         op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_normalize=1),
-            fexp2=FExp2Operator(F_e6m18, stage_product=2),
-            flog2=FLog2Operator(F_e6m18, stage_product=2, stage_product_final=2, stage_normalize=1, stage_pack=1),
+            fadd=FAddOptions(stage_normalize=1),
+            fexp2=FExp2Options(stage_product=2),
+            flog2=FLog2Options(stage_product=2, stage_product_final=2, stage_normalize=1, stage_pack=1),
         ),
     ),
     for_example("remainder", FlowId.YOSYS_ECP5, 100, op_config(F_e6m18)),
@@ -370,21 +368,19 @@ TARGETS: list[SynthTarget] = [
         "remainder",
         FlowId.DIAMOND_ECP5,
         100,
-        op_config(F_e6m18, fdiv=FDivOperator(F_e6m18, stage_input=1, stage_output=1)),
+        op_config(F_e6m18, fdiv=FDivOptions(stage_input=1, stage_output=1)),
     ),
-    for_example(
-        "remainder", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_normalize=1))
-    ),
+    for_example("remainder", FlowId.VIVADO_ARTIX7, 150, op_config(F_e6m18, fadd=FAddOptions(stage_normalize=1))),
     for_example(
         "ekf1_stateless",
         FlowId.YOSYS_ECP5,
         100,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(F_e8m36, stage_input=1, stage_decode=1, stage_normalize=2, stage_pack=1, stage_output=1),
-            fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=2, stage_pack=1, stage_output=1),
-            fdiv=FDivOperator(F_e8m36, stage_input=1, stage_output=1),
-            fmul_ilog2=FMulILog2OperatorFamily(F_e8m36, stage_input=1, stage_decode=1),
+            fadd=FAddOptions(stage_input=1, stage_decode=1, stage_normalize=2, stage_pack=1, stage_output=1),
+            fmul=FMulOptions(stage_input=1, stage_product=2, stage_pack=1, stage_output=1),
+            fdiv=FDivOptions(stage_input=1, stage_output=1),
+            fmul_ilog2=FMulILog2Options(stage_input=1, stage_decode=1),
         ),
     ),
     for_example(
@@ -393,12 +389,12 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(
-                F_e8m36, stage_input=2, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1, stage_output=1
+            fadd=FAddOptions(
+                stage_input=2, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1, stage_output=1
             ),
-            fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=1, stage_pack=1, stage_output=1),
-            fdiv=FDivOperator(F_e8m36, stage_input=1, stage_pack=1, stage_output=1),
-            fmul_ilog2=FMulILog2OperatorFamily(F_e8m36, stage_decode=1),
+            fmul=FMulOptions(stage_input=1, stage_product=1, stage_pack=1, stage_output=1),
+            fdiv=FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
+            fmul_ilog2=FMulILog2Options(stage_decode=1),
         ),
     ),
     for_example(
@@ -407,9 +403,9 @@ TARGETS: list[SynthTarget] = [
         150,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(F_e8m36, stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
-            fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=1, stage_pack=1),
-            fdiv=FDivOperator(F_e8m36, stage_input=1, stage_pack=1, stage_output=1),
+            fadd=FAddOptions(stage_decode=1, stage_align=1, stage_normalize=1, stage_pack=1),
+            fmul=FMulOptions(stage_input=1, stage_product=1, stage_pack=1),
+            fdiv=FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
         ),
     ),
     for_example(
@@ -418,9 +414,9 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(F_e8m36, stage_input=1, stage_decode=1, stage_normalize=2, stage_pack=1),
-            fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=2, stage_output=1),
-            fmul_ilog2=FMulILog2OperatorFamily(F_e8m36, stage_input=1, stage_decode=1),
+            fadd=FAddOptions(stage_input=1, stage_decode=1, stage_normalize=2, stage_pack=1),
+            fmul=FMulOptions(stage_input=1, stage_product=2, stage_output=1),
+            fmul_ilog2=FMulILog2Options(stage_input=1, stage_decode=1),
         ),
         kernel=_ekf1_stateful_kernel,
     ),
@@ -430,9 +426,9 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(F_e8m36, stage_input=2, stage_decode=1, stage_align=1, stage_normalize=2, stage_pack=1),
-            fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=1, stage_pack=1),
-            fdiv=FDivOperator(F_e8m36, stage_input=3, stage_pack=1, stage_output=1),
+            fadd=FAddOptions(stage_input=2, stage_decode=1, stage_align=1, stage_normalize=2, stage_pack=1),
+            fmul=FMulOptions(stage_input=1, stage_product=1, stage_pack=1),
+            fdiv=FDivOptions(stage_input=3, stage_pack=1, stage_output=1),
         ),
         kernel=_ekf1_stateful_kernel,
     ),
@@ -442,9 +438,9 @@ TARGETS: list[SynthTarget] = [
         150,
         op_config(
             F_e8m36,
-            fadd=FAddOperator(F_e8m36, stage_decode=1, stage_align=1, stage_normalize=2, stage_pack=1),
-            fmul=FMulOperator(F_e8m36, stage_input=1, stage_product=1, stage_pack=1),
-            fdiv=FDivOperator(F_e8m36, stage_input=1, stage_pack=1, stage_output=1),
+            fadd=FAddOptions(stage_decode=1, stage_align=1, stage_normalize=2, stage_pack=1),
+            fmul=FMulOptions(stage_input=1, stage_product=1, stage_pack=1),
+            fdiv=FDivOptions(stage_input=1, stage_pack=1, stage_output=1),
         ),
         kernel=_ekf1_stateful_kernel,
     ),
@@ -458,9 +454,9 @@ TARGETS: list[SynthTarget] = [
         target_frequency_MHz=100,
         ops=op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_decode=1),
-            fmul=FMulOperator(F_e6m18, stage_product=1),
-            fmul_ilog2=FMulILog2OperatorFamily(F_e6m18, stage_decode=1),
+            fadd=FAddOptions(stage_decode=1),
+            fmul=FMulOptions(stage_product=1),
+            fmul_ilog2=FMulILog2Options(stage_decode=1),
         ),
         name="imu_frame_transform_e6m18",
     ),
@@ -468,7 +464,7 @@ TARGETS: list[SynthTarget] = [
         kernel=_imu_frame_transform_kernel,
         flow=FlowId.DIAMOND_ECP5,
         target_frequency_MHz=100,
-        ops=op_config(F_e6m18, fadd=FAddOperator(F_e6m18, stage_input=1)),
+        ops=op_config(F_e6m18, fadd=FAddOptions(stage_input=1)),
         name="imu_frame_transform_e6m18",
     ),
     SynthTarget(
@@ -477,8 +473,8 @@ TARGETS: list[SynthTarget] = [
         target_frequency_MHz=150,
         ops=op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_normalize=1, stage_output=1),
-            fmul=FMulOperator(F_e6m18, stage_input=1),
+            fadd=FAddOptions(stage_input=1, stage_normalize=1, stage_output=1),
+            fmul=FMulOptions(stage_input=1),
         ),
         name="imu_frame_transform_e6m18",
     ),
@@ -488,9 +484,9 @@ TARGETS: list[SynthTarget] = [
         target_frequency_MHz=100,
         ops=op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_input=1, stage_decode=1, stage_pack=1),
-            fmul=FMulOperator(F_e6m18, stage_product=1),
-            ffma=FFmaOperator(F_e6m18, stage_product=1, stage_decode=1, stage_normalize=1, stage_pack=1),
+            fadd=FAddOptions(stage_input=1, stage_decode=1, stage_pack=1),
+            fmul=FMulOptions(stage_product=1),
+            ffma=FFmaOptions(stage_product=1, stage_decode=1, stage_normalize=1, stage_pack=1),
         ),
         name="imu_frame_transform_e6m18_fma",
     ),
@@ -500,9 +496,9 @@ TARGETS: list[SynthTarget] = [
         target_frequency_MHz=100,
         ops=op_config(
             F_e6m18,
-            fadd=FAddOperator(F_e6m18, stage_normalize=1),
-            fmul=FMulOperator(F_e6m18, stage_output=1),
-            ffma=FFmaOperator(F_e6m18, stage_normalize=1, stage_pack=1),
+            fadd=FAddOptions(stage_normalize=1),
+            fmul=FMulOptions(stage_output=1),
+            ffma=FFmaOptions(stage_normalize=1, stage_pack=1),
         ),
         name="imu_frame_transform_e6m18_fma",
     ),
@@ -512,8 +508,8 @@ TARGETS: list[SynthTarget] = [
         target_frequency_MHz=150,
         ops=op_config(
             F_e6m18,
-            fmul=FMulOperator(F_e6m18, stage_product=1),
-            ffma=FFmaOperator(F_e6m18, stage_product=1, stage_normalize=1),
+            fmul=FMulOptions(stage_product=1),
+            ffma=FFmaOptions(stage_product=1, stage_normalize=1),
         ),
         name="imu_frame_transform_e6m18_fma",
     ),
@@ -558,7 +554,7 @@ TARGETS: list[SynthTarget] = [
         kernel=_from_polar_kernel,
         flow=FlowId.VIVADO_ARTIX7,
         target_frequency_MHz=150,
-        ops=op_config(F_e6m18, fmul=FMulOperator(F_e6m18, stage_input=1), fsincos=_FROM_POLAR_FSINCOS),
+        ops=op_config(F_e6m18, fmul=FMulOptions(stage_input=1), fsincos=_FROM_POLAR_FSINCOS),
         name="from_polar_e6m18",
     ),
     # kepler: fsincos inside a data-dependent Newton back-edge loop -- the only II>1 operator in a loop in the matrix.

--- a/tests/hdl/test_err_pc.py
+++ b/tests/hdl/test_err_pc.py
@@ -18,32 +18,40 @@ from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
+from holoso._operators import FDivOperator, OpConfig
 from holoso._backend.verilog import generate
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import build, pooled_write_word
+from holoso._lir import pooled_write_word
 from holoso._mir import lower as lower_to_mir
 
 from .hdl_float_oracle import HDL_DIR, REPO_ROOT, SIMULATORS, build_args, drive_reset, sources, start_clock
+from .._modelref import build_lir, build_ops
 
 FMT = FloatFormat(6, 18)
 
 
 def _ops(stage_output: int) -> OpConfig:
-    return OpConfig(
-        FAddOperator(FMT),
-        FMulOperator(FMT),
-        FDivOperator(FMT, stage_output=stage_output),
-        FMulILog2OperatorFamily(FMT),
-        FCmpOperator(FMT),
+    return build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(stage_output=stage_output),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=FMT,
+        )
     )
 
 
@@ -88,7 +96,7 @@ async def err_pc_latches_div0(dut: Any) -> None:
 @pytest.mark.parametrize("stage_output", [0, 1])
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_err_pc(sim: str, stage_output: int) -> None:
-    lir = build(lower_to_mir(optimize(lower(_divide).hir), _ops(stage_output)), "divide", fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(_divide).hir), _ops(stage_output)), "divide")
     # The fdiv asserts div0 at its commit; err_pc latches the write word -- the
     # commit step itself (pooled_write_word). An fdiv output stage pushes the commit later, and the err flag and the
     # result still latch/land together: err_step is recomputed from this build's actual fdiv commit.

--- a/tests/hdl/test_err_pc.py
+++ b/tests/hdl/test_err_pc.py
@@ -96,7 +96,7 @@ async def err_pc_latches_div0(dut: Any) -> None:
 @pytest.mark.parametrize("stage_output", [0, 1])
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_err_pc(sim: str, stage_output: int) -> None:
-    lir = build_lir(lower_to_mir(optimize(lower(_divide).hir), _ops(stage_output)), "divide")
+    lir = build_lir(lower_to_mir(optimize(lower(_divide).hir), _ops(stage_output), FMT), "divide")
     # The fdiv asserts div0 at its commit; err_pc latches the write word -- the
     # commit step itself (pooled_write_word). An fdiv output stage pushes the commit later, and the err flag and the
     # result still latch/land together: err_step is recomputed from this build's actual fdiv commit.

--- a/tests/hdl/test_fadd.py
+++ b/tests/hdl/test_fadd.py
@@ -14,10 +14,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FAddOptions,
-    FloatFormat,
-)
+from holoso import FAddOptions, FloatFormat
 from holoso._operators import FAddOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fadd.py
+++ b/tests/hdl/test_fadd.py
@@ -14,7 +14,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FAddOperator, FloatFormat
+from holoso import (
+    FAddOptions,
+    FloatFormat,
+)
+from holoso._operators import FAddOperator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -116,7 +120,7 @@ STAGE_COMBOS = ((0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 1))
 def test_holoso_fadd(sim: str, stages: tuple[int, int, int]) -> None:
     stage_decode, stage_align, stage_output = stages
     operator = FAddOperator(
-        FloatFormat(8, 24), stage_decode=stage_decode, stage_align=stage_align, stage_output=stage_output
+        FloatFormat(8, 24), FAddOptions(stage_decode=stage_decode, stage_align=stage_align, stage_output=stage_output)
     )
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fadd_d{stage_decode}a{stage_align}o{stage_output}"

--- a/tests/hdl/test_fatan2.py
+++ b/tests/hdl/test_fatan2.py
@@ -13,7 +13,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FAtan2Operator, FloatFormat
+from holoso import (
+    FAtan2Options,
+    FloatFormat,
+)
+from holoso._operators import FAtan2Operator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -104,7 +108,7 @@ async def holoso_fatan2_cocotb(dut: Any) -> None:
 @pytest.mark.parametrize("stages", STAGE_COMBOS, ids=stage_tag)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_holoso_fatan2(sim: str, stages: dict[str, int]) -> None:
-    operator = FAtan2Operator(FloatFormat(8, 24), **stages)
+    operator = FAtan2Operator(FloatFormat(8, 24), FAtan2Options(**stages), 0)
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fatan2_{stage_tag(stages)}"
     runner.build(

--- a/tests/hdl/test_fatan2.py
+++ b/tests/hdl/test_fatan2.py
@@ -13,10 +13,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FAtan2Options,
-    FloatFormat,
-)
+from holoso import FAtan2Options, FloatFormat
 from holoso._operators import FAtan2Operator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fcmp.py
+++ b/tests/hdl/test_fcmp.py
@@ -14,10 +14,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FCmpOptions,
-    FloatFormat,
-)
+from holoso import FCmpOptions, FloatFormat
 from holoso._operators import FCmpOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fcmp.py
+++ b/tests/hdl/test_fcmp.py
@@ -14,7 +14,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FCmpOperator, FloatFormat
+from holoso import (
+    FCmpOptions,
+    FloatFormat,
+)
+from holoso._operators import FCmpOperator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -131,7 +135,7 @@ async def holoso_fcmp_cocotb(dut: Any) -> None:
 
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_holoso_fcmp(sim: str) -> None:
-    operator = FCmpOperator(FloatFormat(8, 24))
+    operator = FCmpOperator(FloatFormat(8, 24), FCmpOptions())
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / "fcmp"
     runner.build(

--- a/tests/hdl/test_fdiv.py
+++ b/tests/hdl/test_fdiv.py
@@ -15,7 +15,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FDivOperator, FloatFormat
+from holoso import (
+    FDivOptions,
+    FloatFormat,
+)
+from holoso._operators import FDivOperator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -133,7 +137,7 @@ def test_holoso_fdiv(sim: str, stages: tuple[int, int]) -> None:
     stage_input, stage_output = stages
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fdiv_i{stage_input}o{stage_output}"
-    operator = FDivOperator(FloatFormat(8, 24), stage_input=stage_input, stage_output=stage_output)
+    operator = FDivOperator(FloatFormat(8, 24), FDivOptions(stage_input=stage_input, stage_output=stage_output))
     runner.build(
         sources=sources(),
         includes=[HDL_DIR],

--- a/tests/hdl/test_fdiv.py
+++ b/tests/hdl/test_fdiv.py
@@ -15,10 +15,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FDivOptions,
-    FloatFormat,
-)
+from holoso import FDivOptions, FloatFormat
 from holoso._operators import FDivOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fexp2.py
+++ b/tests/hdl/test_fexp2.py
@@ -15,7 +15,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FExp2Operator, FloatFormat
+from holoso import (
+    FExp2Options,
+    FloatFormat,
+)
+from holoso._operators import FExp2Operator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -102,7 +106,7 @@ async def holoso_fexp2_cocotb(dut: Any) -> None:
 @pytest.mark.parametrize("stages", STAGE_COMBOS, ids=stage_tag)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_holoso_fexp2(sim: str, stages: dict[str, int]) -> None:
-    operator = FExp2Operator(FloatFormat(8, 24), **stages)
+    operator = FExp2Operator(FloatFormat(8, 24), FExp2Options(**stages), 0)
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fexp2_{stage_tag(stages)}"
     runner.build(

--- a/tests/hdl/test_fexp2.py
+++ b/tests/hdl/test_fexp2.py
@@ -15,10 +15,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FExp2Options,
-    FloatFormat,
-)
+from holoso import FExp2Options, FloatFormat
 from holoso._operators import FExp2Operator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_ffma.py
+++ b/tests/hdl/test_ffma.py
@@ -16,7 +16,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FloatFormat, FFmaOperator
+from holoso import (
+    FFmaOptions,
+    FloatFormat,
+)
+from holoso._operators import FFmaOperator
 
 from .hdl_float_oracle import (
     HDL_DIR,
@@ -119,13 +123,16 @@ def test_holoso_ffma(sim: str, stages: tuple[int, int, int, int, int, int, int])
     si, sp, sd, sa, sn, spk, so = stages
     operator = FFmaOperator(
         FloatFormat(8, 24),
-        stage_input=si,
-        stage_product=sp,
-        stage_decode=sd,
-        stage_align=sa,
-        stage_normalize=sn,
-        stage_pack=spk,
-        stage_output=so,
+        FFmaOptions(
+            stage_input=si,
+            stage_product=sp,
+            stage_decode=sd,
+            stage_align=sa,
+            stage_normalize=sn,
+            stage_pack=spk,
+            stage_output=so,
+        ),
+        0,
     )
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"ffma_{''.join(str(v) for v in stages)}"

--- a/tests/hdl/test_ffma.py
+++ b/tests/hdl/test_ffma.py
@@ -16,10 +16,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FFmaOptions,
-    FloatFormat,
-)
+from holoso import FFmaOptions, FloatFormat
 from holoso._operators import FFmaOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_flog2.py
+++ b/tests/hdl/test_flog2.py
@@ -15,10 +15,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FLog2Options,
-    FloatFormat,
-)
+from holoso import FLog2Options, FloatFormat
 from holoso._operators import FLog2Operator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_flog2.py
+++ b/tests/hdl/test_flog2.py
@@ -15,7 +15,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FLog2Operator, FloatFormat
+from holoso import (
+    FLog2Options,
+    FloatFormat,
+)
+from holoso._operators import FLog2Operator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -112,7 +116,7 @@ async def holoso_flog2_cocotb(dut: Any) -> None:
 @pytest.mark.parametrize("stages", STAGE_COMBOS, ids=stage_tag)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_holoso_flog2(sim: str, stages: dict[str, int]) -> None:
-    operator = FLog2Operator(FloatFormat(8, 24), **stages)
+    operator = FLog2Operator(FloatFormat(8, 24), FLog2Options(**stages), 0)
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"flog2_{stage_tag(stages)}"
     runner.build(

--- a/tests/hdl/test_fmul.py
+++ b/tests/hdl/test_fmul.py
@@ -14,10 +14,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FMulOptions,
-    FloatFormat,
-)
+from holoso import FMulOptions, FloatFormat
 from holoso._operators import FMulOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fmul.py
+++ b/tests/hdl/test_fmul.py
@@ -14,7 +14,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FloatFormat, FMulOperator
+from holoso import (
+    FMulOptions,
+    FloatFormat,
+)
+from holoso._operators import FMulOperator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -112,7 +116,9 @@ async def holoso_fmul_cocotb(dut: Any) -> None:
 def test_holoso_fmul(sim: str, stages: tuple[int, int, int]) -> None:
     stage_input, stage_product, stage_output = stages
     operator = FMulOperator(
-        FloatFormat(8, 24), stage_input=stage_input, stage_product=stage_product, stage_output=stage_output
+        FloatFormat(8, 24),
+        FMulOptions(stage_input=stage_input, stage_product=stage_product, stage_output=stage_output),
+        0,
     )
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fmul_i{stage_input}p{stage_product}o{stage_output}"

--- a/tests/hdl/test_fmul_ilog2_const.py
+++ b/tests/hdl/test_fmul_ilog2_const.py
@@ -14,9 +14,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._operators import FMulILog2Operator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fmul_ilog2_const.py
+++ b/tests/hdl/test_fmul_ilog2_const.py
@@ -14,7 +14,9 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from holoso._operators import FMulILog2Operator
 
 from .hdl_float_oracle import (
@@ -107,7 +109,7 @@ CONFIG_MATRIX = [(k, 0) for k in K_VALUES] + [(0, 1)]
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_holoso_fmul_ilog2_const(sim: str, config: tuple[int, int]) -> None:
     k, stage_decode = config
-    operator = FMulILog2Operator(fmt=FloatFormat(8, 24), k=k, stage_decode=stage_decode)
+    operator = FMulILog2Operator(FloatFormat(8, 24), k, FMulILog2Operator.Options(stage_decode=stage_decode))
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fmlog_k{k}_d{stage_decode}"
     runner.build(

--- a/tests/hdl/test_fround.py
+++ b/tests/hdl/test_fround.py
@@ -15,10 +15,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FRoundOptions,
-    FloatFormat,
-)
+from holoso import FRoundOptions, FloatFormat
 from holoso._operators import FRoundOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fround.py
+++ b/tests/hdl/test_fround.py
@@ -15,7 +15,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FloatFormat, FRoundOperator
+from holoso import (
+    FRoundOptions,
+    FloatFormat,
+)
+from holoso._operators import FRoundOperator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -121,10 +125,9 @@ def test_holoso_fround(sim: str, stages: tuple[int, int, int, int]) -> None:
     stage_input, stage_decode, stage_pack, stage_output = stages
     operator = FRoundOperator(
         FloatFormat(8, 24),
-        stage_input=stage_input,
-        stage_decode=stage_decode,
-        stage_pack=stage_pack,
-        stage_output=stage_output,
+        FRoundOptions(
+            stage_input=stage_input, stage_decode=stage_decode, stage_pack=stage_pack, stage_output=stage_output
+        ),
     )
     runner = get_runner(sim)
     build_dir = (

--- a/tests/hdl/test_fsincos.py
+++ b/tests/hdl/test_fsincos.py
@@ -12,10 +12,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FSincosOptions,
-    FloatFormat,
-)
+from holoso import FSincosOptions, FloatFormat
 from holoso._operators import FSincosOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_fsincos.py
+++ b/tests/hdl/test_fsincos.py
@@ -12,7 +12,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FloatFormat, FSincosOperator
+from holoso import (
+    FSincosOptions,
+    FloatFormat,
+)
+from holoso._operators import FSincosOperator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -97,7 +101,7 @@ async def holoso_fsincos_cocotb(dut: Any) -> None:
 @pytest.mark.parametrize("stages", STAGE_COMBOS, ids=stage_tag)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_holoso_fsincos(sim: str, stages: dict[str, int]) -> None:
-    operator = FSincosOperator(FloatFormat(8, 24), **stages)
+    operator = FSincosOperator(FloatFormat(8, 24), FSincosOptions(**stages), 0)
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fsincos_{stage_tag(stages)}"
     runner.build(

--- a/tests/hdl/test_fsort.py
+++ b/tests/hdl/test_fsort.py
@@ -16,7 +16,11 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import FloatFormat, FSortOperator
+from holoso import (
+    FSortOptions,
+    FloatFormat,
+)
+from holoso._operators import FSortOperator
 
 from .hdl_float_oracle import (
     DIRECTED_F32,
@@ -124,7 +128,7 @@ async def holoso_fsort_cocotb(dut: Any) -> None:
 @pytest.mark.parametrize("stage_input", (0, 1, 2), ids=lambda s: f"i{s}")
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_holoso_fsort(sim: str, stage_input: int) -> None:
-    operator = FSortOperator(FloatFormat(8, 24), stage_input=stage_input)
+    operator = FSortOperator(FloatFormat(8, 24), FSortOptions(stage_input=stage_input))
     runner = get_runner(sim)
     build_dir = REPO_ROOT / "build" / "cocotb" / sim / f"fsort_i{stage_input}"
     runner.build(

--- a/tests/hdl/test_fsort.py
+++ b/tests/hdl/test_fsort.py
@@ -16,10 +16,7 @@ import pytest
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FSortOptions,
-    FloatFormat,
-)
+from holoso import FSortOptions, FloatFormat
 from holoso._operators import FSortOperator
 
 from .hdl_float_oracle import (

--- a/tests/hdl/test_transcendental_err_pc.py
+++ b/tests/hdl/test_transcendental_err_pc.py
@@ -11,21 +11,23 @@ from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner
 
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
-    FExp2Operator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FExp2Options,
+    FLog2Options,
+    FMulILog2Options,
+    FMulOptions,
+    FSortOptions,
     FloatFormat,
-    FLog2Operator,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    FSortOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
+from holoso._operators import OpConfig
 from holoso._backend.verilog import generate
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import build
+from .._modelref import build_lir, build_ops
 from holoso._mir import lower as lower_to_mir
 
 from .hdl_float_oracle import HDL_DIR, REPO_ROOT, SIMULATORS, build_args, drive_reset, sources, start_clock
@@ -34,15 +36,20 @@ FMT = FloatFormat(6, 18)
 
 
 def _ops() -> OpConfig:
-    return OpConfig(
-        FAddOperator(FMT),
-        FMulOperator(FMT),
-        FDivOperator(FMT),
-        FMulILog2OperatorFamily(FMT),
-        FCmpOperator(FMT),
-        fsort=FSortOperator(FMT),
-        fexp2=FExp2Operator(FMT),
-        flog2=FLog2Operator(FMT),
+    return build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+                fsort=FSortOptions(),
+                fexp2=FExp2Options(),
+                flog2=FLog2Options(),
+            ),
+            ffmt=FMT,
+        )
     )
 
 
@@ -129,7 +136,7 @@ async def err_pc_safe_transcendentals(dut: Any) -> None:
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.name)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_safe_transcendental_err_pc(sim: str, case: _Case) -> None:
-    lir = build(lower_to_mir(optimize(lower(case.fn).hir), _ops()), f"err_{case.name}", fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(case.fn).hir), _ops()), f"err_{case.name}")
     gen_dir = REPO_ROOT / "build" / "holoso_gen" / f"err_{case.name}_w{FMT.wexp}_{FMT.wman}"
     gen_dir.mkdir(parents=True, exist_ok=True)
     verilog_path = gen_dir / f"err_{case.name}.v"

--- a/tests/hdl/test_transcendental_err_pc.py
+++ b/tests/hdl/test_transcendental_err_pc.py
@@ -136,7 +136,7 @@ async def err_pc_safe_transcendentals(dut: Any) -> None:
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.name)
 @pytest.mark.parametrize("sim", SIMULATORS)
 def test_safe_transcendental_err_pc(sim: str, case: _Case) -> None:
-    lir = build_lir(lower_to_mir(optimize(lower(case.fn).hir), _ops()), f"err_{case.name}")
+    lir = build_lir(lower_to_mir(optimize(lower(case.fn).hir), _ops(), FMT), f"err_{case.name}")
     gen_dir = REPO_ROOT / "build" / "holoso_gen" / f"err_{case.name}_w{FMT.wexp}_{FMT.wman}"
     gen_dir.mkdir(parents=True, exist_ok=True)
     verilog_path = gen_dir / f"err_{case.name}.v"

--- a/tests/test_arithmetic_behavior.py
+++ b/tests/test_arithmetic_behavior.py
@@ -49,14 +49,15 @@ import pytest
 
 import holoso
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
     FloatValue,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
     SynthesisError,
 )
 from ._modelref import default_tolerance, format_edge_bits, within
@@ -64,9 +65,16 @@ from ._modelref import default_tolerance, format_edge_bits, within
 FMT = FloatFormat(6, 18)
 
 
-def _ops() -> OpConfig:
-    return OpConfig(
-        FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT)
+def _ops() -> Options:
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
     )
 
 
@@ -759,8 +767,15 @@ def test_a_power_of_two_scale_past_the_carrier_folds_to_an_infinity() -> None:
     # Strength reduction can mint a power-of-two scale whose host-precision fold overflows; it folds to the operand's
     # own infinity rather than letting an OverflowError escape as a raw traceback.
     fmt = FloatFormat(11, 53)
-    ops = OpConfig(
-        FAddOperator(fmt), FMulOperator(fmt), FDivOperator(fmt), FMulILog2OperatorFamily(fmt), FCmpOperator(fmt)
+    ops = Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=fmt,
     )
     sim = holoso.synthesize(_scale_past_the_carrier, ops, name="pow2_carrier_overflow").numerical_model.elaborate()
     for c in (False, True):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -11,30 +11,42 @@ import pytest
 
 from holoso import (
     BoolType,
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
+    FSortOptions,
     FloatFormat,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    FSortOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
     UnsupportedConstruct,
 )
+from holoso._operators import FSortOperator, OpConfig
 from holoso._backend.verilog import generate
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import BoolRegRef, RegRef, build, pooled_write_word
+from holoso._lir import BoolRegRef, RegRef, pooled_write_word
 from holoso._mir import Mir, lower as lower_to_mir
 
 from .hdl.hdl_float_oracle import HDL_DIR, sources
+from ._modelref import build_lir, build_ops
 
 requires_iverilog = pytest.mark.skipif(shutil.which("iverilog") is None, reason="iverilog not installed")
 
 
 def _ops(fmt: FloatFormat) -> OpConfig:
-    return OpConfig(
-        FAddOperator(fmt), FMulOperator(fmt), FDivOperator(fmt), FMulILog2OperatorFamily(fmt), FCmpOperator(fmt)
+    return build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
 
 
@@ -70,7 +82,7 @@ def test_operator_instance_names_include_hardware_identity() -> None:
         return a * 4.0 + b * 8.0
 
     fmt = FloatFormat(6, 18)
-    lir = build(_run(scale, _ops(fmt)), "scale", fetch_stages=3)
+    lir = build_lir(_run(scale, _ops(fmt)), "scale")
     names = re.findall(
         r"\bholoso_fmul_ilog2_const\s+#\([^;]+?\)\s+u_([A-Za-z_][A-Za-z0-9_]*)\s+\(", generate(lir).verilog
     )
@@ -95,7 +107,7 @@ def test_comparisons_share_one_pooled_fcmp_instance() -> None:
             y = x
         return y
 
-    verilog = generate(build(_run(kernel, _ops(FloatFormat(8, 24))), "two_cmp", fetch_stages=3)).verilog
+    verilog = generate(build_lir(_run(kernel, _ops(FloatFormat(8, 24))), "two_cmp")).verilog
     assert verilog.count("holoso_fcmp #") == 1
 
 
@@ -132,7 +144,7 @@ def test_small_kernel_elaborates(tmp_path: Path) -> None:
         return (a - b) * 0.25 + a * b
 
     fmt = FloatFormat(8, 24)
-    lir = build(_run(kernel, _ops(fmt)), "kernel", fetch_stages=3)
+    lir = build_lir(_run(kernel, _ops(fmt)), "kernel")
     _elaborate("kernel", generate(lir).verilog, tmp_path)
 
 
@@ -142,7 +154,7 @@ def test_kernel_with_division_elaborates(tmp_path: Path) -> None:
         return a / b + c * 2.0
 
     fmt = FloatFormat(6, 18)
-    lir = build(_run(blend, _ops(fmt)), "blend", fetch_stages=3)
+    lir = build_lir(_run(blend, _ops(fmt)), "blend")
     _elaborate("blend", generate(lir).verilog, tmp_path)
 
 
@@ -154,7 +166,7 @@ def test_constant_only_module_elaborates(tmp_path: Path) -> None:
         return 3.5
 
     fmt = FloatFormat(8, 24)
-    lir = build(_run(const_only, _ops(fmt)), "const_only", fetch_stages=3)
+    lir = build_lir(_run(const_only, _ops(fmt)), "const_only")
     _elaborate("const_only", generate(lir).verilog, tmp_path)
 
 
@@ -173,7 +185,7 @@ def test_boolean_output_port_is_one_bit_and_assigned() -> None:
             return self.y
 
     fmt = FloatFormat(8, 24)
-    lir = build(_run(Trigger().__call__, _ops(fmt)), "bool_trigger", fetch_stages=3)
+    lir = build_lir(_run(Trigger().__call__, _ops(fmt)), "bool_trigger")
     (port,) = [port for port in lir.output_ports if port.name == "state_y"]
     assert isinstance(port.scalar_type, BoolType)
     assert port.width == 1
@@ -187,7 +199,7 @@ def test_boolean_input_port_is_one_bit_and_loaded() -> None:
         return flag
 
     fmt = FloatFormat(8, 24)
-    lir = build(_run(passthrough, _ops(fmt)), "bool_input", fetch_stages=3)
+    lir = build_lir(_run(passthrough, _ops(fmt)), "bool_input")
     assert [load.name for load in lir.inputs] == ["flag"]
     assert isinstance(lir.bool_inputs[0].dst, BoolRegRef)
     assert not isinstance(lir.bool_inputs[0].dst, RegRef)
@@ -212,7 +224,7 @@ def test_boolean_only_stateful_module_elaborates(tmp_path: Path) -> None:
             return self.flag
 
     fmt = FloatFormat(8, 24)
-    lir = build(_run(Toggle().__call__, _ops(fmt)), "bool_toggle", fetch_stages=3)
+    lir = build_lir(_run(Toggle().__call__, _ops(fmt)), "bool_toggle")
     assert lir.input_ports == []
     (port,) = lir.output_ports
     assert port.name == "state_flag"
@@ -231,7 +243,7 @@ def test_parameter_name_colliding_with_control_port_is_rejected() -> None:
 
     fmt = FloatFormat(6, 18)
     with pytest.raises(UnsupportedConstruct, match="duplicate port"):
-        build(_run(collide, _ops(fmt)), "collide", fetch_stages=3)
+        build_lir(_run(collide, _ops(fmt)), "collide")
 
 
 def test_kernel_without_outputs_is_rejected() -> None:
@@ -260,7 +272,7 @@ def test_state_slot_folded_sign_coexists_with_sibling_port(tmp_path: Path) -> No
             return self.y
 
     fmt = FloatFormat(8, 24)
-    lir = build(_run(Collide().__call__, _ops(fmt)), "collide_state", fetch_stages=3)
+    lir = build_lir(_run(Collide().__call__, _ops(fmt)), "collide_state")
     _elaborate("collide_state", generate(lir).verilog, tmp_path)
 
 
@@ -270,7 +282,7 @@ def test_ekf1_stateless_elaborates(tmp_path: Path) -> None:
     import ekf1_stateless
 
     fmt = FloatFormat(6, 18)
-    lir = build(_run(ekf1_stateless.update_x_P, _ops(fmt)), "update_x_P", fetch_stages=3)
+    lir = build_lir(_run(ekf1_stateless.update_x_P, _ops(fmt)), "update_x_P")
     _elaborate("update_x_P", generate(lir).verilog, tmp_path)
 
 
@@ -283,7 +295,7 @@ def test_ekf1_stateful_elaborates(tmp_path: Path) -> None:
     filt = ekf1_stateful.Ekf1(
         x=[0.0, 0.0, 0.0], P_urt=[1.0, 0.0, 0.0, 1.0, 0.0, 1.0], R_diag=[1.0, 1.0], Q_diag=np.array([1.0, 1.0, 1.0])
     )
-    lir = build(_run(filt.update, _ops(fmt)), "ekf1_stateful", fetch_stages=3)
+    lir = build_lir(_run(filt.update, _ops(fmt)), "ekf1_stateful")
     _elaborate("ekf1_stateful", generate(lir).verilog, tmp_path)
 
 
@@ -305,7 +317,7 @@ def test_both_bank_lane_write_commit_rides_the_commit_step() -> None:
     from ._modelref import branch_boundary_kernel, fcmp_staged_ops
 
     fmt = FloatFormat(6, 18)
-    lir = build(_run(branch_boundary_kernel, fcmp_staged_ops(fmt, 1)), "lane_steps", fetch_stages=3)
+    lir = build_lir(_run(branch_boundary_kernel, fcmp_staged_ops(fmt, 1)), "lane_steps")
     events = write_events(lir)
     write_books = write_codebook(events)
     fields = build_microcode(lir, read_codebook(lir), write_books, events, tapped_lanes(lir))
@@ -338,7 +350,7 @@ def test_error_gate_ors_over_multiple_landing_registers() -> None:
     # An error-bearing operator (fdiv) whose result lands in >=2 distinct registers reconstructs its commit window as
     # the OR, over those registers, of ``uc_op_<reg> == <its source code>``. No bundled example produces a multi-term
     # err gate, and the numerical model does not simulate ``err``, so cosim cannot reach it -- pin the reconstruction.
-    verilog = generate(build(_run(_two_division_kernel, _ops(FloatFormat(6, 18))), "two_div", fetch_stages=3)).verilog
+    verilog = generate(build_lir(_run(_two_division_kernel, _ops(FloatFormat(6, 18))), "two_div")).verilog
     err = next(line.strip() for line in verilog.splitlines() if line.strip().startswith("assign err ="))
     assert err.count("uc_op_") >= 2 and " | " in err and "div0" in err, err
 
@@ -363,7 +375,7 @@ def test_wide_multi_output_operator_elaborates_with_per_port_lanes(tmp_path: Pat
     _FETCH_LAG = 2  # datapath lag matching the 3-stage control fetch: one less than fetch_stages
 
     fmt = FloatFormat(6, 18)
-    inst = OperatorInstance(FSortOperator(fmt), 0)
+    inst = OperatorInstance(FSortOperator(fmt, FSortOptions()), 0)
     op = PooledScheduledOp(
         inst=inst,
         operands=[FloatOperand(RegRef(0)), FloatOperand(RegRef(1))],
@@ -422,13 +434,13 @@ def _madd_only(a: float, b: float, c: float) -> float:
 def test_unused_register_bank_is_omitted(tmp_path: Path) -> None:
     # A purely-boolean kernel uses no wide bank, and an arithmetic kernel with no booleans uses no boolean bank; the
     # unused bank must be omitted entirely rather than declared as a zero-length reg array (illegal Verilog).
-    bool_lir = build(_run(_and_gate, _ops(FloatFormat(8, 24))), "and_gate", fetch_stages=3)
+    bool_lir = build_lir(_run(_and_gate, _ops(FloatFormat(8, 24))), "and_gate")
     assert bool_lir.regfile.nreg == 0
     bool_v = generate(bool_lir).verilog
     assert "reg  [W-1:0] regs" not in bool_v and "NREG" not in bool_v and "[0:-1]" not in bool_v
     _elaborate("and_gate", bool_v, tmp_path)
 
-    float_lir = build(_run(_madd_only, _ops(FloatFormat(8, 24))), "madd_only", fetch_stages=3)
+    float_lir = build_lir(_run(_madd_only, _ops(FloatFormat(8, 24))), "madd_only")
     assert float_lir.bool_regfile.nreg == 0
     float_v = generate(float_lir).verilog
     assert "bregs" not in float_v and "NBREG" not in float_v and "[0:-1]" not in float_v
@@ -460,7 +472,7 @@ def test_a_boundary_install_coexisting_with_opcode_writes_elaborates(tmp_path: P
     # kernel is cosimulated in test_cosim.py, so here only the premise and the elaboration are checked.
     from holoso._backend.verilog._microcode import write_events
 
-    lir = build(_run(SharedLiveOut().step, _ops(FloatFormat(6, 18))), "shared_live_out", fetch_stages=3)
+    lir = build_lir(_run(SharedLiveOut().step, _ops(FloatFormat(6, 18))), "shared_live_out")
     steps: dict[object, list[int]] = {}
     for event in write_events(lir):
         steps.setdefault(event.dst, []).append(event.step)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -50,8 +50,8 @@ def _ops(fmt: FloatFormat) -> OpConfig:
     )
 
 
-def _run(target: object, ops: OpConfig) -> Mir:
-    return lower_to_mir(optimize(lower(target).hir), ops)
+def _run(target: object, ops: OpConfig, fmt: FloatFormat) -> Mir:
+    return lower_to_mir(optimize(lower(target).hir), ops, fmt)
 
 
 def _compile(name: str, verilog: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
@@ -82,7 +82,7 @@ def test_operator_instance_names_include_hardware_identity() -> None:
         return a * 4.0 + b * 8.0
 
     fmt = FloatFormat(6, 18)
-    lir = build_lir(_run(scale, _ops(fmt)), "scale")
+    lir = build_lir(_run(scale, _ops(fmt), fmt), "scale")
     names = re.findall(
         r"\bholoso_fmul_ilog2_const\s+#\([^;]+?\)\s+u_([A-Za-z_][A-Za-z0-9_]*)\s+\(", generate(lir).verilog
     )
@@ -107,7 +107,7 @@ def test_comparisons_share_one_pooled_fcmp_instance() -> None:
             y = x
         return y
 
-    verilog = generate(build_lir(_run(kernel, _ops(FloatFormat(8, 24))), "two_cmp")).verilog
+    verilog = generate(build_lir(_run(kernel, _ops(FloatFormat(8, 24)), FloatFormat(8, 24)), "two_cmp")).verilog
     assert verilog.count("holoso_fcmp #") == 1
 
 
@@ -144,7 +144,7 @@ def test_small_kernel_elaborates(tmp_path: Path) -> None:
         return (a - b) * 0.25 + a * b
 
     fmt = FloatFormat(8, 24)
-    lir = build_lir(_run(kernel, _ops(fmt)), "kernel")
+    lir = build_lir(_run(kernel, _ops(fmt), fmt), "kernel")
     _elaborate("kernel", generate(lir).verilog, tmp_path)
 
 
@@ -154,7 +154,7 @@ def test_kernel_with_division_elaborates(tmp_path: Path) -> None:
         return a / b + c * 2.0
 
     fmt = FloatFormat(6, 18)
-    lir = build_lir(_run(blend, _ops(fmt)), "blend")
+    lir = build_lir(_run(blend, _ops(fmt), fmt), "blend")
     _elaborate("blend", generate(lir).verilog, tmp_path)
 
 
@@ -166,7 +166,7 @@ def test_constant_only_module_elaborates(tmp_path: Path) -> None:
         return 3.5
 
     fmt = FloatFormat(8, 24)
-    lir = build_lir(_run(const_only, _ops(fmt)), "const_only")
+    lir = build_lir(_run(const_only, _ops(fmt), fmt), "const_only")
     _elaborate("const_only", generate(lir).verilog, tmp_path)
 
 
@@ -185,7 +185,7 @@ def test_boolean_output_port_is_one_bit_and_assigned() -> None:
             return self.y
 
     fmt = FloatFormat(8, 24)
-    lir = build_lir(_run(Trigger().__call__, _ops(fmt)), "bool_trigger")
+    lir = build_lir(_run(Trigger().__call__, _ops(fmt), fmt), "bool_trigger")
     (port,) = [port for port in lir.output_ports if port.name == "state_y"]
     assert isinstance(port.scalar_type, BoolType)
     assert port.width == 1
@@ -199,7 +199,7 @@ def test_boolean_input_port_is_one_bit_and_loaded() -> None:
         return flag
 
     fmt = FloatFormat(8, 24)
-    lir = build_lir(_run(passthrough, _ops(fmt)), "bool_input")
+    lir = build_lir(_run(passthrough, _ops(fmt), fmt), "bool_input")
     assert [load.name for load in lir.inputs] == ["flag"]
     assert isinstance(lir.bool_inputs[0].dst, BoolRegRef)
     assert not isinstance(lir.bool_inputs[0].dst, RegRef)
@@ -224,7 +224,7 @@ def test_boolean_only_stateful_module_elaborates(tmp_path: Path) -> None:
             return self.flag
 
     fmt = FloatFormat(8, 24)
-    lir = build_lir(_run(Toggle().__call__, _ops(fmt)), "bool_toggle")
+    lir = build_lir(_run(Toggle().__call__, _ops(fmt), fmt), "bool_toggle")
     assert lir.input_ports == []
     (port,) = lir.output_ports
     assert port.name == "state_flag"
@@ -243,7 +243,7 @@ def test_parameter_name_colliding_with_control_port_is_rejected() -> None:
 
     fmt = FloatFormat(6, 18)
     with pytest.raises(UnsupportedConstruct, match="duplicate port"):
-        build_lir(_run(collide, _ops(fmt)), "collide")
+        build_lir(_run(collide, _ops(fmt), fmt), "collide")
 
 
 def test_kernel_without_outputs_is_rejected() -> None:
@@ -252,7 +252,7 @@ def test_kernel_without_outputs_is_rejected() -> None:
 
     fmt = FloatFormat(6, 18)
     with pytest.raises(UnsupportedConstruct, match="an empty aggregate cannot be returned"):
-        _run(empty, _ops(fmt))
+        _run(empty, _ops(fmt), fmt)
 
 
 @requires_iverilog
@@ -272,7 +272,7 @@ def test_state_slot_folded_sign_coexists_with_sibling_port(tmp_path: Path) -> No
             return self.y
 
     fmt = FloatFormat(8, 24)
-    lir = build_lir(_run(Collide().__call__, _ops(fmt)), "collide_state")
+    lir = build_lir(_run(Collide().__call__, _ops(fmt), fmt), "collide_state")
     _elaborate("collide_state", generate(lir).verilog, tmp_path)
 
 
@@ -282,7 +282,7 @@ def test_ekf1_stateless_elaborates(tmp_path: Path) -> None:
     import ekf1_stateless
 
     fmt = FloatFormat(6, 18)
-    lir = build_lir(_run(ekf1_stateless.update_x_P, _ops(fmt)), "update_x_P")
+    lir = build_lir(_run(ekf1_stateless.update_x_P, _ops(fmt), fmt), "update_x_P")
     _elaborate("update_x_P", generate(lir).verilog, tmp_path)
 
 
@@ -295,7 +295,7 @@ def test_ekf1_stateful_elaborates(tmp_path: Path) -> None:
     filt = ekf1_stateful.Ekf1(
         x=[0.0, 0.0, 0.0], P_urt=[1.0, 0.0, 0.0, 1.0, 0.0, 1.0], R_diag=[1.0, 1.0], Q_diag=np.array([1.0, 1.0, 1.0])
     )
-    lir = build_lir(_run(filt.update, _ops(fmt)), "ekf1_stateful")
+    lir = build_lir(_run(filt.update, _ops(fmt), fmt), "ekf1_stateful")
     _elaborate("ekf1_stateful", generate(lir).verilog, tmp_path)
 
 
@@ -317,7 +317,7 @@ def test_both_bank_lane_write_commit_rides_the_commit_step() -> None:
     from ._modelref import branch_boundary_kernel, fcmp_staged_ops
 
     fmt = FloatFormat(6, 18)
-    lir = build_lir(_run(branch_boundary_kernel, fcmp_staged_ops(fmt, 1)), "lane_steps")
+    lir = build_lir(_run(branch_boundary_kernel, fcmp_staged_ops(fmt, 1), fmt), "lane_steps")
     events = write_events(lir)
     write_books = write_codebook(events)
     fields = build_microcode(lir, read_codebook(lir), write_books, events, tapped_lanes(lir))
@@ -350,7 +350,9 @@ def test_error_gate_ors_over_multiple_landing_registers() -> None:
     # An error-bearing operator (fdiv) whose result lands in >=2 distinct registers reconstructs its commit window as
     # the OR, over those registers, of ``uc_op_<reg> == <its source code>``. No bundled example produces a multi-term
     # err gate, and the numerical model does not simulate ``err``, so cosim cannot reach it -- pin the reconstruction.
-    verilog = generate(build_lir(_run(_two_division_kernel, _ops(FloatFormat(6, 18))), "two_div")).verilog
+    verilog = generate(
+        build_lir(_run(_two_division_kernel, _ops(FloatFormat(6, 18)), FloatFormat(6, 18)), "two_div")
+    ).verilog
     err = next(line.strip() for line in verilog.splitlines() if line.strip().startswith("assign err ="))
     assert err.count("uc_op_") >= 2 and " | " in err and "div0" in err, err
 
@@ -434,13 +436,13 @@ def _madd_only(a: float, b: float, c: float) -> float:
 def test_unused_register_bank_is_omitted(tmp_path: Path) -> None:
     # A purely-boolean kernel uses no wide bank, and an arithmetic kernel with no booleans uses no boolean bank; the
     # unused bank must be omitted entirely rather than declared as a zero-length reg array (illegal Verilog).
-    bool_lir = build_lir(_run(_and_gate, _ops(FloatFormat(8, 24))), "and_gate")
+    bool_lir = build_lir(_run(_and_gate, _ops(FloatFormat(8, 24)), FloatFormat(8, 24)), "and_gate")
     assert bool_lir.regfile.nreg == 0
     bool_v = generate(bool_lir).verilog
     assert "reg  [W-1:0] regs" not in bool_v and "NREG" not in bool_v and "[0:-1]" not in bool_v
     _elaborate("and_gate", bool_v, tmp_path)
 
-    float_lir = build_lir(_run(_madd_only, _ops(FloatFormat(8, 24))), "madd_only")
+    float_lir = build_lir(_run(_madd_only, _ops(FloatFormat(8, 24)), FloatFormat(8, 24)), "madd_only")
     assert float_lir.bool_regfile.nreg == 0
     float_v = generate(float_lir).verilog
     assert "bregs" not in float_v and "NBREG" not in float_v and "[0:-1]" not in float_v
@@ -472,7 +474,7 @@ def test_a_boundary_install_coexisting_with_opcode_writes_elaborates(tmp_path: P
     # kernel is cosimulated in test_cosim.py, so here only the premise and the elaboration are checked.
     from holoso._backend.verilog._microcode import write_events
 
-    lir = build_lir(_run(SharedLiveOut().step, _ops(FloatFormat(6, 18))), "shared_live_out")
+    lir = build_lir(_run(SharedLiveOut().step, _ops(FloatFormat(6, 18)), FloatFormat(6, 18)), "shared_live_out")
     steps: dict[object, list[int]] = {}
     for event in write_events(lir):
         steps.setdefault(event.dst, []).append(event.step)

--- a/tests/test_const_install.py
+++ b/tests/test_const_install.py
@@ -10,11 +10,13 @@ import re
 
 import pytest
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import build
+from ._modelref import build_lir
 from holoso._mir import lower as lower_to_mir
 
 from ._cosim import run_cosim
@@ -36,9 +38,7 @@ def _multi_const_install(x: float) -> float:
 
 def test_multi_distinct_const_install_selects_among_constants() -> None:
     """A register must select among >=2 distinct constants; otherwise the cosim below would not exercise that mux."""
-    lir = build(
-        lower_to_mir(optimize(lower(_multi_const_install).hir), default_ops(_FMT)), "multi_const", fetch_stages=3
-    )
+    lir = build_lir(lower_to_mir(optimize(lower(_multi_const_install).hir), default_ops(_FMT)), "multi_const")
     per_reg: dict[str, set[str]] = {}
     for reg, const in re.findall(r"regs\[(\d+)\] <= const_(\d+);", generate_verilog(lir).verilog):
         per_reg.setdefault(reg, set()).add(const)

--- a/tests/test_const_install.py
+++ b/tests/test_const_install.py
@@ -10,9 +10,7 @@ import re
 
 import pytest
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
 from holoso._hir import optimize
@@ -38,7 +36,7 @@ def _multi_const_install(x: float) -> float:
 
 def test_multi_distinct_const_install_selects_among_constants() -> None:
     """A register must select among >=2 distinct constants; otherwise the cosim below would not exercise that mux."""
-    lir = build_lir(lower_to_mir(optimize(lower(_multi_const_install).hir), default_ops(_FMT)), "multi_const")
+    lir = build_lir(lower_to_mir(optimize(lower(_multi_const_install).hir), default_ops(_FMT), _FMT), "multi_const")
     per_reg: dict[str, set[str]] = {}
     for reg, const in re.findall(r"regs\[(\d+)\] <= const_(\d+);", generate_verilog(lir).verilog):
         per_reg.setdefault(reg, set()).add(const)

--- a/tests/test_cosim.py
+++ b/tests/test_cosim.py
@@ -411,7 +411,7 @@ def test_cosim_div0_error(sim: str, config: OperatorCase) -> None:
 
     fmt = FloatFormat(6, 18)
     name = f"kdiv_{config.label}"
-    lir = build_lir(lower_to_mir(optimize(lower(kdiv).hir), config.make_ops(fmt)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(kdiv).hir), config.make_ops(fmt), fmt), name)
     bench = _ERR_BENCH.replace("@@WEXP@@", str(fmt.wexp)).replace("@@WMAN@@", str(fmt.wman))
     _run_err_bench(sim, name, fmt, lir, bench)
 
@@ -474,7 +474,7 @@ def test_cosim_log2_error(sim: str, config: OperatorCase) -> None:
 
     fmt = FloatFormat(6, 18)
     name = f"klog2_{config.label}"
-    lir = build_lir(lower_to_mir(optimize(lower(klog2).hir), config.make_ops(fmt)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(klog2).hir), config.make_ops(fmt), fmt), name)
     bench = _LOG2_ERR_BENCH.replace("@@WEXP@@", str(fmt.wexp)).replace("@@WMAN@@", str(fmt.wman))
     _run_err_bench(sim, name, fmt, lir, bench)
 
@@ -540,7 +540,7 @@ def test_cosim_overlap_div0_errpc(sim: str, config: OperatorCase) -> None:
     # _modelref.overlap_div_err_kernel.
     fmt = FloatFormat(6, 18)
     name = f"overlap_div_err_{config.label}"
-    lir = build_lir(lower_to_mir(optimize(lower(overlap_div_err_kernel).hir), config.make_ops(fmt)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(overlap_div_err_kernel).hir), config.make_ops(fmt), fmt), name)
     entry = next(block for block in lir.blocks if block.index == lir.entry)
     (fdiv,) = [op for op in entry.ops if op.inst.operator.error_ports]
     err_pc = lir.block_base[entry.index] + pooled_write_word(fdiv.commit_cycle)

--- a/tests/test_cosim.py
+++ b/tests/test_cosim.py
@@ -10,23 +10,26 @@ import pytest
 from cocotb_tools.runner import get_runner
 
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
+    FSortOptions,
     FloatFormat,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    FSortOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import Lir, build, pooled_write_word
+from holoso._lir import Lir, pooled_write_word
 from holoso._mir import lower as lower_to_mir
 
 from ._cosim import run_cosim
 from ._modelref import (
+    build_ops,
+    build_lir,
     ChainedSlots,
     COMPARATOR_OP_CASES,
     OperatorCase,
@@ -94,12 +97,17 @@ def test_cosim_staged_kernel(sim: str) -> None:
         return (a - b) * 0.25 + a * b
 
     fmt = FloatFormat(8, 24)
-    ops = OpConfig(
-        FAddOperator(fmt, stage_decode=1),
-        FMulOperator(fmt, stage_product=1),
-        FDivOperator(fmt),
-        FMulILog2OperatorFamily(fmt, stage_decode=1),
-        FCmpOperator(fmt),
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(stage_decode=1),
+                fmul=FMulOptions(stage_product=1),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(stage_decode=1),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
     run_cosim(sim, kernel, fmt, "kernel_staged", ops=ops)
 
@@ -111,12 +119,17 @@ def test_cosim_staged_division(sim: str) -> None:
 
     # Exercise the STAGE_ALIGN (fadd) and STAGE_INPUT (fdiv) knobs end-to-end -- the combos the staged-kernel misses.
     fmt = FloatFormat(6, 18)
-    ops = OpConfig(
-        FAddOperator(fmt, stage_decode=1, stage_align=1),
-        FMulOperator(fmt),
-        FDivOperator(fmt, stage_input=1),
-        FMulILog2OperatorFamily(fmt),
-        FCmpOperator(fmt),
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(stage_decode=1, stage_align=1),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(stage_input=1),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
     run_cosim(sim, blend, fmt, "blend_staged", ops=ops)
 
@@ -198,13 +211,18 @@ def test_cosim_min_max(sim: str) -> None:
         return min(a, b), max(a, b), min(abs(a), abs(b))
 
     fmt = FloatFormat(8, 24)
-    ops = OpConfig(
-        FAddOperator(fmt),
-        FMulOperator(fmt),
-        FDivOperator(fmt),
-        FMulILog2OperatorFamily(fmt),
-        FCmpOperator(fmt),
-        fsort=FSortOperator(fmt),
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+                fsort=FSortOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
     run_cosim(sim, kernel, fmt, "min_max", ops=ops)
 
@@ -294,12 +312,17 @@ def test_cosim_new_operator_stages(sim: str) -> None:
     # Exercise the newly-shipped ZKF knobs end-to-end: fadd STAGE_INPUT/STAGE_NORMALIZE/STAGE_PACK, fmul STAGE_PACK,
     # fdiv STAGE_PACK, and fmul_ilog2 STAGE_INPUT -- all folded into the latency model and the latched datapath.
     fmt = FloatFormat(8, 24)
-    ops = OpConfig(
-        FAddOperator(fmt, stage_input=1, stage_normalize=2, stage_pack=1),
-        FMulOperator(fmt, stage_input=1, stage_pack=1),
-        FDivOperator(fmt, stage_pack=1),
-        FMulILog2OperatorFamily(fmt, stage_input=1),
-        FCmpOperator(fmt),
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(stage_input=1, stage_normalize=2, stage_pack=1),
+                fmul=FMulOptions(stage_input=1, stage_pack=1),
+                fdiv=FDivOptions(stage_pack=1),
+                fmul_ilog2=FMulILog2Options(stage_input=1),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
     run_cosim(sim, kernel, fmt, "new_stages", ops=ops)
 
@@ -388,7 +411,7 @@ def test_cosim_div0_error(sim: str, config: OperatorCase) -> None:
 
     fmt = FloatFormat(6, 18)
     name = f"kdiv_{config.label}"
-    lir = build(lower_to_mir(optimize(lower(kdiv).hir), config.make_ops(fmt)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(kdiv).hir), config.make_ops(fmt)), name)
     bench = _ERR_BENCH.replace("@@WEXP@@", str(fmt.wexp)).replace("@@WMAN@@", str(fmt.wman))
     _run_err_bench(sim, name, fmt, lir, bench)
 
@@ -451,7 +474,7 @@ def test_cosim_log2_error(sim: str, config: OperatorCase) -> None:
 
     fmt = FloatFormat(6, 18)
     name = f"klog2_{config.label}"
-    lir = build(lower_to_mir(optimize(lower(klog2).hir), config.make_ops(fmt)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(klog2).hir), config.make_ops(fmt)), name)
     bench = _LOG2_ERR_BENCH.replace("@@WEXP@@", str(fmt.wexp)).replace("@@WMAN@@", str(fmt.wman))
     _run_err_bench(sim, name, fmt, lir, bench)
 
@@ -517,7 +540,7 @@ def test_cosim_overlap_div0_errpc(sim: str, config: OperatorCase) -> None:
     # _modelref.overlap_div_err_kernel.
     fmt = FloatFormat(6, 18)
     name = f"overlap_div_err_{config.label}"
-    lir = build(lower_to_mir(optimize(lower(overlap_div_err_kernel).hir), config.make_ops(fmt)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(overlap_div_err_kernel).hir), config.make_ops(fmt)), name)
     entry = next(block for block in lir.blocks if block.index == lir.entry)
     (fdiv,) = [op for op in entry.ops if op.inst.operator.error_ports]
     err_pc = lir.block_base[entry.index] + pooled_write_word(fdiv.commit_cycle)

--- a/tests/test_cosim_examples.py
+++ b/tests/test_cosim_examples.py
@@ -28,9 +28,7 @@ from collections.abc import Mapping
 
 import pytest
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from ._cosim import run_cosim
 from ._examples import SPECS, ExampleSpec
 from ._modelref import PIPELINE_OP_CASES, OperatorCase

--- a/tests/test_cosim_examples.py
+++ b/tests/test_cosim_examples.py
@@ -28,7 +28,9 @@ from collections.abc import Mapping
 
 import pytest
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from ._cosim import run_cosim
 from ._examples import SPECS, ExampleSpec
 from ._modelref import PIPELINE_OP_CASES, OperatorCase

--- a/tests/test_cosim_sign.py
+++ b/tests/test_cosim_sign.py
@@ -5,9 +5,7 @@ output taps. The ``remainder``/``pid`` specs already cover the inline-firing and
 
 import pytest
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from ._cosim import run_cosim
 from .hdl.hdl_float_oracle import SIMULATORS
 

--- a/tests/test_cosim_sign.py
+++ b/tests/test_cosim_sign.py
@@ -5,7 +5,9 @@ output taps. The ``remainder``/``pid`` specs already cover the inline-firing and
 
 import pytest
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from ._cosim import run_cosim
 from .hdl.hdl_float_oracle import SIMULATORS
 

--- a/tests/test_cycle_model.py
+++ b/tests/test_cycle_model.py
@@ -15,9 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._backend.numerical import ModelInput, ModelOutput, NumericalSimulator
 from holoso._eel import lower
 from holoso._hir import optimize
@@ -68,7 +66,7 @@ def _drive(model: NumericalSimulator, inputs: list[ModelInput]) -> tuple[list[Mo
 def test_tick_and_call_agree(name: str, factory: Callable[[], Callable[..., object]]) -> None:
     # The hand-driven tick loop and the run() convenience must produce the same outputs: run() is just a tick
     # driver, and the cycle count it would observe is the loop count below.
-    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT), _FMT), name)
     by_tick = NumericalSimulator(lir)
     by_call = NumericalSimulator(lir)
     rng = random.Random(1)
@@ -90,7 +88,7 @@ def test_single_path_latency_is_the_static_initiation_interval(name: str) -> Non
         "ekf1_stateless": lambda: update_x_P,
     }
     factory = factories[name]
-    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT), _FMT), name)
     model = NumericalSimulator(lir)
     rng = random.Random(7)
     for _ in range(8):
@@ -101,7 +99,7 @@ def test_single_path_latency_is_the_static_initiation_interval(name: str) -> Non
 def test_loop_latency_grows_with_the_trip_count() -> None:
     # Newton's reciprocal iterates until convergence, so a harder input runs more loop trips and a strictly longer
     # transaction -- the data-dependent latency a fixed ``initiation_interval`` cannot express.
-    lir = build_lir(lower_to_mir(optimize(lower(NewtonReciprocal().__call__).hir), default_ops(_FMT)), "recip")
+    lir = build_lir(lower_to_mir(optimize(lower(NewtonReciprocal().__call__).hir), default_ops(_FMT), _FMT), "recip")
     model = NumericalSimulator(lir)
     latencies = {_drive(model, [x])[1] for x in (0.5, 0.9, 1.3, 1.7, 2.5, 3.5, 6.0, 12.0)}
     assert len(latencies) >= 3, f"loop latency should vary with the trip count, saw {sorted(latencies)}"
@@ -112,7 +110,7 @@ def test_deep_loop_runs_in_bounded_memory() -> None:
     # The per-clock model holds only the register files and a small in-flight buffer, so a loop with a very high trip
     # count executes without unbounded growth. ``count_down`` runs ``n`` iterations; at n=20000 that is hundreds of
     # thousands of ticks completing in bounded memory and time -- a global-timeline design would be O(trips^2).
-    lir = build_lir(lower_to_mir(optimize(lower(_count_down).hir), default_ops(_FMT)), "count_down")
+    lir = build_lir(lower_to_mir(optimize(lower(_count_down).hir), default_ops(_FMT), _FMT), "count_down")
     shallow_cycles = _drive(NumericalSimulator(lir), [10.0])[1]
     model = NumericalSimulator(lir)
     out, deep_cycles = _drive(model, [20000.0])
@@ -179,7 +177,7 @@ def test_realized_worst_case_latency_does_not_regress(name: str) -> None:
     # re-inflates the count, amplified across loop trips. Freezing the post-optimization figure makes the gate fail on
     # any future change that lengthens a transaction, while still allowing a genuine improvement (the bound is ``<=``).
     factory, vectors, worst = _WORST_CASE_LATENCY[name]
-    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT), _FMT), name)
     model = NumericalSimulator(lir)
     waited = [_drive(model, inputs)[1] for inputs in vectors]
     assert max(waited) <= worst, f"{name}: realized worst-case latency regressed {worst} -> {max(waited)} ({waited})"

--- a/tests/test_cycle_model.py
+++ b/tests/test_cycle_model.py
@@ -15,14 +15,16 @@ from pathlib import Path
 
 import pytest
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from holoso._backend.numerical import ModelInput, ModelOutput, NumericalSimulator
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import Lir, build
+from holoso._lir import Lir
 from holoso._mir import lower as lower_to_mir
 
-from ._modelref import default_ops
+from ._modelref import build_lir, default_ops
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
 import madd  # noqa: E402
@@ -66,7 +68,7 @@ def _drive(model: NumericalSimulator, inputs: list[ModelInput]) -> tuple[list[Mo
 def test_tick_and_call_agree(name: str, factory: Callable[[], Callable[..., object]]) -> None:
     # The hand-driven tick loop and the run() convenience must produce the same outputs: run() is just a tick
     # driver, and the cycle count it would observe is the loop count below.
-    lir = build(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name)
     by_tick = NumericalSimulator(lir)
     by_call = NumericalSimulator(lir)
     rng = random.Random(1)
@@ -88,7 +90,7 @@ def test_single_path_latency_is_the_static_initiation_interval(name: str) -> Non
         "ekf1_stateless": lambda: update_x_P,
     }
     factory = factories[name]
-    lir = build(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name)
     model = NumericalSimulator(lir)
     rng = random.Random(7)
     for _ in range(8):
@@ -99,9 +101,7 @@ def test_single_path_latency_is_the_static_initiation_interval(name: str) -> Non
 def test_loop_latency_grows_with_the_trip_count() -> None:
     # Newton's reciprocal iterates until convergence, so a harder input runs more loop trips and a strictly longer
     # transaction -- the data-dependent latency a fixed ``initiation_interval`` cannot express.
-    lir = build(
-        lower_to_mir(optimize(lower(NewtonReciprocal().__call__).hir), default_ops(_FMT)), "recip", fetch_stages=3
-    )
+    lir = build_lir(lower_to_mir(optimize(lower(NewtonReciprocal().__call__).hir), default_ops(_FMT)), "recip")
     model = NumericalSimulator(lir)
     latencies = {_drive(model, [x])[1] for x in (0.5, 0.9, 1.3, 1.7, 2.5, 3.5, 6.0, 12.0)}
     assert len(latencies) >= 3, f"loop latency should vary with the trip count, saw {sorted(latencies)}"
@@ -112,7 +112,7 @@ def test_deep_loop_runs_in_bounded_memory() -> None:
     # The per-clock model holds only the register files and a small in-flight buffer, so a loop with a very high trip
     # count executes without unbounded growth. ``count_down`` runs ``n`` iterations; at n=20000 that is hundreds of
     # thousands of ticks completing in bounded memory and time -- a global-timeline design would be O(trips^2).
-    lir = build(lower_to_mir(optimize(lower(_count_down).hir), default_ops(_FMT)), "count_down", fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(_count_down).hir), default_ops(_FMT)), "count_down")
     shallow_cycles = _drive(NumericalSimulator(lir), [10.0])[1]
     model = NumericalSimulator(lir)
     out, deep_cycles = _drive(model, [20000.0])
@@ -179,7 +179,7 @@ def test_realized_worst_case_latency_does_not_regress(name: str) -> None:
     # re-inflates the count, amplified across loop trips. Freezing the post-optimization figure makes the gate fail on
     # any future change that lengthens a transaction, while still allowing a genuine improvement (the bound is ``<=``).
     factory, vectors, worst = _WORST_CASE_LATENCY[name]
-    lir = build(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(factory()).hir), default_ops(_FMT)), name)
     model = NumericalSimulator(lir)
     waited = [_drive(model, inputs)[1] for inputs in vectors]
     assert max(waited) <= worst, f"{name}: realized worst-case latency regressed {worst} -> {max(waited)} ({waited})"

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -70,9 +70,9 @@ def coalesce_conflict(x: float, b: float, cc: float) -> tuple[float, float, floa
 def emit_coalesce_conflict() -> None:
     from holoso import FloatFormat, synthesize
 
-    from ._modelref import default_ops
+    from ._modelref import default_options
 
-    result = synthesize(coalesce_conflict, default_ops(FloatFormat(6, 18)))
+    result = synthesize(coalesce_conflict, default_options(FloatFormat(6, 18)))
     _dump(result)
 
 
@@ -82,9 +82,9 @@ def emit_cordic() -> None:
 
     from holoso import FloatFormat, synthesize
 
-    from ._modelref import default_ops
+    from ._modelref import default_options
 
-    result = synthesize(CordicSinCos().__call__, default_ops(FloatFormat(6, 18)))
+    result = synthesize(CordicSinCos().__call__, default_options(FloatFormat(6, 18)))
     _dump(result)
 
 

--- a/tests/test_eel_int_corpus.py
+++ b/tests/test_eel_int_corpus.py
@@ -15,8 +15,10 @@ import pytest
 import holoso
 from holoso._eel import lower
 from holoso._errors import UnsupportedConstruct
+from holoso._operators import OpConfig
 from holoso._mir import lower as lower_to_mir
 
+from ._modelref import build_ops
 from ._eel_corpus import Crc8, Debouncer, IntUartRx, IntUartTx, Lfsr16, NcoPhase, PriorityEncoder, Pwm
 from ._eel_corpus import band_scan, convergence_steps
 from ._eeloracle import InputRow, assert_hir_matches_reference
@@ -93,14 +95,17 @@ def test_corpus_oracle(name: str, make: Callable[[], Callable[..., object]], vec
     assert compared == len(vectors)
 
 
-def _ops() -> holoso.OpConfig:
+def _ops() -> holoso.Options:
     fmt = holoso.FloatFormat(wexp=8, wman=23)
-    return holoso.OpConfig(
-        holoso.FAddOperator(fmt),
-        holoso.FMulOperator(fmt),
-        holoso.FDivOperator(fmt),
-        holoso.FMulILog2OperatorFamily(fmt),
-        holoso.FCmpOperator(fmt),
+    return holoso.Options(
+        holoso.OperatorOptions(
+            fadd=holoso.FAddOptions(),
+            fmul=holoso.FMulOptions(),
+            fdiv=holoso.FDivOptions(),
+            fmul_ilog2=holoso.FMulILog2Options(),
+            fcmp=holoso.FCmpOptions(),
+        ),
+        ffmt=fmt,
     )
 
 
@@ -109,11 +114,11 @@ def test_int_corpus_rejects_at_mir(
     name: str, make: Callable[[], Callable[..., object]], vectors: list[InputRow]
 ) -> None:
     with pytest.raises(UnsupportedConstruct, match="not yet lowerable to hardware"):
-        lower_to_mir(lower(make()).hir, _ops())
+        lower_to_mir(lower(make()).hir, build_ops(_ops()))
 
 
 @pytest.mark.parametrize("name,make,vectors", _FLOAT_CASES, ids=[name for name, _, _ in _FLOAT_CASES])
 def test_float_corpus_lowers_through_mir(
     name: str, make: Callable[[], Callable[..., object]], vectors: list[InputRow]
 ) -> None:
-    lower_to_mir(lower(make()).hir, _ops())
+    lower_to_mir(lower(make()).hir, build_ops(_ops()))

--- a/tests/test_eel_int_corpus.py
+++ b/tests/test_eel_int_corpus.py
@@ -114,11 +114,11 @@ def test_int_corpus_rejects_at_mir(
     name: str, make: Callable[[], Callable[..., object]], vectors: list[InputRow]
 ) -> None:
     with pytest.raises(UnsupportedConstruct, match="not yet lowerable to hardware"):
-        lower_to_mir(lower(make()).hir, build_ops(_ops()))
+        lower_to_mir(lower(make()).hir, build_ops(_ops()), _ops().ffmt)
 
 
 @pytest.mark.parametrize("name,make,vectors", _FLOAT_CASES, ids=[name for name, _, _ in _FLOAT_CASES])
 def test_float_corpus_lowers_through_mir(
     name: str, make: Callable[[], Callable[..., object]], vectors: list[InputRow]
 ) -> None:
-    lower_to_mir(lower(make()).hir, build_ops(_ops()))
+    lower_to_mir(lower(make()).hir, build_ops(_ops()), _ops().ffmt)

--- a/tests/test_error_hierarchy.py
+++ b/tests/test_error_hierarchy.py
@@ -10,7 +10,9 @@ import inspect
 import pkgutil
 
 import holoso
-from holoso import HolosoError
+from holoso import (
+    HolosoError,
+)
 
 
 def test_every_exception_derives_from_the_public_root() -> None:

--- a/tests/test_error_hierarchy.py
+++ b/tests/test_error_hierarchy.py
@@ -10,9 +10,7 @@ import inspect
 import pkgutil
 
 import holoso
-from holoso import (
-    HolosoError,
-)
+from holoso import HolosoError
 
 
 def test_every_exception_derives_from_the_public_root() -> None:

--- a/tests/test_example_reference.py
+++ b/tests/test_example_reference.py
@@ -21,10 +21,7 @@ import numpy as np
 import pytest
 
 import holoso
-from holoso import (
-    BoolType,
-    FloatFormat,
-)
+from holoso import BoolType, FloatFormat
 from ._examples import SPECS, ExampleSpec, ReferenceComparison
 from ._modelref import default_ops, default_options, default_tolerance, flatten_value, within
 

--- a/tests/test_example_reference.py
+++ b/tests/test_example_reference.py
@@ -21,9 +21,12 @@ import numpy as np
 import pytest
 
 import holoso
-from holoso import BoolType, FloatFormat
+from holoso import (
+    BoolType,
+    FloatFormat,
+)
 from ._examples import SPECS, ExampleSpec, ReferenceComparison
-from ._modelref import default_ops, default_tolerance, flatten_value, within
+from ._modelref import default_ops, default_options, default_tolerance, flatten_value, within
 
 # A kernel the generic scalar-lane harness cannot drive (``ReferenceComparison.EXCLUDED``) is skipped here: it has
 # public VECTOR state this harness would read by a non-existent per-element attribute (``ekf1_stateful``); its
@@ -52,7 +55,7 @@ def _quantize(value: float | bool, fmt: FloatFormat) -> float | bool:
 def _model_for(spec: ExampleSpec, fmt: FloatFormat) -> holoso.NumericalSimulator:
     # Built through the public facade, exactly as a user would; ``_lir.ops`` (read once below for the tolerance op
     # count) is the only internal datum the result does not expose publicly.
-    return holoso.synthesize(spec.make_kernel(), default_ops(fmt), name=spec.name).numerical_model.elaborate()
+    return holoso.synthesize(spec.make_kernel(), default_options(fmt), name=spec.name).numerical_model.elaborate()
 
 
 @pytest.mark.parametrize("spec,fmt", _CASES)

--- a/tests/test_extended_operators.py
+++ b/tests/test_extended_operators.py
@@ -12,21 +12,22 @@ import pytest
 
 import holoso
 from holoso import (
-    FAddOperator,
-    FAtan2Operator,
-    FCmpOperator,
-    FDivOperator,
-    FExp2Operator,
+    FAddOptions,
+    FAtan2Options,
+    FCmpOptions,
+    FDivOptions,
+    FExp2Options,
+    FFmaOptions,
+    FLog2Options,
+    FMulILog2Options,
+    FMulOptions,
+    FRoundOptions,
+    FSincosOptions,
+    FSortOptions,
     FloatFormat,
     FloatValue,
-    FFmaOperator,
-    FLog2Operator,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    FRoundOperator,
-    FSincosOperator,
-    FSortOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
     SynthesisError,
     UnsupportedConstruct,
 )
@@ -53,20 +54,23 @@ def _ops(
     with_log2: bool = True,
     with_sincos: bool = True,
     with_atan2: bool = True,
-) -> OpConfig:
-    return OpConfig(
-        FAddOperator(FMT),
-        FMulOperator(FMT),
-        FDivOperator(FMT),
-        FMulILog2OperatorFamily(FMT),
-        FCmpOperator(FMT),
-        fround=FRoundOperator(FMT) if with_round else None,
-        ffma=FFmaOperator(FMT) if with_fma else None,
-        fsort=FSortOperator(FMT) if with_sort else None,
-        fexp2=FExp2Operator(FMT) if with_exp2 else None,
-        flog2=FLog2Operator(FMT) if with_log2 else None,
-        fsincos=FSincosOperator(FMT) if with_sincos else None,
-        fatan2=FAtan2Operator(FMT) if with_atan2 else None,
+) -> Options:
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+            fround=FRoundOptions() if with_round else None,
+            ffma=FFmaOptions() if with_fma else None,
+            fsort=FSortOptions() if with_sort else None,
+            fexp2=FExp2Options() if with_exp2 else None,
+            flog2=FLog2Options() if with_log2 else None,
+            fsincos=FSincosOptions() if with_sincos else None,
+            fatan2=FAtan2Options() if with_atan2 else None,
+        ),
+        ffmt=FMT,
     )
 
 

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -117,7 +117,7 @@ def _surviving_forward_branches_for_probe(name: str, emit: Callable[[fuzz_impl._
         fragment.mode,
     )
     mir, _lir, _model, _interpreter = fuzz_impl._build_with_lir(
-        kernel.callable, fuzz_impl.OP_CONFIGS["default"](_FMT), name
+        kernel.callable, fuzz_impl.OP_CONFIGS["default"](_FMT), name, _FMT
     )
     return fuzz_impl.surviving_forward_branches(mir)
 

--- a/tests/test_gate_edge.py
+++ b/tests/test_gate_edge.py
@@ -19,14 +19,16 @@ from pathlib import Path
 import pytest
 from cocotb_tools.runner import get_runner
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import Lir, build
+from holoso._lir import Lir
 from holoso._mir import lower as lower_to_mir
 
-from ._modelref import default_ops
+from ._modelref import build_lir, default_ops
 from .hdl.hdl_float_oracle import HDL_DIR, REPO_ROOT, build_args, sources
 
 _HDL_DIR = Path(__file__).resolve().parent / "hdl"
@@ -52,9 +54,7 @@ class _ConstInstallState:
 
 
 def _verilog(fn: Callable[..., object], name: str) -> str:
-    return generate_verilog(
-        build(lower_to_mir(optimize(lower(fn).hir), default_ops(_FMT)), name, fetch_stages=3)
-    ).verilog
+    return generate_verilog(build_lir(lower_to_mir(optimize(lower(fn).hir), default_ops(_FMT)), name)).verilog
 
 
 def _assert_effect_trigger_gated(fn: Callable[..., object], name: str, prefix: str) -> None:
@@ -124,7 +124,7 @@ def _run_bench(name: str, lir: Lir, testcase: str, env: dict[str, int], monkeypa
 @pytest.mark.parametrize("k", [0, 1, 2, 3, 5])
 def test_transacting_edge_pins_at_accept_plus_fetch_lag(k: int, monkeypatch: pytest.MonkeyPatch) -> None:
     name = f"gate_edge_k{k}"
-    lir = build(lower_to_mir(optimize(lower(_cycle0_kernel).hir), default_ops(_FMT)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(_cycle0_kernel).hir), default_ops(_FMT)), name)
     assert any(op.issue_cycle == 0 for op in lir.blocks[lir.entry].ops), "kernel must issue a pooled op on cycle 0"
     _run_bench(name, lir, "transacting_edge", {"HOLOSO_DWELL_K": k}, monkeypatch)
 
@@ -133,9 +133,7 @@ def test_transacting_edge_pins_at_accept_plus_fetch_lag(k: int, monkeypatch: pyt
 @pytest.mark.parametrize("k", [1, 2, 3, 5])
 def test_state_slot_inert_during_dwell(k: int, monkeypatch: pytest.MonkeyPatch) -> None:
     name = f"gate_state_k{k}"
-    lir = build(
-        lower_to_mir(optimize(lower(_ConstInstallState().__call__).hir), default_ops(_FMT)), name, fetch_stages=3
-    )
+    lir = build_lir(lower_to_mir(optimize(lower(_ConstInstallState().__call__).hir), default_ops(_FMT)), name)
     slots = lir.float_state_slots
     assert slots, "kernel must have a float state slot with a cycle-0 const install"
     slot = slots[0]

--- a/tests/test_gate_edge.py
+++ b/tests/test_gate_edge.py
@@ -19,9 +19,7 @@ from pathlib import Path
 import pytest
 from cocotb_tools.runner import get_runner
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
 from holoso._hir import optimize
@@ -54,7 +52,7 @@ class _ConstInstallState:
 
 
 def _verilog(fn: Callable[..., object], name: str) -> str:
-    return generate_verilog(build_lir(lower_to_mir(optimize(lower(fn).hir), default_ops(_FMT)), name)).verilog
+    return generate_verilog(build_lir(lower_to_mir(optimize(lower(fn).hir), default_ops(_FMT), _FMT), name)).verilog
 
 
 def _assert_effect_trigger_gated(fn: Callable[..., object], name: str, prefix: str) -> None:
@@ -124,7 +122,7 @@ def _run_bench(name: str, lir: Lir, testcase: str, env: dict[str, int], monkeypa
 @pytest.mark.parametrize("k", [0, 1, 2, 3, 5])
 def test_transacting_edge_pins_at_accept_plus_fetch_lag(k: int, monkeypatch: pytest.MonkeyPatch) -> None:
     name = f"gate_edge_k{k}"
-    lir = build_lir(lower_to_mir(optimize(lower(_cycle0_kernel).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(_cycle0_kernel).hir), default_ops(_FMT), _FMT), name)
     assert any(op.issue_cycle == 0 for op in lir.blocks[lir.entry].ops), "kernel must issue a pooled op on cycle 0"
     _run_bench(name, lir, "transacting_edge", {"HOLOSO_DWELL_K": k}, monkeypatch)
 
@@ -133,7 +131,7 @@ def test_transacting_edge_pins_at_accept_plus_fetch_lag(k: int, monkeypatch: pyt
 @pytest.mark.parametrize("k", [1, 2, 3, 5])
 def test_state_slot_inert_during_dwell(k: int, monkeypatch: pytest.MonkeyPatch) -> None:
     name = f"gate_state_k{k}"
-    lir = build_lir(lower_to_mir(optimize(lower(_ConstInstallState().__call__).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(_ConstInstallState().__call__).hir), default_ops(_FMT), _FMT), name)
     slots = lir.float_state_slots
     assert slots, "kernel must have a float state slot with a cycle-0 const install"
     slot = slots[0]

--- a/tests/test_install_landing.py
+++ b/tests/test_install_landing.py
@@ -36,7 +36,7 @@ from ._modelref import (
 
 def _build(spec: ExampleSpec) -> Lir:
     return build_lir(
-        lower_to_mir(optimize(lower_frontend(spec.make_kernel()).hir), default_ops(spec.formats[0])),
+        lower_to_mir(optimize(lower_frontend(spec.make_kernel()).hir), default_ops(spec.formats[0]), spec.formats[0]),
         spec.name,
     )
 
@@ -147,7 +147,7 @@ def test_state_read_sourced_install_is_inline_class(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)
     options = default_options(FloatFormat(6, 18))
     lir = build_lir(
-        lower_to_mir(optimize(lower_frontend(_HoldOrUpdateBool().__call__).hir), build_ops(options)),
+        lower_to_mir(optimize(lower_frontend(_HoldOrUpdateBool().__call__).hir), build_ops(options), options.ffmt),
         "hold_or_update_bool",
     )
     resident_non_const = [x for b in lir.blocks for x in b.bool_writes if x.resident_source and not x.is_const]
@@ -191,10 +191,11 @@ def test_cross_block_source_install_residence_stays_in_predecessor_frame() -> No
     reading the source's home-block commit instead of the predecessor's ``commit_or_makespan`` -- makes the modeled
     install land far past the predecessor's terminator, and the assert raises (verified by injecting that lookup).
     """
-    ops = default_ops(FloatFormat(8, 36))
+    fmt = FloatFormat(8, 36)
+    ops = default_ops(fmt)
     kernel = _LiveThroughArm().__call__
     lir = build_lir(
-        lower_to_mir(optimize(lower_frontend(kernel).hir), ops), "live_through_arm"
+        lower_to_mir(optimize(lower_frontend(kernel).hir), ops, fmt), "live_through_arm"
     )  # raises on the off-frame drift
     cross = [c for blk in lir.blocks for c in blk.copies if not c.resident_source]
     assert cross, "the kernel no longer exercises a non-coalesced cross-block-source install; the shape changed"
@@ -202,7 +203,7 @@ def test_cross_block_source_install_residence_stays_in_predecessor_frame() -> No
         assert all(c.landing(lir.fetch_lag) <= blk.term_offset for c in blk.copies)
 
     fmt = FloatFormat(8, 36)
-    model, interpreter = build_model_and_interpreter(kernel, ops, "live_through_arm")
+    model, interpreter = build_model_and_interpreter(kernel, ops, "live_through_arm", fmt)
     vectors: list[Vector] = [
         [c, FloatValue.from_float(fmt, a), FloatValue.from_float(fmt, b)]
         for c in (True, False)
@@ -240,9 +241,10 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
     so a later change cannot silently drop it (miscompiling this shape) without failing here. Value correctness is held
     by the schedule-independent model-vs-interpreter differential.
     """
-    ops = default_ops(FloatFormat(8, 36))
+    fmt = FloatFormat(8, 36)
+    ops = default_ops(fmt)
     kernel = _LastWorkArmSource().__call__
-    lir = build_lir(lower_to_mir(optimize(lower_frontend(kernel).hir), ops), "last_work_arm")
+    lir = build_lir(lower_to_mir(optimize(lower_frontend(kernel).hir), ops, fmt), "last_work_arm")
     pushed = [
         blk
         for blk in lir.blocks
@@ -254,7 +256,7 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
         assert all(c.landing(lir.fetch_lag) <= blk.term_offset for c in blk.copies)
 
     fmt = FloatFormat(8, 36)
-    model, interpreter = build_model_and_interpreter(kernel, ops, "last_work_arm")
+    model, interpreter = build_model_and_interpreter(kernel, ops, "last_work_arm", fmt)
     vectors: list[Vector] = [
         [c, FloatValue.from_float(fmt, a), FloatValue.from_float(fmt, b)]
         for c in (True, False)

--- a/tests/test_install_landing.py
+++ b/tests/test_install_landing.py
@@ -12,22 +12,32 @@ of any input vector, so it holds for the data-dependent branch/loop kernels (uar
 import pytest
 
 import holoso
-from holoso import FloatFormat, FloatValue
+from holoso import (
+    FloatFormat,
+    FloatValue,
+)
 from holoso._eel import lower as lower_frontend
 from holoso._hir import _if_convert as if_convert_pass
 from holoso._hir import optimize
-from holoso._lir import BoolWrite, FloatCopy, InlineScheduledOp, Lir, LirBlock, PooledScheduledOp, build
+from holoso._lir import BoolWrite, FloatCopy, InlineScheduledOp, Lir, LirBlock, PooledScheduledOp
 from holoso._mir import lower as lower_to_mir
 
 from ._examples import SPECS, ExampleSpec
-from ._modelref import Vector, assert_model_equals_interpreter, build_model_and_interpreter, default_ops
+from ._modelref import (
+    Vector,
+    assert_model_equals_interpreter,
+    build_lir,
+    build_model_and_interpreter,
+    build_ops,
+    default_options,
+    default_ops,
+)
 
 
 def _build(spec: ExampleSpec) -> Lir:
-    return build(
+    return build_lir(
         lower_to_mir(optimize(lower_frontend(spec.make_kernel()).hir), default_ops(spec.formats[0])),
         spec.name,
-        fetch_stages=3,
     )
 
 
@@ -135,16 +145,17 @@ def test_state_read_sourced_install_is_inline_class(monkeypatch: pytest.MonkeyPa
     corrupt (the model vs a fresh Python reference, schedule-independent).
     """
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)
-    ops = default_ops(FloatFormat(6, 18))
-    lir = build(
-        lower_to_mir(optimize(lower_frontend(_HoldOrUpdateBool().__call__).hir), ops),
+    options = default_options(FloatFormat(6, 18))
+    lir = build_lir(
+        lower_to_mir(optimize(lower_frontend(_HoldOrUpdateBool().__call__).hir), build_ops(options)),
         "hold_or_update_bool",
-        fetch_stages=3,
     )
     resident_non_const = [x for b in lir.blocks for x in b.bool_writes if x.resident_source and not x.is_const]
     assert resident_non_const, "the state-read phi arm did not install as a resident-source bool write"
 
-    model = holoso.synthesize(_HoldOrUpdateBool().__call__, ops, name="hold_or_update_bool").numerical_model.elaborate()
+    model = holoso.synthesize(
+        _HoldOrUpdateBool().__call__, options, name="hold_or_update_bool"
+    ).numerical_model.elaborate()
     reference = _HoldOrUpdateBool()
     for a, c in [(True, False), (False, False), (True, True), (False, False), (True, False), (False, True)]:
         assert tuple(bool(v) for v in model.run(a, c)) == reference(a, c)
@@ -182,8 +193,8 @@ def test_cross_block_source_install_residence_stays_in_predecessor_frame() -> No
     """
     ops = default_ops(FloatFormat(8, 36))
     kernel = _LiveThroughArm().__call__
-    lir = build(
-        lower_to_mir(optimize(lower_frontend(kernel).hir), ops), "live_through_arm", fetch_stages=3
+    lir = build_lir(
+        lower_to_mir(optimize(lower_frontend(kernel).hir), ops), "live_through_arm"
     )  # raises on the off-frame drift
     cross = [c for blk in lir.blocks for c in blk.copies if not c.resident_source]
     assert cross, "the kernel no longer exercises a non-coalesced cross-block-source install; the shape changed"
@@ -231,7 +242,7 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
     """
     ops = default_ops(FloatFormat(8, 36))
     kernel = _LastWorkArmSource().__call__
-    lir = build(lower_to_mir(optimize(lower_frontend(kernel).hir), ops), "last_work_arm", fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower_frontend(kernel).hir), ops), "last_work_arm")
     pushed = [
         blk
         for blk in lir.blocks

--- a/tests/test_install_landing.py
+++ b/tests/test_install_landing.py
@@ -12,10 +12,7 @@ of any input vector, so it holds for the data-dependent branch/loop kernels (uar
 import pytest
 
 import holoso
-from holoso import (
-    FloatFormat,
-    FloatValue,
-)
+from holoso import FloatFormat, FloatValue
 from holoso._eel import lower as lower_frontend
 from holoso._hir import _if_convert as if_convert_pass
 from holoso._hir import optimize

--- a/tests/test_interpret.py
+++ b/tests/test_interpret.py
@@ -65,7 +65,7 @@ _EXAMPLE_CASES = [
 
 @pytest.mark.parametrize("spec,fmt", _EXAMPLE_CASES)
 def test_interpreter_matches_model_on_examples(spec: ExampleSpec, fmt: FloatFormat) -> None:
-    model, interpreter = build_model_and_interpreter(spec.make_kernel(), default_ops(fmt), spec.name)
+    model, interpreter = build_model_and_interpreter(spec.make_kernel(), default_ops(fmt), spec.name, fmt)
     vectors = [_decode_spec_vector(model, fmt, row) for row in spec.vectors(fmt)]
     assert_model_equals_interpreter(model, interpreter, vectors, spec.name)
 
@@ -107,7 +107,7 @@ def test_interpreter_matches_model_on_corners(
     label: str, make_kernel: Callable[[], Callable[..., object]], ops_factory: Callable[[FloatFormat], OpConfig]
 ) -> None:
     fmt = FloatFormat(6, 18)
-    model, interpreter = build_model_and_interpreter(make_kernel(), ops_factory(fmt), label)
+    model, interpreter = build_model_and_interpreter(make_kernel(), ops_factory(fmt), label, fmt)
     rng = np.random.default_rng(0xC0FFEE)
     vectors = _bounded_vectors(model, fmt, rng, 64)
     assert_model_equals_interpreter(model, interpreter, vectors, f"{label}-{ops_factory.__name__}")
@@ -115,7 +115,7 @@ def test_interpreter_matches_model_on_corners(
 
 def test_interpreter_matches_model_on_edge_bits() -> None:
     fmt = FloatFormat(6, 18)
-    model, interpreter = build_model_and_interpreter(branch_boundary_kernel, default_ops(fmt), "branch_boundary")
+    model, interpreter = build_model_and_interpreter(branch_boundary_kernel, default_ops(fmt), "branch_boundary", fmt)
     rng = np.random.default_rng(0x5EED)
     vectors: list[Vector] = [
         [FloatValue.from_bits(fmt, random_legal_bits(fmt, rng)) for _ in model.inputs] for _ in range(256)
@@ -130,7 +130,7 @@ def test_loop_header_phi_swap_resolves_in_parallel() -> None:
     either oracle -- or one shared by both -- surfaces as a divergence. Integer-valued inputs keep every output exact.
     """
     fmt = FloatFormat(6, 18)
-    model, interpreter = build_model_and_interpreter(phi_swap_loop, default_ops(fmt), "phi_swap_loop")
+    model, interpreter = build_model_and_interpreter(phi_swap_loop, default_ops(fmt), "phi_swap_loop", fmt)
     for x in (2.0, -3.0, 0.5, 5.0):
         for n in (1.0, 2.0, 3.0, 4.0):
             vector = [FloatValue.from_float(fmt, x), FloatValue.from_float(fmt, n)]
@@ -151,7 +151,7 @@ def test_loop_header_phi_swap_with_computed_arm_resolves_in_parallel() -> None:
     the same LIR, and interp==model is asserted so a divergence localizes the guilty layer.
     """
     fmt = FloatFormat(6, 18)
-    model, interpreter = build_model_and_interpreter(phi_swap_computed_loop, default_ops(fmt), "phi_swap_computed")
+    model, interpreter = build_model_and_interpreter(phi_swap_computed_loop, default_ops(fmt), "phi_swap_computed", fmt)
     for x in (1.0, 2.0, -1.5):
         for n in (1.0, 2.0, 3.0, 4.0):
             vector = [FloatValue.from_float(fmt, x), FloatValue.from_float(fmt, n)]
@@ -168,7 +168,7 @@ def test_bool_loop_header_phi_swap_with_computed_arm_resolves_in_parallel() -> N
     """The boolean-bank twin of the computed-arm swap: the latch installs are BoolWrites, not FloatCopys."""
     fmt = FloatFormat(6, 18)
     model, interpreter = build_model_and_interpreter(
-        bool_phi_swap_computed_loop, default_ops(fmt), "bool_phi_swap_computed"
+        bool_phi_swap_computed_loop, default_ops(fmt), "bool_phi_swap_computed", fmt
     )
     for x in (False, True):
         for n in (1.0, 2.0, 3.0, 4.0):
@@ -190,7 +190,9 @@ def test_mixed_arm_swap_diamond_builds_and_matches_python() -> None:
     arm's install and the residence assert trips), so the value grid is secondary to synthesis itself.
     """
     fmt = FloatFormat(6, 18)
-    model, interpreter = build_model_and_interpreter(branchy_swap_mixed_arm_loop, default_ops(fmt), "mixed_arm_swap")
+    model, interpreter = build_model_and_interpreter(
+        branchy_swap_mixed_arm_loop, default_ops(fmt), "mixed_arm_swap", fmt
+    )
     for x in (1.0, -1.0):
         for n in (1.0, 2.0, 3.0):
             vector = [FloatValue.from_float(fmt, x), FloatValue.from_float(fmt, 4.0), FloatValue.from_float(fmt, n)]
@@ -209,7 +211,7 @@ def test_state_slot_swap_writeback_is_parallel() -> None:
     surfaces. Integer inputs keep the output exact.
     """
     fmt = FloatFormat(6, 18)
-    model, interpreter = build_model_and_interpreter(SlotSwap().step, default_ops(fmt), "slot_swap")
+    model, interpreter = build_model_and_interpreter(SlotSwap().step, default_ops(fmt), "slot_swap", fmt)
     reference = SlotSwap()
     for x in (0.0, 1.0, -2.0, 3.0, -4.0, 5.0):
         vector = [FloatValue.from_float(fmt, x)]

--- a/tests/test_language_features.py
+++ b/tests/test_language_features.py
@@ -18,22 +18,30 @@ import pytest
 
 import holoso
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
 from holoso._errors import UnsupportedConstruct
 
 _FMT = FloatFormat(4, 8)
 
 
-def _ops() -> OpConfig:
-    return OpConfig(
-        FAddOperator(_FMT), FMulOperator(_FMT), FDivOperator(_FMT), FMulILog2OperatorFamily(_FMT), FCmpOperator(_FMT)
+def _ops() -> Options:
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=_FMT,
     )
 
 

--- a/tests/test_latency_freeze.py
+++ b/tests/test_latency_freeze.py
@@ -22,9 +22,7 @@ which the value-blind schedule freeze cannot.
 import pytest
 
 import holoso
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._eel import lower as lower_frontend
 from holoso._hir import optimize
 from holoso._lir import FloatStateSlot
@@ -75,7 +73,7 @@ _SPEC_BY_NAME = {spec.name: spec for spec in SPECS}
 def test_schedule_length_is_frozen(name: str) -> None:
     spec = _SPEC_BY_NAME[name]
     lir = build_lir(
-        lower_to_mir(optimize(lower_frontend(spec.make_kernel()).hir), default_ops(spec.formats[0])),
+        lower_to_mir(optimize(lower_frontend(spec.make_kernel()).hir), default_ops(spec.formats[0]), spec.formats[0]),
         name,
     )
     got = (lir.min_initiation_interval, lir.last_pc)
@@ -126,7 +124,7 @@ _CHAINED_COPY: list[tuple[str, type[_Delay3] | type[_BoolShift3], tuple[int, int
 def test_chained_copy_schedule_is_frozen(
     name: str, kernel_cls: type[_Delay3] | type[_BoolShift3], frozen: tuple[int, int]
 ) -> None:
-    lir = build_lir(lower_to_mir(optimize(lower_frontend(kernel_cls().__call__).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower_frontend(kernel_cls().__call__).hir), default_ops(_FMT), _FMT), name)
     slots: list[FloatStateSlot | BoolStateSlot] = [*lir.float_state_slots, *lir.bool_state_slots]
     assert all(
         slot.needs_copy for slot in slots

--- a/tests/test_latency_freeze.py
+++ b/tests/test_latency_freeze.py
@@ -22,15 +22,17 @@ which the value-blind schedule freeze cannot.
 import pytest
 
 import holoso
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from holoso._eel import lower as lower_frontend
 from holoso._hir import optimize
-from holoso._lir import FloatStateSlot, build
+from holoso._lir import FloatStateSlot
 from holoso._lir._ir import BoolStateSlot
 from holoso._mir import lower as lower_to_mir
 
 from ._examples import SPECS
-from ._modelref import default_ops
+from ._modelref import build_lir, default_ops, default_options
 
 # Kernel name -> frozen (min initiation interval, last microcode PC). last_pc is the out_valid boundary PC -- the
 # end of the static schedule across all blocks -- so it pins the full schedule even for data-dependent (branch/loop)
@@ -72,10 +74,9 @@ _SPEC_BY_NAME = {spec.name: spec for spec in SPECS}
 @pytest.mark.parametrize("name", sorted(_FROZEN_SCHEDULE))
 def test_schedule_length_is_frozen(name: str) -> None:
     spec = _SPEC_BY_NAME[name]
-    lir = build(
+    lir = build_lir(
         lower_to_mir(optimize(lower_frontend(spec.make_kernel()).hir), default_ops(spec.formats[0])),
         name,
-        fetch_stages=3,
     )
     got = (lir.min_initiation_interval, lir.last_pc)
     assert got == _FROZEN_SCHEDULE[name], (
@@ -125,9 +126,7 @@ _CHAINED_COPY: list[tuple[str, type[_Delay3] | type[_BoolShift3], tuple[int, int
 def test_chained_copy_schedule_is_frozen(
     name: str, kernel_cls: type[_Delay3] | type[_BoolShift3], frozen: tuple[int, int]
 ) -> None:
-    lir = build(
-        lower_to_mir(optimize(lower_frontend(kernel_cls().__call__).hir), default_ops(_FMT)), name, fetch_stages=3
-    )
+    lir = build_lir(lower_to_mir(optimize(lower_frontend(kernel_cls().__call__).hir), default_ops(_FMT)), name)
     slots: list[FloatStateSlot | BoolStateSlot] = [*lir.float_state_slots, *lir.bool_state_slots]
     assert all(
         slot.needs_copy for slot in slots
@@ -145,13 +144,15 @@ def test_chained_copy_captures_old_values() -> None:
     input by exactly three transactions. A value-blind schedule freeze cannot see a read-after-write miscompile here.
     """
     fmt = _FMT
-    fmodel = holoso.synthesize(_Delay3().__call__, default_ops(fmt), name="delay3").numerical_model.elaborate()
+    fmodel = holoso.synthesize(_Delay3().__call__, default_options(fmt), name="delay3").numerical_model.elaborate()
     fref = _Delay3()
     for raw in (1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0):
         x = fmt.decode(fmt.encode(raw))  # quantize so the model and the reference see the identical operand
         assert float(fmodel.run(x)[0]) == fref(x)
 
-    bmodel = holoso.synthesize(_BoolShift3().__call__, default_ops(fmt), name="bool_shift3").numerical_model.elaborate()
+    bmodel = holoso.synthesize(
+        _BoolShift3().__call__, default_options(fmt), name="bool_shift3"
+    ).numerical_model.elaborate()
     bref = _BoolShift3()
     for b in (True, False, True, True, False, False, True, False):
         assert bool(bmodel.run(b)[0]) == bref(b)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -17,12 +17,17 @@ from numpy import matmul as _matmul
 from jaxtyping import Bool, Float, Float64, Int, Shaped
 
 import holoso
-from holoso import FFmaOperator, FloatFormat, UnsupportedConstruct
+from holoso._operators import FFmaOperator
+from holoso import (
+    FFmaOptions,
+    FloatFormat,
+    UnsupportedConstruct,
+)
 from holoso._eel import lower
 from holoso._hir import FloatAdd, FloatMul, optimize
 from holoso._mir import lower as lower_to_mir
 
-from ._modelref import arith_count as _arith_count, default_ops
+from ._modelref import arith_count as _arith_count, default_ops, default_options
 
 # Wide enough that the model's arithmetic coincides with float64 up to the final rounding, so kernels can be compared
 # against their own native numpy execution with a tight tolerance.
@@ -71,7 +76,7 @@ class TrackingFilter:
 
 
 def _sim(fn: Callable[..., object]) -> holoso.NumericalSimulator:
-    return holoso.synthesize(fn, default_ops(_FMT), name="kernel").numerical_model.elaborate()
+    return holoso.synthesize(fn, default_options(_FMT), name="kernel").numerical_model.elaborate()
 
 
 def _run(sim: holoso.NumericalSimulator, *arrays: np.ndarray | float) -> np.ndarray:
@@ -174,7 +179,7 @@ def test_dot_product_left_fold_contracts_to_fma_chain() -> None:
     def mnemonic_counts(with_fma: bool) -> dict[str, int]:
         ops = default_ops(_FMT)
         if with_fma:
-            ops = dataclasses.replace(ops, ffma=FFmaOperator(_FMT))
+            ops = dataclasses.replace(ops, ffma=FFmaOperator(_FMT, FFmaOptions(), 0))
         mir = lower_to_mir(optimize(lower(dot).hir), ops)
         counts: dict[str, int] = {}
         for node in mir.nodes.values():
@@ -773,7 +778,7 @@ def test_transpose_of_matrix_state_attribute() -> None:
             return self.P.T * s
 
     sim = holoso.synthesize(
-        Holder(np.array([[1.0, 2.0], [3.0, 4.0]])).step, default_ops(_FMT), name="pt"
+        Holder(np.array([[1.0, 2.0], [3.0, 4.0]])).step, default_options(_FMT), name="pt"
     ).numerical_model.elaborate()
     got = _run(sim, 2.0).reshape(2, 2)
     assert np.allclose(got, np.array([[1.0, 2.0], [3.0, 4.0]]).T * 2.0)
@@ -974,7 +979,7 @@ def test_matrix_state_update_matches_numpy_across_transactions() -> None:
         def step(self, f: Float64[np.ndarray, "2 2"]) -> None:
             self.P = f @ self.P @ f.T
 
-    sim = holoso.synthesize(Decay(np.eye(2)).step, default_ops(_FMT), name="decay").numerical_model.elaborate()
+    sim = holoso.synthesize(Decay(np.eye(2)).step, default_options(_FMT), name="decay").numerical_model.elaborate()
     assert [p.name for p in sim.outputs] == ["state_P_0_0", "state_P_0_1", "state_P_1_0", "state_P_1_1"]
     reference = Decay(np.eye(2))
     f = np.array([[1.0, 0.125], [-0.25, 0.9375]])
@@ -1012,7 +1017,7 @@ def test_runtime_divisor_division_matches_numpy() -> None:
 
     scalar_cases = [(6.0, 3.0), (1.0, -4.0), (2.5, 0.5), (0.0, 7.0)]  # each divides exactly in both formats; last: 0/b
     for fmt in (_FMT, FloatFormat(6, 18)):  # a second, narrower datapath width also exercises the divide
-        sim = holoso.synthesize(scalar_div, default_ops(fmt), name="div").numerical_model.elaborate()
+        sim = holoso.synthesize(scalar_div, default_options(fmt), name="div").numerical_model.elaborate()
         for a, b in scalar_cases:
             assert np.allclose(_run(sim, a, b), a / b, rtol=1e-12, atol=1e-300), (fmt, a, b)
 
@@ -1028,7 +1033,7 @@ def test_stateful_kalman_style_filter_matches_numpy_across_transactions() -> Non
     # Locks in the whole matrix feature surface composed in one stateful kernel across transactions: matrix/vector
     # parameters and carried state, ndarray module constants, ``@`` in every shape with transpose, elementwise scalar
     # broadcast, an annotated local, a static row loop, a shaped return, and the runtime-divisor Kalman gain.
-    sim = holoso.synthesize(TrackingFilter().update, default_ops(_FMT), name="tracker").numerical_model.elaborate()
+    sim = holoso.synthesize(TrackingFilter().update, default_options(_FMT), name="tracker").numerical_model.elaborate()
     assert [p.name for p in sim.outputs] == [
         "out_0", "out_1", "state_P_0_0", "state_P_0_1", "state_P_1_0", "state_P_1_1", "state_x_0", "state_x_1",
     ]  # fmt: skip
@@ -1068,8 +1073,9 @@ def test_imu_frame_transform_fma_matches_numpy() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     import imu_frame_transform
 
-    ops = dataclasses.replace(default_ops(_FMT), ffma=FFmaOperator(_FMT))
-    sim = holoso.synthesize(imu_frame_transform.transform, ops, name="imu_fma").numerical_model.elaborate()
+    options = default_options(_FMT)
+    options = dataclasses.replace(options, operator=dataclasses.replace(options.operator, ffma=FFmaOptions()))
+    sim = holoso.synthesize(imu_frame_transform.transform, options, name="imu_fma").numerical_model.elaborate()
     yaw90 = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
     roll90 = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
     for rotation in (yaw90, roll90):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -18,11 +18,7 @@ from jaxtyping import Bool, Float, Float64, Int, Shaped
 
 import holoso
 from holoso._operators import FFmaOperator
-from holoso import (
-    FFmaOptions,
-    FloatFormat,
-    UnsupportedConstruct,
-)
+from holoso import FFmaOptions, FloatFormat, UnsupportedConstruct
 from holoso._eel import lower
 from holoso._hir import FloatAdd, FloatMul, optimize
 from holoso._mir import lower as lower_to_mir

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -180,7 +180,7 @@ def test_dot_product_left_fold_contracts_to_fma_chain() -> None:
         ops = default_ops(_FMT)
         if with_fma:
             ops = dataclasses.replace(ops, ffma=FFmaOperator(_FMT, FFmaOptions(), 0))
-        mir = lower_to_mir(optimize(lower(dot).hir), ops)
+        mir = lower_to_mir(optimize(lower(dot).hir), ops, _FMT)
         counts: dict[str, int] = {}
         for node in mir.nodes.values():
             operator = getattr(node, "operator", None)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,9 +29,7 @@ from pathlib import Path
 
 import pytest
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._eel import lower
 from holoso._hir import optimize
 from holoso._lir import Lir
@@ -117,7 +115,9 @@ class Metrics:
 # The baselines are frozen against the shipped allocator defaults, passed explicitly so no environment speed-up can
 # leak in here; changing a default deliberately re-freezes them.
 def _measure(name: str) -> Metrics:
-    lir: Lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name, SHIPPED_TUNING)
+    lir: Lir = build_lir(
+        lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT), _FMT), name, SHIPPED_TUNING
+    )
     straight = (
         len(lir.blocks) == 1
         and not lir.bool_state_slots

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,12 +29,14 @@ from pathlib import Path
 
 import pytest
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import Lir, build
+from holoso._lir import Lir
 from holoso._mir import lower as lower_to_mir
-from ._modelref import default_ops
+from ._modelref import SHIPPED_TUNING, build_lir, default_ops
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
 import madd  # noqa: E402
@@ -112,25 +114,10 @@ class Metrics:
     max_block_span: int
 
 
-@pytest.fixture(autouse=True)
-def _pinned_regalloc_knobs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """
-    Pin every register-allocation tuning knob to its shipped default so the frozen baselines are reproducible
-    regardless of the developer's environment (``HOLOSO_REGALLOC_EFFORT`` speed-ups, write-cap/price experiments).
-    The knobs are env-read-once at import, so the module attributes are patched to the named defaults; changing a
-    default deliberately re-freezes the baselines.
-    """
-    import holoso._lir._regalloc as regalloc
-
-    # Pinned to the knobs' default values (the getenv fallbacks in _regalloc), restated here as literals: the
-    # baselines are frozen against the defaults, so an env override must not leak into this gate.
-    monkeypatch.setattr(regalloc, "_REFINE_MAXITER", 5000)
-    monkeypatch.setattr(regalloc, "_REG_REUSE_WRITE_CAP", 2)
-    monkeypatch.setattr(regalloc, "_REG_PRICE", 2.0)
-
-
+# The baselines are frozen against the shipped allocator defaults, passed explicitly so no environment speed-up can
+# leak in here; changing a default deliberately re-freezes them.
 def _measure(name: str) -> Metrics:
-    lir: Lir = build(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name, fetch_stages=3)
+    lir: Lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name, SHIPPED_TUNING)
     straight = (
         len(lir.blocks) == 1
         and not lir.bool_state_slots

--- a/tests/test_mir_fusions.py
+++ b/tests/test_mir_fusions.py
@@ -5,24 +5,37 @@ from collections import Counter
 from collections.abc import Callable
 
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import build
+from ._modelref import build_lir, build_ops
+from holoso._operators import OpConfig
 from holoso._mir import Mir, MirOperation
 from holoso._mir import lower as lower_to_mir
 
 from ._modelref import build_model
 
 FMT = FloatFormat(6, 18)
-OPS = OpConfig(FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT))
+OPS = build_ops(
+    Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
+    )
+)
 
 
 def _run(target: Callable[..., object], ops: OpConfig = OPS) -> Mir:
@@ -47,7 +60,7 @@ def test_directional_inf_composites_lower_to_one_classifier() -> None:
     assert counts.get("fisposinf") == 2 and counts.get("fisneginf") == 2
     assert "band" not in counts and "fcmp" not in counts and "fisfinite" not in counts
 
-    model = build_model(build(mir, "directional_inf", fetch_stages=3))
+    model = build_model(build_lir(mir, "directional_inf"))
     for x in (float("inf"), float("-inf"), 1.0, -1.0, 0.0):
         got = model.run(x, x, x, x)
         want = [
@@ -72,7 +85,7 @@ def test_directional_inf_fusion_preserves_reused_predicates() -> None:
     assert counts.get("fcmp") == 1
     assert counts.get("band") == 1
 
-    model = build_model(build(mir, "directional_inf_reused", fetch_stages=3))
+    model = build_model(build_lir(mir, "directional_inf_reused"))
     for x in (float("inf"), float("-inf"), 1.0, -1.0):
         inf = math.isinf(x)
         pos = x > 0.0
@@ -90,7 +103,7 @@ def test_directional_inf_fusion_suppresses_predicate_shared_only_by_fused_ands()
     assert counts.get("fisneginf") == 1
     assert "fisfinite" not in counts and "fcmp" not in counts and "band" not in counts
 
-    model = build_model(build(mir, "directional_inf_shared", fetch_stages=3))
+    model = build_model(build_lir(mir, "directional_inf_shared"))
     for x in (float("inf"), float("-inf"), 1.0, -1.0):
         inf = math.isinf(x)
         assert model.run(x) == [inf and x > 0.0, inf and x < 0.0]

--- a/tests/test_mir_fusions.py
+++ b/tests/test_mir_fusions.py
@@ -39,7 +39,7 @@ OPS = build_ops(
 
 
 def _run(target: Callable[..., object], ops: OpConfig = OPS) -> Mir:
-    return lower_to_mir(optimize(lower(target).hir), ops)
+    return lower_to_mir(optimize(lower(target).hir), ops, FMT)
 
 
 def _mir_operation_counts(mir: Mir) -> Counter[str]:

--- a/tests/test_overlap_behavior.py
+++ b/tests/test_overlap_behavior.py
@@ -26,14 +26,15 @@ import pytest
 import holoso
 from holoso import (
     BoolType,
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
     FloatType,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
 
 from ._modelref import default_tolerance, within
@@ -41,9 +42,16 @@ from ._modelref import default_tolerance, within
 FMT = FloatFormat(6, 18)
 
 
-def _ops() -> OpConfig:
-    return OpConfig(
-        FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT)
+def _ops() -> Options:
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
     )
 
 

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -141,8 +141,8 @@ class OtherFold(Operator):
         return OtherConst(operand.value + 1)
 
 
-def _run(target: Callable[..., object], ops: OpConfig = OPS) -> Mir:
-    return lower_to_mir(optimize(lower(target).hir), ops)
+def _run(target: Callable[..., object], ops: OpConfig = OPS, fmt: FloatFormat = FMT) -> Mir:
+    return lower_to_mir(optimize(lower(target).hir), ops, fmt)
 
 
 def _op_count(mir: Mir, cls: type) -> int:
@@ -197,7 +197,7 @@ def test_lower_rejects_non_float_hir_input_type() -> None:
     hir = builder.finish()
 
     try:
-        lower_to_mir(hir, OPS)
+        lower_to_mir(hir, OPS, FMT)
     except UnsupportedConstruct as ex:
         assert "no MIR lowering rule" in str(ex)
     else:
@@ -292,7 +292,7 @@ def test_wide_supported_pow2_uses_ilog2_operator() -> None:
             ffmt=fmt,
         )
     )
-    mir = _run(f, ops)
+    mir = _run(f, ops, fmt)
     selected = _ops(mir)
     assert [type(o.operator) for o in selected] == [FMulILog2Operator]
     assert isinstance(selected[0].operator, FMulILog2Operator) and selected[0].operator.k == 4
@@ -317,7 +317,7 @@ def test_unsupported_pow2_shift_is_rejected() -> None:
         )
     )
     try:
-        _run(f, ops)
+        _run(f, ops, fmt)
     except UnsupportedConstruct as ex:
         assert "unsupported power-of-two float scale" in str(ex)
     else:
@@ -619,7 +619,7 @@ def test_bool_select_reductions_are_truth_table_correct() -> None:
         assert (
             has_select == keeps_select
         ), f"{fn.__name__}: bool_select presence {has_select} != expected {keeps_select}"
-        model = build_model(build_lir(lower_to_mir(hir, OPS), fn.__name__))
+        model = build_model(build_lir(lower_to_mir(hir, OPS, FMT), fn.__name__))
         for combo in itertools.product([False, True], repeat=arity):
             got = bool(model.run(*combo)[0])
             assert got == bool(ref(*combo)), f"{fn.__name__}{combo}: got {got}, want {ref(*combo)}"
@@ -653,7 +653,7 @@ def test_identical_mux_arms_collapse_whatever_the_selector() -> None:
         assert not any(
             isinstance(n, Operation) and isinstance(n.operator, (BoolSelect, Select)) for n in hir.nodes.values()
         ), f"{kernel.__name__}: a mux over identical arms survived"
-        model = build_model(build_lir(lower_to_mir(hir, OPS), kernel.__name__))
+        model = build_model(build_lir(lower_to_mir(hir, OPS, FMT), kernel.__name__))
         for x in (-8.0, -1.0, 0.0, 0.5, 3.0):
             got, want = read(model.run(x)[0]), read(kernel(x))
             assert got == want, f"{kernel.__name__}({x}): got {got}, want {want}"
@@ -849,7 +849,7 @@ def test_a_constant_integer_expression_folds_away_entirely() -> None:
     assert not [node for node in hir.nodes.values() if isinstance(node, Operation)]
     (out,) = hir.outputs
     assert hir.nodes[out.value] == FloatConst(float(5 * 2**200))
-    lower_to_mir(hir, OPS)  # nothing integer is left, so MIR accepts it
+    lower_to_mir(hir, OPS, FMT)  # nothing integer is left, so MIR accepts it
 
 
 def test_integer_folding_is_exact_across_the_vocabulary() -> None:
@@ -900,7 +900,7 @@ def test_integer_folding_has_no_size_limit() -> None:
     hir = optimize(builder.finish())
     assert not [node for node in hir.nodes.values() if isinstance(node, Operation)]
     assert hir.nodes[hir.outputs[0].value] == FloatConst(0.0)
-    lower_to_mir(hir, OPS)  # nothing integer survives, however wide the intermediate was
+    lower_to_mir(hir, OPS, FMT)  # nothing integer survives, however wide the intermediate was
 
 
 @pytest.mark.parametrize(
@@ -1269,7 +1269,7 @@ def test_integer_nodes_are_refused_by_mir_lowering(make: Callable[[HirBuilder], 
     make(builder)
     builder.ret()
     with pytest.raises(UnsupportedConstruct, match="not yet lowerable to hardware"):
-        lower_to_mir(builder.finish(), OPS)
+        lower_to_mir(builder.finish(), OPS, FMT)
 
 
 def test_a_bool_select_repeating_its_condition_reduces_to_a_gate() -> None:

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -11,14 +11,16 @@ import pytest
 
 import holoso
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
+from holoso._operators import FAddOperator, FDivOperator, FMulOperator, OpConfig
 from holoso._errors import SynthesisError, UnsupportedConstruct
 from holoso._util import ValueId
 from holoso._eel import lower
@@ -90,14 +92,25 @@ from holoso._hir import (
     IntType,
 )
 from holoso._hir import _if_convert as if_convert_pass
-from holoso._lir import build
+from ._modelref import build_lir
 from holoso._mir import lower as lower_to_mir, Mir, MirFloatConst, MirFloatInput, MirFloatOutput, MirOperation
 from holoso._operators import FMulILog2Operator, FloatSignControl
 from ._importguard import forbidden_imports
-from ._modelref import build_model
+from ._modelref import build_model, build_ops
 
 FMT = FloatFormat(6, 18)
-OPS = OpConfig(FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT))
+OPS = build_ops(
+    Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
+    )
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -267,8 +280,17 @@ def test_wide_supported_pow2_uses_ilog2_operator() -> None:
         return a * 16.0
 
     fmt = FloatFormat(3, 4)
-    ops = OpConfig(
-        FAddOperator(fmt), FMulOperator(fmt), FDivOperator(fmt), FMulILog2OperatorFamily(fmt), FCmpOperator(fmt)
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
     mir = _run(f, ops)
     selected = _ops(mir)
@@ -282,8 +304,17 @@ def test_unsupported_pow2_shift_is_rejected() -> None:
         return a * 64.0
 
     fmt = FloatFormat(3, 4)
-    ops = OpConfig(
-        FAddOperator(fmt), FMulOperator(fmt), FDivOperator(fmt), FMulILog2OperatorFamily(fmt), FCmpOperator(fmt)
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
     try:
         _run(f, ops)
@@ -386,7 +417,7 @@ def test_deep_cfg_does_not_overflow_recursion() -> None:
     # LIR build) since each contains a CFG DFS, and check the bit-exact model against the plain-Python reference.
     hir = lower(_deep_cfg_kernel).hir
     assert len(hir.blocks) > 1000  # the CFG is genuinely deep (otherwise the regression would not bite)
-    model = build_model(build(_run(_deep_cfg_kernel), "deep", fetch_stages=3))
+    model = build_model(build_lir(_run(_deep_cfg_kernel), "deep"))
     for x in (0.5, 2.0, 8.0):  # acc stays positive -> +900 every time; 0.5/2.0/8.0 are exact in ZKF
         assert float(model.run(x)[0]) == _deep_cfg_kernel(x)
 
@@ -588,7 +619,7 @@ def test_bool_select_reductions_are_truth_table_correct() -> None:
         assert (
             has_select == keeps_select
         ), f"{fn.__name__}: bool_select presence {has_select} != expected {keeps_select}"
-        model = build_model(build(lower_to_mir(hir, OPS), fn.__name__, fetch_stages=3))
+        model = build_model(build_lir(lower_to_mir(hir, OPS), fn.__name__))
         for combo in itertools.product([False, True], repeat=arity):
             got = bool(model.run(*combo)[0])
             assert got == bool(ref(*combo)), f"{fn.__name__}{combo}: got {got}, want {ref(*combo)}"
@@ -622,7 +653,7 @@ def test_identical_mux_arms_collapse_whatever_the_selector() -> None:
         assert not any(
             isinstance(n, Operation) and isinstance(n.operator, (BoolSelect, Select)) for n in hir.nodes.values()
         ), f"{kernel.__name__}: a mux over identical arms survived"
-        model = build_model(build(lower_to_mir(hir, OPS), kernel.__name__, fetch_stages=3))
+        model = build_model(build_lir(lower_to_mir(hir, OPS), kernel.__name__))
         for x in (-8.0, -1.0, 0.0, 0.5, 3.0):
             got, want = read(model.run(x)[0]), read(kernel(x))
             assert got == want, f"{kernel.__name__}({x}): got {got}, want {want}"
@@ -673,7 +704,7 @@ def test_speculatable_hir_operators_map_to_error_free_hardware() -> None:
     # error-bearing operator today, and it must stay unspeculatable. A future error-bearing operator must declare
     # speculatable=False (the default) on its HIR side, or if-conversion would assert the module error flag for a
     # never-taken path.
-    assert FDivOperator(FMT).error_ports and not HirFloatDiv.speculatable
+    assert FDivOperator(FMT, FDivOptions()).error_ports and not HirFloatDiv.speculatable
 
 
 def test_dead_diamond_frees_its_condition_cone() -> None:
@@ -1261,7 +1292,7 @@ def test_a_bool_select_repeating_its_condition_reduces_to_a_gate() -> None:
         assert not any(isinstance(op, BoolSelect) for op in operators), f"{kernel.__name__}: the mux survived"
         assert any(isinstance(op, gate) for op in operators), f"{kernel.__name__}: expected a {gate.__name__}"
         # The shape alone cannot tell an `and` rewritten as an `or`; only the truth table can.
-        sim = build_model(build(_run(kernel), kernel.__name__, fetch_stages=3))
+        sim = build_model(build_lir(_run(kernel), kernel.__name__))
         for c in (False, True):
             for other in (False, True):
                 assert sim.run(c, other)[0] is kernel(c, other), f"{kernel.__name__}({c}, {other})"

--- a/tests/test_public_api_behavior.py
+++ b/tests/test_public_api_behavior.py
@@ -35,14 +35,15 @@ import numpy as np
 import holoso
 from holoso import (
     BoolType,
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
     FloatType,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
 
 from ._modelref import default_tolerance, within
@@ -50,9 +51,16 @@ from ._modelref import default_tolerance, within
 FMT = FloatFormat(6, 18)
 
 
-def _ops() -> OpConfig:
-    return OpConfig(
-        FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT)
+def _ops() -> Options:
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
     )
 
 

--- a/tests/test_refusal.py
+++ b/tests/test_refusal.py
@@ -20,16 +20,19 @@ from collections.abc import Callable
 import pytest
 
 import holoso
-from holoso import FloatFormat, OpConfig
+from holoso import (
+    Options,
+    FloatFormat,
+)
 from holoso._errors import SynthesisError
 
-from ._modelref import default_ops
+from ._modelref import default_options
 
 _FMT = FloatFormat(8, 23)
 
 
-def _ops() -> OpConfig:
-    return default_ops(_FMT)
+def _ops() -> Options:
+    return default_options(_FMT)
 
 
 def _sim(fn: Callable[..., object], name: str) -> holoso.NumericalSimulator:

--- a/tests/test_refusal.py
+++ b/tests/test_refusal.py
@@ -20,10 +20,7 @@ from collections.abc import Callable
 import pytest
 
 import holoso
-from holoso import (
-    Options,
-    FloatFormat,
-)
+from holoso import Options, FloatFormat
 from holoso._errors import SynthesisError
 
 from ._modelref import default_options

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -11,9 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from holoso import (
-    FloatFormat,
-)
+from holoso import FloatFormat
 from holoso._backend.html import generate as generate_report
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
@@ -57,13 +55,13 @@ _EXAMPLES: dict[str, Callable[[], Callable[..., object]]] = {
 
 
 def _report(name: str) -> str:
-    lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT), _FMT), name)
     return generate_report(lir, generate_verilog(lir)).html
 
 
 @pytest.mark.parametrize("name", list(_EXAMPLES))
 def test_report_renders_for_each_example(name: str) -> None:
-    lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name)
+    lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT), _FMT), name)
     html = generate_report(lir, generate_verilog(lir)).html
     assert html.lstrip().startswith("<!")
     assert "<h2>Schedule</h2>" in html
@@ -107,7 +105,7 @@ def test_report_draws_per_arm_edges_for_a_multi_arm_spill() -> None:
 
     from holoso._backend.html._schedule import render_schedule
 
-    lir = build_lir(lower_to_mir(optimize(lower(overlap_spill_kernel).hir), default_ops(_FMT)), "overlap_spill")
+    lir = build_lir(lower_to_mir(optimize(lower(overlap_spill_kernel).hir), default_ops(_FMT), _FMT), "overlap_spill")
     html = render_schedule(lir)
     marker = "var data = "
     payload, _ = json.JSONDecoder().raw_decode(html, html.index(marker) + len(marker))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -11,14 +11,16 @@ from pathlib import Path
 
 import pytest
 
-from holoso import FloatFormat
+from holoso import (
+    FloatFormat,
+)
 from holoso._backend.html import generate as generate_report
 from holoso._backend.verilog import generate as generate_verilog
 from holoso._eel import lower
 from holoso._hir import optimize
-from holoso._lir import build, RegRef
+from holoso._lir import RegRef
 from holoso._mir import lower as lower_to_mir
-from ._modelref import default_ops, overlap_spill_kernel
+from ._modelref import build_lir, default_ops, overlap_spill_kernel
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
 import madd  # noqa: E402
@@ -55,13 +57,13 @@ _EXAMPLES: dict[str, Callable[[], Callable[..., object]]] = {
 
 
 def _report(name: str) -> str:
-    lir = build(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name)
     return generate_report(lir, generate_verilog(lir)).html
 
 
 @pytest.mark.parametrize("name", list(_EXAMPLES))
 def test_report_renders_for_each_example(name: str) -> None:
-    lir = build(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name, fetch_stages=3)
+    lir = build_lir(lower_to_mir(optimize(lower(_EXAMPLES[name]()).hir), default_ops(_FMT)), name)
     html = generate_report(lir, generate_verilog(lir)).html
     assert html.lstrip().startswith("<!")
     assert "<h2>Schedule</h2>" in html
@@ -105,9 +107,7 @@ def test_report_draws_per_arm_edges_for_a_multi_arm_spill() -> None:
 
     from holoso._backend.html._schedule import render_schedule
 
-    lir = build(
-        lower_to_mir(optimize(lower(overlap_spill_kernel).hir), default_ops(_FMT)), "overlap_spill", fetch_stages=3
-    )
+    lir = build_lir(lower_to_mir(optimize(lower(overlap_spill_kernel).hir), default_ops(_FMT)), "overlap_spill")
     html = render_schedule(lir)
     marker = "var data = "
     payload, _ = json.JSONDecoder().raw_decode(html, html.index(marker) + len(marker))

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -9,17 +9,20 @@ from pathlib import Path
 
 import pytest
 
+import holoso
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
+    FSortOptions,
     FloatFormat,
     FloatValue,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    FSortOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
+from holoso._operators import FAddOperator, FCmpOperator, FDivOperator, FMulOperator, FSortOperator, OpConfig
 from holoso._errors import UnsupportedConstruct
 from holoso._operators import Relation
 from holoso._eel import lower
@@ -72,12 +75,13 @@ from holoso._operators import (
     PooledHardwareOperator,
     SelectOperator,
 )
-from ._modelref import build_model
-from holoso._lir import build
+from ._modelref import build_lir, build_model
 from holoso._lir._schedule import resolve_pool, schedule_ops, Schedule
 from holoso._type import BoolType, FloatType, ScalarType
 
 from ._modelref import (
+    default_options,
+    build_ops,
     ChainedSlots,
     COMPARATOR_OP_CASES,
     OperatorCase,
@@ -96,7 +100,18 @@ from ._modelref import (
 from ._writetimeline import InlineProducer, build_write_timeline, latest_producer_before
 
 FMT = FloatFormat(6, 18)
-OPS = OpConfig(FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT))
+OPS = build_ops(
+    Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
+    )
+)
 _FETCH_LAG = 2  # the datapath lag the tests schedule against: one less than the 3-stage control fetch they build
 
 
@@ -179,7 +194,7 @@ def test_two_comparisons_in_a_block_serialize_on_the_shared_comparator(config: O
     def f(x: float, lo: float, hi: float) -> float:
         return 0.0 if lo < x < hi else x
 
-    lir = build(_run(f, config.make_ops(FMT)), f"deadband_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(f, config.make_ops(FMT)), f"deadband_{config.label}")
     in_valid_pcs = [
         lir.block_base[block.index] + op.issue_cycle
         for block in lir.blocks
@@ -197,7 +212,7 @@ def test_branch_comparison_commits_at_block_makespan(config: OperatorCase) -> No
     # in its block and feeds the branch -- at comparator-only and full-pipeline latency points. If a schedule change
     # ever moves the comparison off the makespan, this fails before the cosim silently de-targets.
     ops = config.make_ops(FMT)
-    lir = build(_run(branch_boundary_kernel, ops), f"cmp_at_boundary_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(branch_boundary_kernel, ops), f"cmp_at_boundary_{config.label}")
     branch_blocks = [block for block in lir.blocks if isinstance(block.terminator, Branch)]
     assert len(branch_blocks) == 1
     (block,) = branch_blocks
@@ -217,7 +232,7 @@ def test_overlap_shrinks_branch_terminator_below_drained_boundary(config: Operat
     # that chain's write word while the result lands in the single-pred arm frames. (recip_newton's loop header
     # does not shrink -- its drained boundary is naturally tight, landing exactly at the boundary;
     # test_overlapping_loop_kernel_landings_are_real_model_writes pins that tight drain.)
-    lir = build(_run(overlap_spill_kernel, config.make_ops(FMT)), f"overlap_shrink_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(overlap_spill_kernel, config.make_ops(FMT)), f"overlap_shrink_{config.label}")
     shrunk = [
         block
         for block in lir.blocks
@@ -245,7 +260,7 @@ def test_entry_branch_on_resident_condition_skips_the_drained_boundary() -> None
             self._armed = a > b
             return r
 
-    lir = build(_run(_EntryStateBranch().step), "entry_state_branch", fetch_stages=3)
+    lir = build_lir(_run(_EntryStateBranch().step), "entry_state_branch")
     entry = lir.blocks[lir.entry]
     assert isinstance(entry.terminator, Branch)
     assert not entry.ops and not entry.inline_ops
@@ -276,7 +291,7 @@ def test_non_entry_branch_on_resident_condition_redirects_at_its_base() -> None:
             self._armed = p
             return r
 
-    lir = build(_run(_NestedResidentBranch().step), "nested_resident_branch", fetch_stages=3)
+    lir = build_lir(_run(_NestedResidentBranch().step), "nested_resident_branch")
     entry = lir.blocks[lir.entry]
     assert isinstance(entry.terminator, Branch) and entry.term_offset == 1  # the entry still cannot redirect at PC 0
     non_entry_empty_branches = [
@@ -305,7 +320,7 @@ def test_resident_bound_inline_select_lands_combinationally() -> None:
             self._armed = c > d
             return r
 
-    lir = build(_run(_ResidentSelect().step), "resident_select", fetch_stages=3)
+    lir = build_lir(_run(_ResidentSelect().step), "resident_select")
     selects = [
         (block, op) for block in lir.blocks for op in block.inline_ops if isinstance(op.operator, SelectOperator)
     ]
@@ -326,7 +341,7 @@ def test_overlap_spilled_result_lands_in_successor_frame(config: OperatorCase) -
     # to the chain's WRITE WORD and the chain result lands PAST the terminator -- in the single-predecessor arm frames.
     # Pins that a wide result genuinely spills (landing_cycle beyond term_offset, while its write word stays in the
     # block); the cosim twin proves the arm read waits for the in-flight landing rather than reading stale data.
-    lir = build(_run(overlap_spill_kernel, config.make_ops(FMT)), f"overlap_spill_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(overlap_spill_kernel, config.make_ops(FMT)), f"overlap_spill_{config.label}")
     spilled = [
         (block, op, write)
         for block in lir.blocks
@@ -354,9 +369,7 @@ def test_overlap_dead_arm_spill_does_not_clobber_a_sibling_live_value(config: Op
     # shared kernel's else arm reads `v` while `w` is dead and spills; crash-before, w (=15 for x=3,y=1,z=2) overwrote
     # v's register and the else result was grossly wrong (~3.4 instead of 1.2).
     model = build_model(
-        build(
-            _run(overlap_dead_arm_spill_kernel, config.make_ops(FMT)), f"dead_arm_spill_{config.label}", fetch_stages=3
-        )
+        build_lir(_run(overlap_dead_arm_spill_kernel, config.make_ops(FMT)), f"dead_arm_spill_{config.label}")
     )
     for x, y, z in [(3.0, 1.0, 2.0), (4.0, 2.0, 0.5), (2.5, 0.5, 1.5)]:  # x > y selects the else arm, where w is dead
         want = (x + y + z) / (z * z + 1.0)
@@ -374,7 +387,7 @@ def test_overlap_keeps_error_op_diagnostic_latch_in_frame(config: OperatorCase) 
     # frame. The data write is unaffected (it still lands correctly), so only a step-accurate err_pc check sees it; the
     # shrink floor must keep the err_pc latch in-block: term_offset >= the write word + fetch_lag for an error-bearing
     # op. Crash-before: term_offset was the bare write word (one fetch_lag short), so err_pc latched a redirected pc.
-    lir = build(_run(overlap_div_err_kernel, config.make_ops(FMT)), f"overlap_div_err_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(overlap_div_err_kernel, config.make_ops(FMT)), f"overlap_div_err_{config.label}")
     checked = False
     for block in lir.blocks:
         if not isinstance(block.terminator, Branch):
@@ -414,7 +427,7 @@ def test_spilled_result_landings_match_the_numerical_model(config: OperatorCase)
         (overlap_dead_arm_spill_kernel, "dead_arm_spill"),
         (overlap_div_err_kernel, "overlap_div_err"),
     ]:
-        lir = build(_run(kernel, config.make_ops(FMT)), f"{name}_{config.label}", fetch_stages=3)
+        lir = build_lir(_run(kernel, config.make_ops(FMT)), f"{name}_{config.label}")
         # These kernels write every register through an operation (no copies/installs/state), so the model's writeback
         # set is exactly the op-result landings -- the cleanest tie to write_landing_pcs.
         assert not any(block.copies or block.bool_writes for block in lir.blocks)
@@ -462,7 +475,7 @@ def test_overlapping_loop_kernel_landings_are_real_model_writes(config: Operator
                 self.writes.setdefault(dst.index, set()).add(self.pc)
             super()._write(dst, value)  # type: ignore[arg-type]
 
-    lir = build(_run(NewtonReciprocal().__call__, config.make_ops(FMT)), f"recip_newton_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(NewtonReciprocal().__call__, config.make_ops(FMT)), f"recip_newton_{config.label}")
     assert any(
         isinstance(block.terminator, Branch) and block.term_offset == boundary_step(block.block_makespan, lir.fetch_lag)
         for block in lir.blocks
@@ -504,7 +517,7 @@ def test_bool_only_block_drains_at_the_work_boundary(monkeypatch: pytest.MonkeyP
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from phase_frequency_detector import PhaseFrequencyDetector  # noqa: PLC0415
 
-    pfd = build(_run(PhaseFrequencyDetector().__call__), "pfd_bool_drain", fetch_stages=3)
+    pfd = build_lir(_run(PhaseFrequencyDetector().__call__), "pfd_bool_drain")
     pfd_ret = next(block for block in pfd.blocks if isinstance(block.terminator, Ret))
     assert (
         is_bool_only(pfd_ret) and not pfd_ret.bool_writes and pfd_ret.block_makespan > 0
@@ -531,7 +544,7 @@ def test_bool_only_block_drains_at_the_work_boundary(monkeypatch: pytest.MonkeyP
             r = a or b
         return r, x
 
-    computed = bool_install_blocks(build(_run(computed_source_install), "computed_source_install", fetch_stages=3))
+    computed = bool_install_blocks(build_lir(_run(computed_source_install), "computed_source_install"))
     assert computed and all(
         not w.resident_source for b in computed for w in b.bool_writes
     ), "no computed-source bool install to exercise the later-draining case"
@@ -546,7 +559,7 @@ def test_bool_only_block_drains_at_the_work_boundary(monkeypatch: pytest.MonkeyP
             r = a and b
         return r, a
 
-    resident = bool_install_blocks(build(_run(resident_source_install), "resident_source_install", fetch_stages=3))
+    resident = bool_install_blocks(build_lir(_run(resident_source_install), "resident_source_install"))
     assert resident and all(
         w.resident_source for b in resident for w in b.bool_writes
     ), "no resident-source bool install to exercise the inline-class drain"
@@ -564,7 +577,7 @@ def test_entry_block_reclaims_its_first_control_word() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from quadrature_encoder import QuadratureEncoder
 
-    lir = build(_run(QuadratureEncoder().__call__), "quad_reclaim", fetch_stages=3)
+    lir = build_lir(_run(QuadratureEncoder().__call__), "quad_reclaim")
     entry = next(block for block in lir.blocks if lir.block_base[block.index] == 0)
     first = min(entry.inline_ops, key=lambda op: op.issue_cycle)
     assert first.issue_cycle == 0, "entry block's first inline op did not reclaim ucode[0]"
@@ -590,8 +603,8 @@ def test_entry_state_liveout_producer_reclaims_cycle_0() -> None:
     def _stateless(a: bool, b: bool) -> bool:
         return a and b
 
-    stateful = build(_run(_Stateful().__call__), "dwell_stateful", fetch_stages=3)
-    stateless = build(_run(_stateless), "dwell_stateless", fetch_stages=3)
+    stateful = build_lir(_run(_Stateful().__call__), "dwell_stateful")
+    stateless = build_lir(_run(_stateless), "dwell_stateless")
     sf = min(op.issue_cycle for block in stateful.blocks for op in block.inline_ops)
     sl = min(op.issue_cycle for block in stateless.blocks for op in block.inline_ops)
     assert sl == 0, "a stateless entry inline op should reclaim ucode[0]"
@@ -610,7 +623,7 @@ def test_const_branch_install_block_drains_to_its_inline_landing(config: Operato
     # condition the following step. The drain must neither shrink below it (terminator reads a stale condition -- the
     # original B1 bug) nor pay the wider computed-source-copy boundary. Crash-before: KeyError (model) / stale branch
     # read (RTL); pass-after: bit-exact vs the reference.
-    lir = build(_run(const_branch_kernel, config.make_ops(FMT)), f"const_branch_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(const_branch_kernel, config.make_ops(FMT)), f"const_branch_{config.label}")
     # Structural teeth: the surviving const-branch block branches on a constant materialized by an entry-resident tail
     # bool write, so it drains to that install's inline-class landing. Pins the drain itself, not only the output, so a
     # future drain regression here is localized rather than silently model-correct.
@@ -644,7 +657,7 @@ def test_coalesced_install_block_pays_no_spurious_install_drain() -> None:
             r = y / x
         return r
 
-    lir = build(_run(div_diamond), "div_diamond", fetch_stages=3)
+    lir = build_lir(_run(div_diamond), "div_diamond")
     arms = [b for b in lir.blocks if b.ops and not b.copies and not b.bool_writes and isinstance(b.terminator, Jump)]
     assert len(arms) == 2, "the division diamond's two coalesced arm blocks are the B2 target"
     for block in arms:
@@ -659,9 +672,7 @@ def test_empty_merge_block_is_threaded_into_its_successor(config: OperatorCase) 
     # terminated diamond arms. Merge threading eliminates it, composing the diamond's phi arms into the loop header's
     # init arm. Crash-before (no merge threading): that empty Jump merge survives. The bit-exact RTL check of the
     # resulting three-arm loop-header phi is the cosim twin (test_cosim.py test_cosim_diamond_then_loop).
-    lir = build(
-        _run(diamond_then_loop_kernel, config.make_ops(FMT)), f"diamond_then_loop_{config.label}", fetch_stages=3
-    )
+    lir = build_lir(_run(diamond_then_loop_kernel, config.make_ops(FMT)), f"diamond_then_loop_{config.label}")
     by_index = {block.index: block for block in lir.blocks}
     preds: dict[int, list[int]] = {block.index: [] for block in lir.blocks}
     for block in lir.blocks:
@@ -704,7 +715,7 @@ def test_merge_threading_refuses_a_back_edge_carried_merge_phi() -> None:
             z = x
         return z
 
-    model = build_model(build(_run(loop_invariant_merge), "loop_invariant_merge", fetch_stages=3))
+    model = build_model(build_lir(_run(loop_invariant_merge), "loop_invariant_merge"))
     for a, den, c in [(2.0, 2.0, 3.0), (-1.0, 4.0, 5.0), (3.0, 1.0, 0.0)]:  # x >= 1 so the latch loop terminates
         (got,) = model.run(a, den, c)
         assert math.isclose(float(got), loop_invariant_merge(a, den, c), rel_tol=1e-6)
@@ -722,7 +733,7 @@ def test_spill_carry_reads_at_the_model_landing_pc_not_one_cycle_late(config: Op
     # optimally, so no II is lost). So tightness here is read_pc in {landing, landing+1}; a real coordinate-frame
     # regression (the historical land - term_offset +1 bug) would push every read to landing+2.
     for kernel, name in [(overlap_spill_kernel, "overlap_spill"), (overlap_dead_arm_spill_kernel, "dead_arm_spill")]:
-        lir = build(_run(kernel, config.make_ops(FMT)), f"{name}_{config.label}", fetch_stages=3)
+        lir = build_lir(_run(kernel, config.make_ops(FMT)), f"{name}_{config.label}")
         by_index = {block.index: block for block in lir.blocks}
         spilled_any = False
         tight = 0
@@ -939,18 +950,18 @@ def test_residence_tint_is_path_exact_across_a_merge() -> None:
         return wide, boolean
 
     cases: list[tuple[str, Lir, list[tuple[float, ...]]]] = [
-        ("join_spill", build(_run(join_spill), "join_spill", fetch_stages=3), [(0.5, 2.0, 1.5), (2.0, 0.5, 1.5)]),
-        ("phi_merge", build(_run(phi_merge), "phi_merge", fetch_stages=3), [(0.5, 2.0), (2.0, 0.5)]),
+        ("join_spill", build_lir(_run(join_spill), "join_spill"), [(0.5, 2.0, 1.5), (2.0, 0.5, 1.5)]),
+        ("phi_merge", build_lir(_run(phi_merge), "phi_merge"), [(0.5, 2.0), (2.0, 0.5)]),
         (
             "bool_write_merge",
-            build(_run(bool_write_merge), "bool_write_merge", fetch_stages=3),
+            build_lir(_run(bool_write_merge), "bool_write_merge"),
             [(0.5, 2.0), (2.0, 0.5)],
         ),
         # recip_newton is a real overlapping LOOP kernel with two non-coalesced wide phi copies (the install skew site);
         # its internal iteration covers the loop body, and the seed converges for a < 3.
         (
             "recip_newton",
-            build(_run(NewtonReciprocal().__call__), "recip_newton", fetch_stages=3),
+            build_lir(_run(NewtonReciprocal().__call__), "recip_newton"),
             [(0.5,), (1.5,), (2.5,)],
         ),
     ]
@@ -1165,19 +1176,19 @@ def test_state_slot_residence_matches_the_model_under_carry() -> None:
         return wide, boolean
 
     cases: list[tuple[str, Lir, list[tuple[float, ...]]]] = [
-        ("Delay", build(_run(Delay().__call__), "Delay", fetch_stages=3), [(0.5,), (-0.5,), (1.5,), (2.0,)]),
+        ("Delay", build_lir(_run(Delay().__call__), "Delay"), [(0.5,), (-0.5,), (1.5,), (2.0,)]),
         (
             "MBWide",
-            build(_run(MBWide().__call__), "MBWide", fetch_stages=3),
+            build_lir(_run(MBWide().__call__), "MBWide"),
             [(1.0, 2.0), (-1.0, 2.0), (1.5, 3.0), (-2.0, 4.0)],
         ),
-        ("BoolHold", build(_run(BoolHold().__call__), "BoolHold", fetch_stages=3), [(1.0,), (-2.0,), (-0.5,), (2.0,)]),
+        ("BoolHold", build_lir(_run(BoolHold().__call__), "BoolHold"), [(1.0,), (-2.0,), (-0.5,), (2.0,)]),
         (
             "BoolToggle",
-            build(_run(BoolToggle().__call__), "BoolToggle", fetch_stages=3),
+            build_lir(_run(BoolToggle().__call__), "BoolToggle"),
             [(0.5,), (1.5,), (-0.5,), (2.0,)],
         ),
-        ("BoolSpin", build(_run(BoolSpin().__call__), "BoolSpin", fetch_stages=3), [(0.5,), (1.5,), (-0.5,), (2.0,)]),
+        ("BoolSpin", build_lir(_run(BoolSpin().__call__), "BoolSpin"), [(0.5,), (1.5,), (-0.5,), (2.0,)]),
     ]
     compared = 0
     for name, lir, vectors in cases:
@@ -1230,7 +1241,7 @@ def test_control_arrows_anchor_at_the_terminator_pc() -> None:
     # below the terminator, where the condition register is already dead, so its dotted feed pointed at a blank cell.
     from holoso._backend.html._schedule import _control_arrows
 
-    lir = build(_run(overlap_spill_kernel), "overlap_spill", fetch_stages=3)
+    lir = build_lir(_run(overlap_spill_kernel), "overlap_spill")
     arrows = _control_arrows(lir)
     assert arrows, "the branchy kernel must emit at least one control-transfer arrow"
     term_pcs = {lir.term_pc(block) for block in lir.blocks}
@@ -1268,7 +1279,7 @@ def test_phi_install_does_not_clobber_the_branch_condition() -> None:
     merged = builder.phi(BoolType(), [(entry, other, BoolInversion()), (then, inverted, BoolInversion())])
     builder.bool_output("out", merged)
     builder.ret()
-    model = build_model(build(builder.finish(), "phi_cond_clobber", fetch_stages=3))
+    model = build_model(build_lir(builder.finish(), "phi_cond_clobber"))
     for flag_value in (False, True):
         for other_value in (False, True):
             want = (not other_value) if flag_value else other_value
@@ -1298,7 +1309,7 @@ def test_branch_on_phi_installed_in_the_branching_block_is_rejected() -> None:
     builder.bool_output("out", looping)
     builder.ret()
     with pytest.raises(UnsupportedConstruct, match="arm from the same block"):
-        build(builder.finish(), "self_loop_cond", fetch_stages=3)
+        build_lir(builder.finish(), "self_loop_cond")
 
 
 def _ilog2(mir: Mir) -> list[int]:
@@ -1357,7 +1368,7 @@ def test_build_lir_small_kernel() -> None:
     def f(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
-    lir = build(_run(f), "kernel", fetch_stages=3)
+    lir = build_lir(_run(f), "kernel")
     assert lir.module_name == "kernel"
     assert lir.float_format == FMT
     assert lir.regfile.width == lir.float_format.width
@@ -1394,7 +1405,7 @@ def test_state_writeback_installs_early_and_is_first_class() -> None:
             self._p = x  # a non-coalesced writeback whose source (the input x) is an ordinary register
             return out
 
-    lir = build(_run(LeakyDelay().__call__), "leaky_delay", fetch_stages=3)
+    lir = build_lir(_run(LeakyDelay().__call__), "leaky_delay")
     (slot,) = lir.float_state_slots
     assert (
         bool(lir.float_state_slots or lir.bool_state_slots) and slot.needs_copy and isinstance(slot.tap, FloatOperand)
@@ -1436,7 +1447,7 @@ def test_cfg_phi_merge_register_shows_residence(monkeypatch: pytest.MonkeyPatch)
             z = 2.0
         return z
 
-    lir = build(_run(f), "diamond", fetch_stages=3)
+    lir = build_lir(_run(f), "diamond")
     assert any(block.copies for block in lir.blocks), "the merge must be resolved by phi-arm copies"
     (out,) = lir.float_outputs
     assert isinstance(out.tap.source, RegRef)
@@ -1461,7 +1472,7 @@ def test_cfg_write_only_state_slot_is_reserved() -> None:
             self.acc = -t
             return self.acc
 
-    lir = build(_run(WriteOnlyBranch().__call__), "write_only", fetch_stages=3)
+    lir = build_lir(_run(WriteOnlyBranch().__call__), "write_only")
     (slot,) = lir.float_state_slots
     assert slot.name == "acc" and slot.needs_copy
     assert slot.reg.index not in {write.dst.index for op in lir.ops for write in op.writes}
@@ -1481,7 +1492,7 @@ def test_cfg_state_slot_coalesces_onto_its_register() -> None:
             self.state = self.state * 0.9 + x
             return float(x > 0.0) * self.state
 
-    lir = build(_run(Filt().__call__), "filt", fetch_stages=3)
+    lir = build_lir(_run(Filt().__call__), "filt")
     assert any(block.inline_ops for block in lir.blocks)
     (slot,) = lir.float_state_slots
     assert not slot.needs_copy, "the slot live-out must coalesce onto the slot register (no install copy)"
@@ -1508,7 +1519,7 @@ def test_cfg_branch_conditions_reuse_boolean_registers(monkeypatch: pytest.Monke
             a = a + 4.0
         return a
 
-    lir = build(_run(f), "branches", fetch_stages=3)
+    lir = build_lir(_run(f), "branches")
     comparisons = sum(1 for b in lir.blocks for op in b.ops if isinstance(op.inst.operator, FCmpOperator))
     assert comparisons >= 3
     assert lir.bool_regfile.nreg < comparisons
@@ -1541,7 +1552,7 @@ def test_diamond_op_result_arms_coalesce(monkeypatch: pytest.MonkeyPatch) -> Non
             z = x * y
         return z * x  # an operator use of the merged value, not only the boundary output
 
-    lir = build(_run(f), "phicoal", fetch_stages=3)
+    lir = build_lir(_run(f), "phicoal")
     assert sum(len(b.copies) for b in lir.blocks) == 0, "the diamond's op-result arms must coalesce away their copies"
     assert _coalescing_self_copies(lir) == 0
     model = build_model(lir)
@@ -1563,7 +1574,7 @@ def test_loop_carried_phi_coalesces_when_non_interfering() -> None:
             i = i + 1.0
         return acc
 
-    lir = build(_run(f), "accum", fetch_stages=3)
+    lir = build_lir(_run(f), "accum")
     register_source_copies = [
         copy for block in lir.blocks for copy in block.copies if isinstance(copy.source.source, RegRef)
     ]
@@ -1581,7 +1592,7 @@ def test_interfering_loop_carried_phi_keeps_its_copy() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from recip_newton import NewtonReciprocal  # noqa: PLC0415  (example kernels live under examples/)
 
-    lir = build(_run(NewtonReciprocal().__call__), "recip", fetch_stages=3)
+    lir = build_lir(_run(NewtonReciprocal().__call__), "recip")
     back_edge_op_copies = [
         copy
         for block in lir.blocks
@@ -1593,8 +1604,8 @@ def test_interfering_loop_carried_phi_keeps_its_copy() -> None:
 
 
 def _check_float_kernel(fn: Callable[..., tuple[float, ...]], name: str, samples: list[tuple[float, ...]]) -> None:
-    lir = build(
-        _run(fn), name, fetch_stages=3
+    lir = build_lir(
+        _run(fn), name
     )  # crash-before: the install-free oracle admitted an unsound merge -> backstop assert
     model = build_model(lir)
     for args in samples:
@@ -1679,9 +1690,7 @@ def test_bool_phi_coalescing_residual_install_conflict_is_resolved() -> None:
             d = q and r
         return a, z, d
 
-    lir = build(
-        _run(k), "coal_bool", fetch_stages=3
-    )  # crash-before: the bool oracle admitted the unsound merge -> backstop assert
+    lir = build_lir(_run(k), "coal_bool")  # crash-before: the bool oracle admitted the unsound merge -> backstop assert
     model = build_model(lir)
     for p, q, r in itertools.product([False, True], repeat=3):
         got: list[bool] = []
@@ -1704,7 +1713,7 @@ def test_state_war_backstop_allows_noop_writeback() -> None:
             self.s = self.s
             return out
 
-    lir = build(_run(Hold().__call__), "hold", fetch_stages=3)  # must not raise AssertionError
+    lir = build_lir(_run(Hold().__call__), "hold")  # must not raise AssertionError
     assert {s.name for s in lir.float_state_slots} == {"s"}
 
 
@@ -1720,7 +1729,7 @@ def test_copy_slot_residence_unbroken_when_tapped_at_boundary() -> None:
             self._d = x
             return prev
 
-    lir = build(_run(Delay().__call__), "delay", fetch_stages=3)
+    lir = build_lir(_run(Delay().__call__), "delay")
     (slot,) = lir.float_state_slots
     assert sorted(lir.reg_liveness[slot.reg]) == list(range(1, lir.initiation_interval + 1))
 
@@ -1732,7 +1741,7 @@ def test_state_early_copy_frees_source_register() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from trapezoidal_leaky_streaming_integrator import TrapezoidalLeakyStreamingIntegrator
 
-    lir = build(_run(TrapezoidalLeakyStreamingIntegrator(k=2**-22).__call__), "trapz", fetch_stages=3)
+    lir = build_lir(_run(TrapezoidalLeakyStreamingIntegrator(k=2**-22).__call__), "trapz")
     (xprev,) = [s for s in lir.float_state_slots if s.name == "_x_prev"]
     (in_x,) = [load for load in lir.float_inputs if load.name == "x"]
     assert xprev.needs_copy and in_x.dst == xprev.tap.source
@@ -1745,7 +1754,7 @@ def test_build_lir_ekf1_stateless() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     import ekf1_stateless
 
-    lir = build(_run(ekf1_stateless.update_x_P), "update_x_P", fetch_stages=3)
+    lir = build_lir(_run(ekf1_stateless.update_x_P), "update_x_P")
     assert len(lir.float_inputs) == 17
     assert len(lir.float_outputs) == 9
     fdivs = [inst for inst in lir.instances if isinstance(inst.operator, FDivOperator)]
@@ -1774,7 +1783,7 @@ def test_sign_paired_constants_collapse_to_one_magnitude() -> None:
     def f(a: float) -> float:
         return a * 1000.0 + a * (-1000.0)
 
-    lir = build(_run(f), "f", fetch_stages=3)
+    lir = build_lir(_run(f), "f")
     assert [c for c in lir.float_consts if abs(c) == 1000.0] == [1000.0]
     operands = [opnd for op in lir.ops for opnd in op.operands if isinstance(opnd.source, FloatConstRef)]
     assert len({opnd.source.index for opnd in operands}) == 1
@@ -1785,7 +1794,7 @@ def test_negative_constant_operand_is_stored_as_magnitude_with_negate() -> None:
     def f(a: float) -> float:
         return a + (-1000.0)
 
-    lir = build(_run(f), "f", fetch_stages=3)
+    lir = build_lir(_run(f), "f")
     assert all(c >= 0.0 for c in lir.float_consts)
     (operand,) = [opnd for op in lir.ops for opnd in op.operands if isinstance(opnd.source, FloatConstRef)]
     assert lir.float_consts[operand.source.index] == 1000.0
@@ -1803,7 +1812,7 @@ def test_constant_pool_is_canonically_nonnegative() -> None:
         R_diag=[1e3, 1e-6],
         Q_diag=np.array([1e-3, 1e9, 1e-9]),
     )
-    lir = build(_run(filt.update), "ekf1_stateful", fetch_stages=3)
+    lir = build_lir(_run(filt.update), "ekf1_stateful")
     assert all(c >= 0.0 for c in lir.float_consts)
     assert len(lir.float_consts) == 6  # the +1000.0 / -1000.0 pair collapsed (was 7)
 
@@ -1814,7 +1823,7 @@ def test_underflowing_negative_constant_is_not_sign_folded() -> None:
     def f(a: float) -> float:
         return a + (-1e-12)  # -1e-12 underflows to +0 in FloatFormat(6, 18)
 
-    lir = build(_run(f), "f", fetch_stages=3)
+    lir = build_lir(_run(f), "f")
     (operand,) = [opnd for op in lir.ops for opnd in op.operands if isinstance(opnd.source, FloatConstRef)]
     assert FMT.encode(lir.float_consts[operand.source.index]) == 0
     assert operand.sign == FloatSignControl()
@@ -1824,7 +1833,7 @@ def test_underflowing_negative_constant_output_stays_canonical_zero() -> None:
     def f(a: float) -> tuple[float, float]:
         return a + a, -1e-12  # the -1e-12 output underflows to +0; it must stay canonical, not fold to illegal -0
 
-    lir = build(_run(f), "f", fetch_stages=3)
+    lir = build_lir(_run(f), "f")
     (wire,) = [w for w in lir.float_outputs if isinstance(w.tap.source, FloatConstRef)]
     assert FMT.encode(lir.float_consts[wire.tap.source.index]) == 0
     assert wire.tap.sign == FloatSignControl()
@@ -1843,7 +1852,7 @@ def test_stateful_slot_register_gaps_are_reused() -> None:
         R_diag=[1e3, 1e-6],
         Q_diag=np.array([1e-3, 1e9, 1e-9]),
     )
-    lir = build(_run(filt.update), "ekf1_stateful", fetch_stages=3)
+    lir = build_lir(_run(filt.update), "ekf1_stateful")
     assert lir.regfile.nreg <= 40  # gap-reuse sheds ~6; a regression to the fully-reserved 45 trips this
 
 
@@ -1855,7 +1864,7 @@ def test_register_sharing_is_hardware_disjoint() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     import ekf1_stateless
 
-    lir = build(_run(ekf1_stateless.update_x_P), "update_x_P", fetch_stages=3)
+    lir = build_lir(_run(ekf1_stateless.update_x_P), "update_x_P")
     timeline = build_write_timeline(lir)
     last_read: dict[tuple[int, str, int], int] = {}
 
@@ -1891,7 +1900,7 @@ def test_build_rejects_mir_with_mixed_float_formats() -> None:
         nodes={
             0: MirFloatInput("a", FloatType(FMT)),
             1: MirOperation(
-                FAddOperator(other),
+                FAddOperator(other, FAddOptions()),
                 [0, 0],
                 [FloatSignControl(), FloatSignControl()],
                 0,
@@ -1905,7 +1914,7 @@ def test_build_rejects_mir_with_mixed_float_formats() -> None:
         state_slots=[],
     )
     with pytest.raises(ValueError, match="configured format"):
-        build(mir, "mixed", fetch_stages=3)
+        build_lir(mir, "mixed")
 
 
 def test_mir_builder_rejects_mixed_float_operand_formats() -> None:
@@ -1915,7 +1924,7 @@ def test_mir_builder_rejects_mixed_float_operand_formats() -> None:
     b = builder.float_input("b", FloatType(other))
     with pytest.raises(ValueError, match="expects operands"):
         builder.operation(
-            FAddOperator(FMT),
+            FAddOperator(FMT, FAddOptions()),
             [a, b],
             [FloatSignControl(), FloatSignControl()],
         )
@@ -1927,13 +1936,15 @@ def test_mir_operation_validates_invariants() -> None:
     with pytest.raises(TypeError, match="scalar_type"):
         MirFloatConst(OtherScalarType(), 1.0)  # type: ignore[arg-type]  # deliberately wrong scalar type
     with pytest.raises(ValueError, match="operand"):
-        MirOperation(FAddOperator(FMT), [0], [FloatSignControl(), FloatSignControl()], 0, FloatSignControl(), ())
+        MirOperation(
+            FAddOperator(FMT, FAddOptions()), [0], [FloatSignControl(), FloatSignControl()], 0, FloatSignControl(), ()
+        )
     with pytest.raises(ValueError, match="conditioner"):
-        MirOperation(FAddOperator(FMT), [0, 0], [FloatSignControl()], 0, FloatSignControl(), ())
+        MirOperation(FAddOperator(FMT, FAddOptions()), [0, 0], [FloatSignControl()], 0, FloatSignControl(), ())
     # A boolean output port carries an inversion, never a sign control: booleans have no sign.
     with pytest.raises(TypeError, match="output conditioner"):
         MirOperation(
-            FCmpOperator(FMT),
+            FCmpOperator(FMT, FCmpOptions()),
             [0, 0],
             [FloatSignControl(), FloatSignControl()],
             2,
@@ -1944,7 +1955,14 @@ def test_mir_operation_validates_invariants() -> None:
     with pytest.raises(TypeError, match="operand conditioner"):
         MirOperation(BoolAndOperator(), [0, 0], [FloatSignControl(), BoolInversion()], 0, BoolInversion(), ())
     with pytest.raises(ValueError, match="does not exist"):
-        MirOperation(FAddOperator(FMT), [0, 0], [FloatSignControl(), FloatSignControl()], 1, FloatSignControl(), ())
+        MirOperation(
+            FAddOperator(FMT, FAddOptions()),
+            [0, 0],
+            [FloatSignControl(), FloatSignControl()],
+            1,
+            FloatSignControl(),
+            (),
+        )
     with pytest.raises(TypeError, match="sign"):
         MirFloatOutput("out_0", 0, object())  # type: ignore[arg-type]  # deliberately wrong sign control type
 
@@ -1990,17 +2008,17 @@ def test_float_view_rejects_missing_input_id() -> None:
 
 def test_fmul_ilog2_operator_rejects_out_of_range_k() -> None:
     limit = (1 << FMT.wexp) - 2
-    assert FMulILog2Operator(FMT, k=-limit).k == -limit
-    assert FMulILog2Operator(FMT, k=limit - 1).k == limit - 1
+    assert FMulILog2Operator(FMT, -limit, FMulILog2Options()).k == -limit
+    assert FMulILog2Operator(FMT, limit - 1, FMulILog2Options()).k == limit - 1
     with pytest.raises(ValueError, match="outside"):
-        FMulILog2Operator(FMT, k=limit)
+        FMulILog2Operator(FMT, limit, FMulILog2Options())
     with pytest.raises(ValueError, match="outside"):
-        FMulILog2Operator(FMT, k=-limit - 1)
+        FMulILog2Operator(FMT, -limit - 1, FMulILog2Options())
 
 
 def test_float_operator_rejects_bad_stage_knob_at_construction() -> None:
     with pytest.raises(ValueError, match="outside"):
-        FAddOperator(FMT, stage_decode=7)
+        FAddOperator(FMT, FAddOptions(stage_decode=7))
 
 
 def test_default_ops_omits_transcendentals_unrealizable_on_narrow_formats() -> None:
@@ -2022,8 +2040,8 @@ def test_marked_commutative_operators_are_bit_exact_commutative() -> None:
     from holoso._value import FloatValue
 
     rng = random.Random(0)
-    assert FAddOperator(FMT).is_commutative and FMulOperator(FMT).is_commutative
-    assert not FDivOperator(FMT).is_commutative
+    assert FAddOperator(FMT, FAddOptions()).is_commutative and FMulOperator(FMT, FMulOptions(), 0).is_commutative
+    assert not FDivOperator(FMT, FDivOptions()).is_commutative
     for evaluate in (operator.add, operator.mul):
         for _ in range(5000):
             a = FloatValue.from_float(FMT, rng.uniform(-2.0, 2.0) * 2.0 ** rng.randint(-22, 22))
@@ -2039,17 +2057,22 @@ def test_commutative_port_assignment_never_increases_read_mux_fan_in(
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     import ekf1_stateless
 
-    cfg = OpConfig(
-        FAddOperator(FMT, stage_decode=1),
-        FMulOperator(FMT, stage_input=1),
-        FDivOperator(FMT),
-        FMulILog2OperatorFamily(FMT),
-        FCmpOperator(FMT),
+    cfg = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(stage_decode=1),
+                fmul=FMulOptions(stage_input=1),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=FMT,
+        )
     )
     monkeypatch.setattr(build_module, "assign_commutative_ports", lambda *args, **kwargs: {})
-    baseline = build(_run(ekf1_stateless.update_x_P, cfg), "ekf1_stateless", fetch_stages=3)
+    baseline = build_lir(_run(ekf1_stateless.update_x_P, cfg), "ekf1_stateless")
     monkeypatch.undo()
-    optimized = build(_run(ekf1_stateless.update_x_P, cfg), "ekf1_stateless", fetch_stages=3)
+    optimized = build_lir(_run(ekf1_stateless.update_x_P, cfg), "ekf1_stateless")
 
     assert _read_mux_fan_in(optimized) <= _read_mux_fan_in(baseline)
     assert _read_mux_fan_in(optimized) < _read_mux_fan_in(baseline)  # ekf1_stateless has commutative reach to reclaim
@@ -2062,7 +2085,7 @@ def test_optional_stages_raise_latency_without_changing_numerics() -> None:
 
     fmt = FloatFormat(8, 36)
     configs = {"default": default_ops(fmt), "staged": staged_ops(fmt)}
-    lirs = {name: build(_run(kernel, ops), f"stages_{name}", fetch_stages=3) for name, ops in configs.items()}
+    lirs = {name: build_lir(_run(kernel, ops), f"stages_{name}") for name, ops in configs.items()}
     assert lirs["default"].initiation_interval < lirs["staged"].initiation_interval
 
     def bits(outputs: list[FloatValue | bool]) -> list[int]:  # the kernel is all-float, so every output is a FloatValue
@@ -2101,22 +2124,21 @@ def test_reach_floor_seed_skips_annealing(monkeypatch: pytest.MonkeyPatch) -> No
     def sharing_kernel(a: float, b: float, c: float) -> float:
         return a * b + c  # the product and the sum reuse registers, lifting the objective above the floor
 
-    build(_run(floor_kernel), "floor", fetch_stages=3)
+    build_lir(_run(floor_kernel), "floor")
     assert calls == []
-    build(_run(sharing_kernel), "sharing", fetch_stages=3)
+    build_lir(_run(sharing_kernel), "sharing")
     assert calls
 
 
 def test_zero_regalloc_effort_bypasses_annealing(monkeypatch: pytest.MonkeyPatch) -> None:
     import holoso._lir._regalloc as regalloc
 
-    monkeypatch.setattr(regalloc, "_REFINE_MAXITER", 0)
     monkeypatch.setattr(regalloc, "dual_annealing", lambda *args, **kwargs: pytest.fail("annealing was not bypassed"))
 
     def sharing_kernel(a: float, b: float, c: float) -> float:
         return a * b + c
 
-    build(_run(sharing_kernel), "sharing", fetch_stages=3)
+    holoso.synthesize(sharing_kernel, replace(default_options(FMT), regalloc_effort=0), name="sharing")
 
 
 def test_bool_to_float_cast_result_is_live_on_its_landing_cycle() -> None:
@@ -2128,7 +2150,7 @@ def test_bool_to_float_cast_result_is_live_on_its_landing_cycle() -> None:
     def f(x: float) -> float:
         return float(x > 0.0) * x
 
-    lir = build(_run(f), "cast_mul", fetch_stages=3)
+    lir = build_lir(_run(f), "cast_mul")
     interval = lir.initiation_interval
     casts = [(b, op) for b in lir.blocks for op in b.inline_ops if isinstance(op.write.dst, RegRef)]
     assert casts, "expected a bool->float cast result in the wide bank"
@@ -2161,7 +2183,7 @@ def test_two_relations_over_one_operand_pair_fuse_into_one_firing() -> None:
         same = a == b
         return float(below), float(same)
 
-    lir = build(_run(f), "fused_relations", fetch_stages=3)
+    lir = build_lir(_run(f), "fused_relations")
     firings = [op for block in lir.blocks for op in block.ops if isinstance(op.inst.operator, FCmpOperator)]
     assert len(firings) == 1, "lt and eq taps of one operand pair must fuse into one comparator firing"
     (firing,) = firings
@@ -2182,7 +2204,7 @@ def test_same_port_taps_with_different_inversions_do_not_fuse() -> None:
         not_below = a >= b
         return float(below), float(not_below)
 
-    lir = build(_run(f), "split_inversions", fetch_stages=3)
+    lir = build_lir(_run(f), "split_inversions")
     firings = [op for block in lir.blocks for op in block.ops if isinstance(op.inst.operator, FCmpOperator)]
     assert len(firings) == 2, "same-port taps cannot share a firing"
     assert len({op.issue_cycle for op in firings}) == 2
@@ -2205,7 +2227,7 @@ def test_initiation_interval_spaces_firings_on_one_instance() -> None:
     builder.block()
     a = builder.float_input("a", FloatType(FMT))
     b = builder.float_input("b", FloatType(FMT))
-    slow = _ThrottledAdd(FMT)
+    slow = _ThrottledAdd(FMT, FAddOptions())
     first = builder.operation(slow, [a, b], [FloatSignControl(), FloatSignControl()])
     second = builder.operation(slow, [b, a], [FloatSignControl(), FloatSignControl()])
     builder.float_output("out_0", first)
@@ -2236,7 +2258,7 @@ def test_progress_cap_accommodates_long_initiation_intervals() -> None:
     # The cap now charges max(latency, initiation_interval) per firing (the old latency-only cap aborted at this
     # II with this many firings). Same-port duplicates do not fuse, so the
     # hand-built identical operations below are forty separate firings serialized on one instance.
-    slow = _HeavilyThrottledAdd(FMT)
+    slow = _HeavilyThrottledAdd(FMT, FAddOptions())
     nodes: dict[int, MirNode] = {0: MirFloatInput("a", FloatType(FMT)), 1: MirFloatInput("b", FloatType(FMT))}
     count = 40
     for i in range(count):
@@ -2256,9 +2278,9 @@ def test_cross_block_reuse_bound_pins_the_drained_edge_boundary() -> None:
         return a + b
 
     def _ops(fadd: FAddOperator) -> OpConfig:
-        return OpConfig(fadd, FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT))
+        return replace(default_ops(FMT), fadd=fadd)
 
-    build(_run(_add, _ops(_HeavilyThrottledAdd(FMT))), "at_bound", fetch_stages=3)  # II == 8 == bound: builds clean
+    build_lir(_run(_add, _ops(_HeavilyThrottledAdd(FMT, FAddOptions()))), "at_bound")  # II == 8 == bound: builds clean
 
     class _OverBoundAdd(_HeavilyThrottledAdd):
         @property
@@ -2266,7 +2288,7 @@ def test_cross_block_reuse_bound_pins_the_drained_edge_boundary() -> None:
             return 9  # one past the bound: a drained-edge successor issuing at cycle 0 could double-issue this instance
 
     with pytest.raises(AssertionError, match="cross-block busy tracking"):
-        build(_run(_add, _ops(_OverBoundAdd(FMT))), "over_bound", fetch_stages=3)
+        build_lir(_run(_add, _ops(_OverBoundAdd(FMT, FAddOptions()))), "over_bound")
 
 
 def test_write_timeline_resolves_inline_wide_producers() -> None:
@@ -2276,7 +2298,7 @@ def test_write_timeline_resolves_inline_wide_producers() -> None:
     def f(x: float) -> float:
         return float(x > 0.0) * x
 
-    lir = build(_run(f), "cast_timeline", fetch_stages=3)
+    lir = build_lir(_run(f), "cast_timeline")
     timeline = build_write_timeline(lir)
     resolved = 0
     for op in lir.ops:
@@ -2302,7 +2324,7 @@ def test_commutative_comparator_swap_permutes_output_taps(config: OperatorCase) 
         above = b < a
         return float(below), float(above)
 
-    lir = build(_run(f, config.make_ops(FMT)), f"mirrored_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(f, config.make_ops(FMT)), f"mirrored_{config.label}")
     firings = [op for block in lir.blocks for op in block.ops if isinstance(op.inst.operator, FCmpOperator)]
     assert len(firings) == 2
     sources = [tuple(operand.source for operand in op.operands) for op in firings]
@@ -2323,7 +2345,7 @@ def test_chained_slot_live_in_blocks_early_install(config: OperatorCase) -> None
     # early-install decision did not, so "_b"'s new value landed before "_a"'s boundary copy captured the old one.
     # The RTL then returned the NEW "_b" through "_a" while the model kept the old one (cosim diverged on the second
     # transaction). The tapped slot must now install at the boundary, and the model must match plain Python.
-    lir = build(_run(ChainedSlots().__call__, config.make_ops(FMT)), f"chained_slots_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(ChainedSlots().__call__, config.make_ops(FMT)), f"chained_slots_{config.label}")
     slots = {slot.name: slot for slot in lir.float_state_slots}
     assert lir.state_copy_step(slots["_b"]) == lir.initiation_interval, "the tapped slot must not install early"
     reference = ChainedSlots()
@@ -2341,7 +2363,7 @@ def test_select_folds_arm_signs_into_operand_conditioners() -> None:
         y = x if c > 0.0 else -x
         return y
 
-    lir = build(_run(f), "signed_select", fetch_stages=3)
+    lir = build_lir(_run(f), "signed_select")
     assert len(lir.blocks) == 1, "the diamond must fully if-convert"
     selects = [op for block in lir.blocks for op in block.inline_ops if isinstance(op.operator, SelectOperator)]
     assert len(selects) == 1
@@ -2362,7 +2384,7 @@ def test_state_early_install_respects_a_select_reader(config: OperatorCase) -> N
     # step (issue + latency + fetch_lag + 1), one cycle past where an issue-frame bound would have allowed the
     # slot's install copy to fire -- an early install bounded by issue cycles would overwrite the live-in before
     # the select reads it (RTL would take the NEW value through ``old`` while the model keeps the old one).
-    lir = build(_run(SelectHold().step, config.make_ops(FMT)), f"select_hold_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(SelectHold().step, config.make_ops(FMT)), f"select_hold_{config.label}")
     selects = [
         (block, op) for block in lir.blocks for op in block.inline_ops if isinstance(op.operator, SelectOperator)
     ]
@@ -2390,7 +2412,7 @@ def test_not_folds_into_every_sink_position() -> None:
         out_logic = flag and (c > 0.0)
         return float(flag), float(out_logic)
 
-    lir = build(_run(f), "not_sinks", fetch_stages=3)
+    lir = build_lir(_run(f), "not_sinks")
     inline_mnemonics = sorted(op.operator.mnemonic for block in lir.blocks for op in block.inline_ops)
     assert inline_mnemonics == ["band", "ffrombool", "ffrombool"], inline_mnemonics
     band = next(op for block in lir.blocks for op in block.inline_ops if op.operator.mnemonic == "band")
@@ -2413,7 +2435,7 @@ def test_not_on_a_branch_condition_swaps_the_targets() -> None:
             y = b / (a * a + 1.0)
         return y
 
-    lir = build(_run(f), "not_branch", fetch_stages=3)
+    lir = build_lir(_run(f), "not_branch")
     assert not any(block.inline_ops for block in lir.blocks), "the NOT must not materialize any gate"
     model = build_model(lir)
     for a, b in [(1.0, 2.0), (2.0, 1.0)]:
@@ -2427,7 +2449,7 @@ def test_double_negation_cancels() -> None:
         flag = not (not (a > b))
         return float(flag)
 
-    lir = build(_run(f), "double_not", fetch_stages=3)
+    lir = build_lir(_run(f), "double_not")
     casts = [op for block in lir.blocks for op in block.inline_ops if op.operator.mnemonic == "ffrombool"]
     (cast,) = casts
     (operand,) = cast.operands
@@ -2442,7 +2464,7 @@ def test_value_consumed_in_both_polarities_shares_one_producer() -> None:
         flag = a > b
         return float(flag), float(not flag)
 
-    lir = build(_run(f), "both_polarities", fetch_stages=3)
+    lir = build_lir(_run(f), "both_polarities")
     comparisons = [op for block in lir.blocks for op in block.ops if isinstance(op.inst.operator, FCmpOperator)]
     assert len(comparisons) == 1 and len(comparisons[0].writes) == 1, "one tap serves both polarities"
     model = build_model(lir)
@@ -2463,7 +2485,7 @@ class _InvertedState:
 def test_bool_state_slot_carries_a_live_out_inversion() -> None:
     # The toggle's live-out is its own live-in inverted: the inversion rides the slot's install (needs_copy must be
     # True even though the source register IS the slot register), and the model must toggle across transactions.
-    lir = build(_run(_InvertedState().step), "toggle", fetch_stages=3)
+    lir = build_lir(_run(_InvertedState().step), "toggle")
     (slot,) = lir.bool_state_slots
     assert slot.needs_copy, "an inverted live-out needs its install copy even from the slot's own register"
     reference = _InvertedState()
@@ -2487,7 +2509,7 @@ def test_inverted_bool_phi_arm_installs_with_opposite_polarities(config: Operato
             d = b
         return float(flag), d
 
-    lir = build(_run(f, config.make_ops(FMT)), f"inverted_arm_{config.label}", fetch_stages=3)
+    lir = build_lir(_run(f, config.make_ops(FMT)), f"inverted_arm_{config.label}")
     sources = [(write.source.source, write.source.inversion) for block in lir.blocks for write in block.bool_writes]
     flag_sources = [(src, inv) for src, inv in sources if isinstance(src, BoolRegRef)]
     assert len(flag_sources) == 2, flag_sources
@@ -2511,7 +2533,7 @@ def test_boolean_registers_are_reused_within_a_block() -> None:
             x = (x - 1.0) if x > 1.0 else (x + 1.0)
         return x
 
-    lir = build(_run(f), "breg_reuse", fetch_stages=3)
+    lir = build_lir(_run(f), "breg_reuse")
     conditions = sum(1 for block in lir.blocks for op in block.ops if isinstance(op.inst.operator, FCmpOperator))
     assert conditions == 6, "the unrolled chain carries six comparisons"
     assert lir.bool_regfile.nreg <= 2, f"disjoint condition lifetimes must share registers, got {lir.bool_regfile.nreg}"
@@ -2532,7 +2554,7 @@ def test_boolean_logic_chain_reuses_registers_on_the_tight_same_bank_edge() -> N
     def f(a: float, b: float, c: float, d: float, e: float, g: float) -> float:
         return 1.0 if (a > b and c > d and e > g and a > d and b > e) else 0.0
 
-    lir = build(_run(f), "bool_chain", fetch_stages=3)
+    lir = build_lir(_run(f), "bool_chain")
     comparisons = sum(1 for block in lir.blocks for op in block.ops if isinstance(op.inst.operator, FCmpOperator))
     ands = sum(1 for block in lir.blocks for op in block.inline_ops if op.operator.mnemonic == "band")
     assert comparisons == 5 and ands >= 4, (comparisons, ands)
@@ -2558,7 +2580,7 @@ def test_drain_only_ret_with_a_resident_output_needs_no_boundary_drain() -> None
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from octave_index import octave_index  # noqa: PLC0415  (example kernels live under examples/)
 
-    lir = build(_run(octave_index), "octave_drain_only_ret", fetch_stages=3)
+    lir = build_lir(_run(octave_index), "octave_drain_only_ret")
     ret = next(b for b in lir.blocks if isinstance(b.terminator, Ret))
     # Nothing lands in the Ret's own frame -- it neither computes nor installs; the output is resident.
     assert not (ret.ops or ret.inline_ops or ret.copies or ret.bool_writes), "the exit block must be pure drain"
@@ -2595,13 +2617,13 @@ def test_aliased_state_slots_merge_onto_one_register() -> None:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
     from phase_frequency_detector import PhaseFrequencyDetector  # noqa: PLC0415
 
-    pfd = build(_run(PhaseFrequencyDetector().__call__), "pfd_merge", fetch_stages=3)
+    pfd = build_lir(_run(PhaseFrequencyDetector().__call__), "pfd_merge")
     assert pfd.bool_regfile.nreg == 5
     assert pfd.regfile.nreg == 0  # purely boolean: the wide bank is unused
     assert len(pfd.bool_state_slots) == 2  # the four attributes collapse onto two registers
     assert all(not slot.needs_copy for slot in pfd.bool_state_slots)
 
-    flt = build(_run(_AliasedFloatState().step), "aliased_float", fetch_stages=3)
+    flt = build_lir(_run(_AliasedFloatState().step), "aliased_float")
     assert len(flt.float_state_slots) == 1  # pub and _alias share one register
     assert all(not slot.needs_copy for slot in flt.float_state_slots)
 
@@ -2610,7 +2632,7 @@ def test_aliased_state_slots_merge_onto_one_register() -> None:
 # initiation_interval > 1, so the scheduler's busy_until spacing is exercised here for the first time.
 
 # default_ops already carries fexp2/flog2/fsincos/fatan2; the lone-hypot decomposition also needs fsort.
-_CORDIC_OPS = replace(default_ops(FMT), fsort=FSortOperator(FMT))
+_CORDIC_OPS = replace(default_ops(FMT), fsort=FSortOperator(FMT, FSortOptions()))
 
 
 def _instance_counts(lir: Lir) -> Counter[str]:
@@ -2625,7 +2647,7 @@ def test_sincos_coalesces_sin_and_cos_into_one_firing() -> None:
     def kernel(x: float) -> tuple[float, float]:
         return math.sin(x), math.cos(x)
 
-    lir = build(_run(kernel, _CORDIC_OPS), "sincos_coalesce", fetch_stages=3)
+    lir = build_lir(_run(kernel, _CORDIC_OPS), "sincos_coalesce")
     assert _instance_counts(lir).get("fsincos") == 1
     firings = _firings(lir, "fsincos")
     assert len(firings) == 1 and len(firings[0].writes) == 2
@@ -2635,7 +2657,7 @@ def test_atan2_and_hypot_coalesce_into_one_firing() -> None:
     def kernel(y: float, x: float) -> tuple[float, float]:
         return math.hypot(y, x), math.atan2(y, x)
 
-    lir = build(_run(kernel, _CORDIC_OPS), "atan2_hypot_coalesce", fetch_stages=3)
+    lir = build_lir(_run(kernel, _CORDIC_OPS), "atan2_hypot_coalesce")
     assert _instance_counts(lir).get("fatan2") == 1
     firings = _firings(lir, "fatan2")
     assert len(firings) == 1 and len(firings[0].writes) == 2
@@ -2647,7 +2669,7 @@ def test_hypot_fuses_with_atan2_regardless_of_operand_order() -> None:
     def kernel(y: float, x: float) -> tuple[float, float]:
         return math.hypot(x, y), math.atan2(y, x)
 
-    lir = build(_run(kernel, _CORDIC_OPS), "hypot_swapped_fuse", fetch_stages=3)
+    lir = build_lir(_run(kernel, _CORDIC_OPS), "hypot_swapped_fuse")
     assert _instance_counts(lir).get("fatan2") == 1 and "fsort" not in _instance_counts(lir)
     firings = _firings(lir, "fatan2")
     assert len(firings) == 1 and len(firings[0].writes) == 2
@@ -2657,7 +2679,7 @@ def test_lone_sin_is_one_firing_with_untapped_cos() -> None:
     def kernel(x: float) -> float:
         return math.sin(x)
 
-    lir = build(_run(kernel, _CORDIC_OPS), "lone_sin", fetch_stages=3)
+    lir = build_lir(_run(kernel, _CORDIC_OPS), "lone_sin")
     firings = _firings(lir, "fsincos")
     assert len(firings) == 1 and len(firings[0].writes) == 1
 
@@ -2666,7 +2688,7 @@ def test_lone_hypot_decomposes_without_spinning_up_a_cordic() -> None:
     def kernel(y: float, x: float) -> float:
         return math.hypot(y, x)
 
-    counts = _instance_counts(build(_run(kernel, _CORDIC_OPS), "lone_hypot", fetch_stages=3))
+    counts = _instance_counts(build_lir(_run(kernel, _CORDIC_OPS), "lone_hypot"))
     assert "fatan2" not in counts
     assert counts.get("flog2") == 1 and counts.get("fexp2") == 1  # the exp2(log2/2) sqrt stopgap
 
@@ -2675,7 +2697,7 @@ def test_independent_sincos_share_one_instance_spaced_by_ii() -> None:
     def kernel(a: float, b: float) -> tuple[float, float, float, float]:
         return math.sin(a), math.cos(a), math.sin(b), math.cos(b)
 
-    lir = build(_run(kernel, _CORDIC_OPS), "two_sincos_ii", fetch_stages=3)
+    lir = build_lir(_run(kernel, _CORDIC_OPS), "two_sincos_ii")
     _assert_two_firings_at_minimal_ii(lir, "fsincos")
 
 
@@ -2683,7 +2705,7 @@ def test_independent_atan2_share_one_instance_spaced_by_ii() -> None:
     def kernel(a: float, b: float, c: float, d: float) -> tuple[float, float]:
         return math.atan2(a, b), math.atan2(c, d)
 
-    lir = build(_run(kernel, _CORDIC_OPS), "two_atan2_ii", fetch_stages=3)
+    lir = build_lir(_run(kernel, _CORDIC_OPS), "two_atan2_ii")
     _assert_two_firings_at_minimal_ii(lir, "fatan2")
 
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -127,8 +127,8 @@ class OtherMirInput(MirInput):
     pass
 
 
-def _run(target: Callable[..., object], ops: OpConfig = OPS) -> Mir:
-    return lower_to_mir(optimize(lower(target).hir), ops)
+def _run(target: Callable[..., object], ops: OpConfig = OPS, fmt: FloatFormat = FMT) -> Mir:
+    return lower_to_mir(optimize(lower(target).hir), ops, fmt)
 
 
 def _view(mir: Mir) -> MirFloatView:
@@ -2085,7 +2085,7 @@ def test_optional_stages_raise_latency_without_changing_numerics() -> None:
 
     fmt = FloatFormat(8, 36)
     configs = {"default": default_ops(fmt), "staged": staged_ops(fmt)}
-    lirs = {name: build_lir(_run(kernel, ops), f"stages_{name}") for name, ops in configs.items()}
+    lirs = {name: build_lir(_run(kernel, ops, fmt), f"stages_{name}") for name, ops in configs.items()}
     assert lirs["default"].initiation_interval < lirs["staged"].initiation_interval
 
     def bits(outputs: list[FloatValue | bool]) -> list[int]:  # the kernel is all-float, so every output is a FloatValue
@@ -2752,7 +2752,7 @@ def test_forced_install_regrowth_pins_and_stays_correct(
     monkeypatch.setattr(_build, "actual_install_blocks", fake_installs)
     fmt = FloatFormat(6, 18)
     with caplog.at_level("INFO", logger="holoso._lir._build"):
-        model, interpreter = build_model_and_interpreter(kernel, default_ops(fmt), "forced_pin")
+        model, interpreter = build_model_and_interpreter(kernel, default_ops(fmt), "forced_pin", fmt)
     assert any("pinning regrown block" in r.message for r in caplog.records), "the faked narrowing did not pin"
     for x in (1.0, -2.0):
         for n in (1.0, 3.0):
@@ -2789,7 +2789,7 @@ def test_forced_state_copy_regrowth_latches_and_stays_correct(
     monkeypatch.setattr(_build, "_has_state_copy", fake_state)
     fmt = FloatFormat(8, 36)
     with caplog.at_level("INFO", logger="holoso._lir._build"):
-        model, _interpreter = build_model_and_interpreter(Delay2().__call__, default_ops(fmt), "forced_latch")
+        model, _interpreter = build_model_and_interpreter(Delay2().__call__, default_ops(fmt), "forced_latch", fmt)
     assert any("latching the state-copy charge" in r.message for r in caplog.records), "the fake did not latch"
     reference = Delay2()
     for raw in (1.0, 2.0, 3.0, 4.0, 5.0):

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -10,13 +10,14 @@ import pytest
 
 import holoso
 from holoso import (
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    OperatorOptions,
+    Options,
 )
 
 
@@ -28,9 +29,16 @@ FMT32 = FloatFormat(8, 24)
 _NAN = float("nan")
 
 
-def _ops(fmt: FloatFormat = FMT32) -> OpConfig:
-    return OpConfig(
-        FAddOperator(fmt), FMulOperator(fmt), FDivOperator(fmt), FMulILog2OperatorFamily(fmt), FCmpOperator(fmt)
+def _ops(fmt: FloatFormat = FMT32) -> Options:
+    return Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=fmt,
     )
 
 
@@ -41,25 +49,12 @@ def _has_localparam(verilog: str, name: str, value: int) -> bool:
     )
 
 
-def test_op_config_rejects_mixed_float_formats() -> None:
-    fmt24 = FloatFormat(6, 18)
-    ops = OpConfig(
-        FAddOperator(FMT32),
-        FMulOperator(fmt24),
-        FDivOperator(FMT32),
-        FMulILog2OperatorFamily(FMT32),
-        FCmpOperator(FMT32),
-    )
-    with pytest.raises(ValueError, match="same format"):
-        _ = ops.float_format
-
-
 def test_constant_only_module_keeps_operator_configured_format() -> None:
     def const_only() -> float:
         return 3.5
 
     fmt = FloatFormat(6, 18)
-    result = holoso.synthesize(const_only, ops=_ops(fmt))
+    result = holoso.synthesize(const_only, _ops(fmt))
     assert result.numerical_model.float_format == fmt
     assert _has_localparam(result.verilog_output.verilog, "WEXP", 6)
     assert _has_localparam(result.verilog_output.verilog, "WMAN", 18)
@@ -67,15 +62,18 @@ def test_constant_only_module_keeps_operator_configured_format() -> None:
 
 
 def test_synthesize_threads_pipeline_stages() -> None:
-    base = holoso.synthesize(_kernel, ops=_ops())
+    base = holoso.synthesize(_kernel, _ops())
     staged = holoso.synthesize(
         _kernel,
-        ops=OpConfig(
-            FAddOperator(FMT32, stage_decode=1),
-            FMulOperator(FMT32, stage_product=2),
-            FDivOperator(FMT32),
-            FMulILog2OperatorFamily(FMT32),
-            FCmpOperator(FMT32),
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(stage_decode=1),
+                fmul=FMulOptions(stage_product=2),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=FMT32,
         ),
     )
     # Every STAGE_* is emitted explicitly (defaults as 0), so the instantiation is self-describing and configured
@@ -93,13 +91,13 @@ def test_rejects_nan_constant_data_and_nan_producing_folds_alike() -> None:
         return a + _NAN
 
     with pytest.raises(holoso.UnsupportedConstruct):
-        holoso.synthesize(nan_global, ops=_ops())
+        holoso.synthesize(nan_global, _ops())
 
     def folds_to_nan(a: float) -> float:
         return a + (1e400 - 1e400)  # inf + -inf: an indeterminate form, so it names nothing
 
     with pytest.raises(holoso.SynthesisError, match="names no number"):
-        holoso.synthesize(folds_to_nan, ops=_ops())
+        holoso.synthesize(folds_to_nan, _ops())
 
 
 def test_infinity_constants_are_allowed() -> None:
@@ -110,15 +108,15 @@ def test_infinity_constants_are_allowed() -> None:
         t = a + 1e400
         return 0.0 * t, 0.0 / t, t / t
 
-    out = holoso.synthesize(overflow, ops=_ops()).numerical_model.elaborate().run(1.0)[0]
+    out = holoso.synthesize(overflow, _ops()).numerical_model.elaborate().run(1.0)[0]
     assert math.isinf(float(out)) and float(out) > 0.0
 
-    folded = holoso.synthesize(hidden_by_fast_math, ops=_ops()).numerical_model.elaborate().run(1.0)
+    folded = holoso.synthesize(hidden_by_fast_math, _ops()).numerical_model.elaborate().run(1.0)
     assert [float(value) for value in folded] == [0.0, 0.0, 1.0]
 
 
 def test_write_artifacts(tmp_path: Path) -> None:
-    result = holoso.synthesize(_kernel, ops=_ops())
+    result = holoso.synthesize(_kernel, _ops())
     paths = result.write(tmp_path)
     assert set(paths) == {
         "_kernel.v",
@@ -134,7 +132,7 @@ def test_write_artifacts(tmp_path: Path) -> None:
 
 def test_frontend_ir_records_the_passes(tmp_path: Path) -> None:
     """The written documents are the front end's own passes in order, not two prints of one program."""
-    result = holoso.synthesize(_kernel, ops=_ops())
+    result = holoso.synthesize(_kernel, _ops())
     desugared, refined = result.frontend_ir
     # The desugarer knows no types and keeps the source spelling; partial evaluation types the boundary and
     # resolves the operators, so the subtraction has become a negate-and-add pair by the second document.
@@ -151,21 +149,19 @@ def test_rejects_invalid_and_reserved_module_names() -> None:
     # An empty name is falsy, so it is not "invalid" -- it just falls back to the target-derived default.
     for bad in ("1bad", "bad-name", "a/b", "has space", "../escape"):
         with pytest.raises(ValueError, match="valid identifier"):
-            holoso.synthesize(_kernel, ops=_ops(), name=bad)
+            holoso.synthesize(_kernel, _ops(), name=bad)
     for reserved in ("holoso", "Holoso_x", "holoso_support", "HOLOSOmod"):
         with pytest.raises(ValueError, match="reserved"):
-            holoso.synthesize(_kernel, ops=_ops(), name=reserved)
+            holoso.synthesize(_kernel, _ops(), name=reserved)
     # Reserved words would emit unparsable RTL (`module module (`); a same-spelled non-keyword is still fine.
     for keyword in ("module", "reg", "wire", "assign", "always"):
         with pytest.raises(ValueError, match="reserved keyword"):
-            holoso.synthesize(_kernel, ops=_ops(), name=keyword)
-    assert (
-        holoso.synthesize(_kernel, ops=_ops(), name="Module").module_name == "Module"
-    )  # case-sensitive: not a keyword
+            holoso.synthesize(_kernel, _ops(), name=keyword)
+    assert holoso.synthesize(_kernel, _ops(), name="Module").module_name == "Module"  # case-sensitive: not a keyword
 
 
 def test_accepts_valid_module_name(tmp_path: Path) -> None:
-    result = holoso.synthesize(_kernel, ops=_ops(), name="good_name")
+    result = holoso.synthesize(_kernel, _ops(), name="good_name")
     assert result.module_name == "good_name"
     paths = result.write(tmp_path)
     assert set(paths) == {
@@ -183,7 +179,7 @@ def test_synthesize_ekf1_stateless() -> None:
     import ekf1_stateless
 
     fmt = FloatFormat(6, 18)
-    result = holoso.synthesize(ekf1_stateless.update_x_P, ops=_ops(fmt))
+    result = holoso.synthesize(ekf1_stateless.update_x_P, _ops(fmt))
     assert result.module_name == "update_x_P"
     assert len(result.output_ports) == 9
     compile(result.cocotb_output.testbench, "<generated-testbench>", "exec")
@@ -195,4 +191,4 @@ def test_class_target_is_unsupported() -> None:
             return x
 
     with pytest.raises(holoso.UnsupportedConstruct, match="is not a plain function"):
-        holoso.synthesize(Stateful, ops=_ops(FloatFormat(6, 18)))
+        holoso.synthesize(Stateful, _ops(FloatFormat(6, 18)))

--- a/tests/test_synth_examples.py
+++ b/tests/test_synth_examples.py
@@ -34,7 +34,7 @@ def test_some_target_flow_is_available() -> None:
 
 
 # Heaviest-first so xdist starts the long wide-datapath rows immediately instead of scheduling them last and tailing.
-_BY_COST = sorted(TARGETS, key=lambda t: t.ops.float_format.wman, reverse=True)
+_BY_COST = sorted(TARGETS, key=lambda t: t.ops.ffmt.wman, reverse=True)
 
 
 @pytest.mark.parametrize("target", _BY_COST, ids=lambda t: t.label)

--- a/tests/test_timing_equivalence_behavior.py
+++ b/tests/test_timing_equivalence_behavior.py
@@ -32,10 +32,7 @@ from collections.abc import Callable
 import numpy as np
 
 import holoso
-from holoso import (
-    FloatFormat,
-    FloatValue,
-)
+from holoso import FloatFormat, FloatValue
 
 from ._modelref import default_ops, default_options, overlap_spill_kernel, staged_ops, staged_options
 

--- a/tests/test_timing_equivalence_behavior.py
+++ b/tests/test_timing_equivalence_behavior.py
@@ -32,16 +32,19 @@ from collections.abc import Callable
 import numpy as np
 
 import holoso
-from holoso import FloatFormat, FloatValue
+from holoso import (
+    FloatFormat,
+    FloatValue,
+)
 
-from ._modelref import default_ops, overlap_spill_kernel, staged_ops
+from ._modelref import default_ops, default_options, overlap_spill_kernel, staged_ops, staged_options
 
 FMT = FloatFormat(6, 18)
 
 
 def _pair(fn: Callable[..., object], name: str) -> tuple[holoso.NumericalSimulator, holoso.NumericalSimulator]:
-    short = holoso.synthesize(fn, default_ops(FMT), name=f"{name}_short").numerical_model.elaborate()
-    long = holoso.synthesize(fn, staged_ops(FMT), name=f"{name}_long").numerical_model.elaborate()
+    short = holoso.synthesize(fn, default_options(FMT), name=f"{name}_short").numerical_model.elaborate()
+    long = holoso.synthesize(fn, staged_options(FMT), name=f"{name}_long").numerical_model.elaborate()
     return short, long
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -10,25 +10,27 @@ import pytest
 import holoso
 from holoso import (
     BoolType,
-    FloatValue,
-    FAddOperator,
-    FCmpOperator,
-    FDivOperator,
+    FAddOptions,
+    FCmpOptions,
+    FDivOptions,
+    FMulILog2Options,
+    FMulOptions,
     FloatFormat,
     FloatType,
-    FMulILog2OperatorFamily,
-    FMulOperator,
-    OpConfig,
+    FloatValue,
+    OperatorOptions,
+    Options,
     UnsupportedConstruct,
 )
-from ._modelref import build_model, generate
+from ._modelref import build_lir, build_model, default_options, generate
 from holoso._eel import lower
 from holoso._hir import optimize
 from holoso._hir import _if_convert as if_convert_pass
-from holoso._lir import FloatStateSlot, Lir, build
+from holoso._lir import FloatStateSlot, Lir
 from holoso._lir._ir import BoolStateSlot
 from holoso._mir import Mir, lower as lower_to_mir
 from ._modelref import (
+    build_ops,
     assert_model_equals_interpreter,
     bounded,
     build_model_and_interpreter,
@@ -57,14 +59,25 @@ from ._examples import (
 
 F32 = FloatFormat(8, 24)
 FMT = FloatFormat(6, 18)
-OPS = OpConfig(FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT))
+OPS = build_ops(
+    Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
+    )
+)
 
 
 def test_equal_temperament_default_sweep_has_no_log2_sidebands() -> None:
     # The shipped self-test bench sweeps every input over cocotb's default (-4, 4) range (the _DEFAULT_RANGE template
     # constant in holoso/_backend/cocotb.py) and asserts err_pc == 0, so log2's argument must stay positive across it or
     # the artifact aborts on a domain_error/pole.
-    sim = holoso.synthesize(equal_temperament, default_ops(F32), name="et_sweep").numerical_model.elaborate()
+    sim = holoso.synthesize(equal_temperament, default_options(F32), name="et_sweep").numerical_model.elaborate()
     for raw in np.linspace(-4.0, 4.0, 25):  # hertz is monotonic in note, so a coarse grid suffices
         x = F32.decode(F32.encode(float(raw)))
         out = sim.run(x)
@@ -85,7 +98,7 @@ def test_model_exact_integer_comparison_is_not_folded_via_float() -> None:
             r = a + 1.0
         return r
 
-    model = build_model(build(_run(exact_int_comparison), "eic", fetch_stages=3))
+    model = build_model(build_lir(_run(exact_int_comparison), "eic"))
     for a in (5.0, 0.0, -2.0):
         assert float(model.run(a)[0]) == exact_int_comparison(a)
 
@@ -153,7 +166,7 @@ def test_model_matches_reference_small_kernels() -> None:
         return (a - b) * 0.25 + a * b
 
     inputs = {"a": 1.25, "b": -3.5}
-    model = build_model(build(_run(f), "f", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "f"))
     got = model.run(*[inputs[name] for name in [p.name for p in model.inputs]])
     ref = evaluate_reference(f, inputs)
     rtol, atol = default_tolerance(FMT, len(model._lir.ops), magnitude=max(abs(v) for v in inputs.values()))
@@ -172,7 +185,7 @@ def test_model_matches_reference_dense_boolean_chain() -> None:
         live = bool(gated + a)
         return (gated, live)
 
-    model = build_model(build(_run(f), "dense_bool", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "dense_bool"))
     values = (-1.5, -0.25, 0.0, 0.25, 1.5)
     for a in values:
         for b in values:
@@ -190,7 +203,7 @@ def test_tuple_unpacking_matches_python_reference() -> None:
         return x - y, x * y
 
     inputs = {"a": 1.25, "b": -3.5}
-    model = build_model(build(_run(f), "f", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "f"))
     got = model.run(*[inputs[name] for name in [p.name for p in model.inputs]])
     ref = evaluate_reference(f, inputs)
     rtol, atol = default_tolerance(FMT, len(model._lir.ops), magnitude=max(abs(v) for v in inputs.values()))
@@ -211,7 +224,7 @@ def test_for_counter_reassigned_to_runtime_clears_static_binding() -> None:
             r = 200.0
         return r
 
-    model = build_model(build(_run(f), "f", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "f"))
     for a in (5.0, 0.5, -3.0, 2.0):  # a>1 must take the else arm (200); the defect always returns 100
         assert float(model.run(a)[0]) == float(f(a)), f"mismatch at a={a}"
 
@@ -229,7 +242,7 @@ def test_for_counter_reassigned_after_loop_clears_static_binding() -> None:
             acc = acc + 50.0
         return acc
 
-    model = build_model(build(_run(f), "f", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "f"))
     for a in (5.0, 0.5, 2.0, -1.0):
         assert float(model.run(a)[0]) == float(f(a)), f"mismatch at a={a}"
 
@@ -246,7 +259,7 @@ def test_runtime_reassigned_for_counter_is_not_a_static_index() -> None:
         return vec[i]
 
     with pytest.raises(UnsupportedConstruct):
-        build(_run(f), "f", fetch_stages=3)
+        build_lir(_run(f), "f")
 
 
 def test_for_counter_reassign_keeps_scan_and_lowering_in_lockstep() -> None:
@@ -278,7 +291,7 @@ def test_for_counter_reassign_keeps_scan_and_lowering_in_lockstep() -> None:
     hir = lower(K().step).hir
     assert "s" in {slot.name for slot in hir.state_slots}  # the loop-written attr must be registered as state
 
-    model = build_model(build(_run(K().step), "k", fetch_stages=3))
+    model = build_model(build_lir(_run(K().step), "k"))
     ref = K()
     for a in (0.5, 5.0, -7.0):  # t<1 (then arm, no write) for a<1; else arm runs the loop and writes s for a>=1
         assert float(model.run(a)[0]) == float(ref.step(a)), f"mismatch at a={a}"
@@ -310,7 +323,7 @@ def test_walrus_counter_demotion_keeps_scan_and_lowering_in_lockstep() -> None:
     hir = lower(K().step).hir
     assert "s" in {slot.name for slot in hir.state_slots}  # the loop-written attr must be registered as state
 
-    model = build_model(build(_run(K().step), "k", fetch_stages=3))
+    model = build_model(build_lir(_run(K().step), "k"))
     ref = K()
     for a in (0.5, 5.0, -7.0):  # a<1 takes the empty then arm; a>=1 runs the else loop and writes s
         assert float(model.run(a)[0]) == float(ref.step(a)), f"mismatch at a={a}"
@@ -338,7 +351,7 @@ def test_for_counter_reassigned_inside_while_is_demoted_after_the_loop() -> None
 
     # With the stale binding resurrected, ``i`` folds to 0 -> ``0 < 0.0`` is always False -> r is always 200.0.
     assert len(lower(kernel).hir.blocks) > 1  # the comparison is a real branch, not folded away
-    model = build_model(build(_run(kernel), "k", fetch_stages=3))
+    model = build_model(build_lir(_run(kernel), "k"))
     for a in (-5.0, -0.5, 0.5, 7.0):
         assert float(model.run(a)[0]) == float(kernel(a)), f"mismatch at a={a}"
 
@@ -356,7 +369,7 @@ def test_for_counter_reassigned_inside_while_is_a_runtime_value_afterwards() -> 
             w = w + 1.0
         return a * i
 
-    model = build_model(build(_run(kernel), "demoted_counter", fetch_stages=3))
+    model = build_model(build_lir(_run(kernel), "demoted_counter"))
     for a in (1.0, 2.0, 3.0):
         assert float(model.run(a)[0]) == pytest.approx(kernel(a), rel=1e-6)
 
@@ -366,10 +379,19 @@ def test_model_uses_exact_ilog2_for_wide_supported_shift() -> None:
         return a * 16.0
 
     fmt = FloatFormat(3, 4)
-    ops = OpConfig(
-        FAddOperator(fmt), FMulOperator(fmt), FDivOperator(fmt), FMulILog2OperatorFamily(fmt), FCmpOperator(fmt)
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
-    model = build_model(build(lower_to_mir(optimize(lower(f).hir), ops), "f", fetch_stages=3))
+    model = build_model(build_lir(lower_to_mir(optimize(lower(f).hir), ops), "f"))
     assert model.run(FloatValue.from_float(fmt, 0.5))[0] == FloatValue.from_float(fmt, 8.0)
 
 
@@ -377,7 +399,7 @@ def test_model_handles_unused_input_ports() -> None:
     def f(a: float, b: float) -> float:
         return b
 
-    model = build_model(build(_run(f), "f", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "f"))
     assert [load.name for load in model._lir.float_inputs] == ["a", "b"]
     assert [load.dst.index for load in model._lir.float_inputs] == [0, 1]
     assert model._lir.regfile.nload == 2
@@ -388,7 +410,7 @@ def test_model_rejects_ambiguous_int_and_mismatched_float_value_format() -> None
     def f(a: float) -> float:
         return a
 
-    model = build_model(build(_run(f), "f", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "f"))
     assert model.run(1.0)[0] == FloatValue.from_float(FMT, 1.0)
 
     with pytest.raises(TypeError, match="FloatValue or float"):
@@ -402,11 +424,20 @@ def test_model_is_bit_exact_for_wide_zkf_multiply_regression() -> None:
         return a * b
 
     fmt = FloatFormat(8, 36)
-    ops = OpConfig(
-        FAddOperator(fmt), FMulOperator(fmt), FDivOperator(fmt), FMulILog2OperatorFamily(fmt), FCmpOperator(fmt)
+    ops = build_ops(
+        Options(
+            OperatorOptions(
+                fadd=FAddOptions(),
+                fmul=FMulOptions(),
+                fdiv=FDivOptions(),
+                fmul_ilog2=FMulILog2Options(),
+                fcmp=FCmpOptions(),
+            ),
+            ffmt=fmt,
+        )
     )
     mir = lower_to_mir(optimize(lower(f).hir), ops)
-    model = build_model(build(mir, "f", fetch_stages=3))
+    model = build_model(build_lir(mir, "f"))
     got = model.run(
         FloatValue.from_bits(fmt, 0x42BF30E6505),
         FloatValue.from_bits(fmt, 0xBD734F60F3A),
@@ -437,7 +468,7 @@ def test_model_matches_reference_ekf1_stateless() -> None:
         "z_ct": bounded(rng, -1.0, 1.0),
         "z_shunt": bounded(rng, -1.0, 1.0),
     }
-    model = build_model(build(_run(ekf1_stateless.update_x_P), "ekf1_stateless", fetch_stages=3))
+    model = build_model(build_lir(_run(ekf1_stateless.update_x_P), "ekf1_stateless"))
     got = model.run(*[inputs[name] for name in [p.name for p in model.inputs]])
     ref = evaluate_reference(ekf1_stateless.update_x_P, inputs)
     assert len(ref) == 9 and all(np.isfinite(ref))
@@ -452,7 +483,7 @@ def test_model_matches_reference_aggregates() -> None:
         return v[2], *head  # index, slice, and unpack -> (c, a, b)
 
     inputs = {"a": 1.0, "b": 2.0, "c": 3.0}
-    model = build_model(build(_run(f), "agg", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "agg"))
     got = model.run(*[inputs[name] for name in [p.name for p in model.inputs]])
     ref = evaluate_reference(f, inputs)  # these aggregate ops run identically in plain Python
     rtol, atol = default_tolerance(FMT, max(len(model._lir.ops), 1), magnitude=3.0)
@@ -472,7 +503,7 @@ def test_model_matches_reference_ekf1_stateful() -> None:
     def fresh() -> ekf1_stateful.Ekf1:
         return ekf1_stateful.Ekf1(x=list(x), P_urt=list(p_urt), R_diag=list(r_diag), Q_diag=np.array(q_diag))
 
-    model = build_model(build(_run(fresh().update), "ekf1_stateful", fetch_stages=3))
+    model = build_model(build_lir(_run(fresh().update), "ekf1_stateful"))
     got = model.run(*[step_inputs[name] for name in [p.name for p in model.inputs]])
 
     # update() is ordinary executable numpy, so the reference is just one native step from the same reset; the new
@@ -489,7 +520,7 @@ def test_model_pickles_and_round_trips() -> None:
     def f(a: float, b: float) -> float:
         return (a - b) * 0.25 + a * b
 
-    model = build_model(build(_run(f), "f", fetch_stages=3))
+    model = build_model(build_lir(_run(f), "f"))
     inputs = [1.25, -3.5]
     restored = pickle.loads(pickle.dumps(model))
     assert restored.run(*inputs) == model.run(*inputs)
@@ -522,7 +553,7 @@ def test_sampling_legal_and_spd() -> None:
 
 
 def test_model_executes_first_sample_branch() -> None:
-    model = build_model(build(_run(IIR1LPF().__call__), "iir1_lpf", fetch_stages=3))
+    model = build_model(build_lir(_run(IIR1LPF().__call__), "iir1_lpf"))
     reference = IIR1LPF()
     stream = [1.0, 2.0, 3.0, 0.5, -1.0, 8.0]
     rtol, atol = default_tolerance(FMT, len(model._lir.ops), magnitude=8.0)
@@ -534,7 +565,7 @@ def test_model_executes_first_sample_branch() -> None:
 
 
 def test_model_branch_reset_restarts_the_first_sample_arm() -> None:
-    model = build_model(build(_run(IIR1LPF().__call__), "iir1_lpf", fetch_stages=3))
+    model = build_model(build_lir(_run(IIR1LPF().__call__), "iir1_lpf"))
     model.run(1.0)
     second = float(model.run(5.0)[0])
     assert second != 5.0  # the second sample took the IIR arm, not y = x
@@ -543,7 +574,7 @@ def test_model_branch_reset_restarts_the_first_sample_arm() -> None:
 
 
 def test_model_pid_controller_all_arms_anti_windup_and_first_update() -> None:
-    model = build_model(build(_run(PID().__call__), "pid", fetch_stages=3))
+    model = build_model(build_lir(_run(PID().__call__), "pid"))
     reference = PID()
     ui = [p.name for p in model.outputs].index("out_0")
     rtol, atol = default_tolerance(FMT, len(model._lir.ops), magnitude=10.0)
@@ -575,7 +606,7 @@ def test_model_walrus_binds_once_and_stays_visible_after_the_test() -> None:
             r = t
         return r
 
-    model = build_model(build(_run(walrus), "walrus", fetch_stages=3))
+    model = build_model(build_lir(_run(walrus), "walrus"))
     for x in (3.0, 1.0, 2.0, -5.0, 0.0):  # >2 takes the then arm (reads t), else reads the same bound t
         assert float(model.run(x)[0]) == walrus(x)
 
@@ -592,7 +623,7 @@ def test_model_walrus_reassigned_loop_variable_is_loop_carried() -> None:
             i = i + 1.0
         return acc
 
-    model = build_model(build(_run(walrus_loop), "walrus_loop", fetch_stages=3))
+    model = build_model(build_lir(_run(walrus_loop), "walrus_loop"))
     for x in (2.5, 1.0, -3.0):  # the defect (walrus invisible to the loop scan) returns 0.0 instead of 4*x
         assert float(model.run(x)[0]) == walrus_loop(x)
 
@@ -606,7 +637,7 @@ def test_model_remainder_iterative_reduction_is_exact_and_matches_ieee() -> None
     # forever, which the explicit unit-place handling avoids.
     import math
 
-    model = build_model(build(_run(remainder), "remainder", fetch_stages=3))
+    model = build_model(build_lir(_run(remainder), "remainder"))
     ui = [p.name for p in model.outputs].index("out_0")
     min_normal = 2.0 ** (1 - (2 ** (FMT.wexp - 1) - 1))
     cases = [(5.0, 3.0), (10.0, 3.0), (7.5, 2.0), (-7.5, 2.0), (13.0, 4.0), (6.0, 4.0), (2.0, 4.0), (0.0, 2.0)]
@@ -632,14 +663,14 @@ def test_model_schmitt_trigger_hysteresis() -> None:
                 self.y = 0.0
             return self.y
 
-    model = build_model(build(_run(FloatSchmittTrigger().__call__), "schmitt", fetch_stages=3))
+    model = build_model(build_lir(_run(FloatSchmittTrigger().__call__), "schmitt"))
     reference = FloatSchmittTrigger()
     for x in [0.0, 0.5, 1.5, 0.5, -0.5, -1.5, -0.5, 0.5, 2.0]:
         assert float(model.run(x)[0]) == reference(x)  # 0.0/1.0 are exact in ZKF
 
 
 def test_model_public_boolean_state_output() -> None:
-    model = build_model(build(_run(SchmittTrigger().__call__), "bool_schmitt", fetch_stages=3))
+    model = build_model(build_lir(_run(SchmittTrigger().__call__), "bool_schmitt"))
     reference = SchmittTrigger()
     assert [p.name for p in model.outputs] == ["state_y"]
     for x in [0.0, 0.5, 1.5, 0.5, -0.5, -1.5, -0.5, 0.5, 2.0]:
@@ -657,7 +688,7 @@ def test_model_boolean_only_state_output() -> None:
             self.flag = not self.flag
             return self.flag
 
-    model = build_model(build(_run(BoolToggle().__call__), "bool_toggle", fetch_stages=3))
+    model = build_model(build_lir(_run(BoolToggle().__call__), "bool_toggle"))
     reference = BoolToggle()
     assert [p.name for p in model.inputs] == []
     assert [p.name for p in model.outputs] == ["state_flag"]
@@ -673,7 +704,7 @@ def test_model_boolean_input_and_mixed_outputs() -> None:
             y = -x
         return flag, y
 
-    model = build_model(build(_run(gate), "bool_gate", fetch_stages=3))
+    model = build_model(build_lir(_run(gate), "bool_gate"))
     assert [p.name for p in model.inputs] == ["flag", "x"]
     got_flag, got_y = model.run(True, 2.0)
     assert got_flag is True
@@ -695,7 +726,7 @@ def test_model_ports_carry_scalar_types() -> None:
             y = -x
         return flag, y
 
-    handle = generate(build(_run(gate), "bool_gate", fetch_stages=3))
+    handle = generate(build_lir(_run(gate), "bool_gate"))
     simulator = handle.elaborate()
     for ports in (handle.inputs, simulator.inputs):
         assert [(p.name, p.scalar_type) for p in ports] == [("flag", BoolType()), ("x", FloatType(FMT))]
@@ -714,7 +745,7 @@ def test_model_unused_boolean_input_keeps_cfg_state_timing() -> None:
             self.y = self.y + x + 1.0
             return self.y
 
-    model = build_model(build(_run(UnusedBoolInputStateAccumulator().__call__), "unused_bool", fetch_stages=3))
+    model = build_model(build_lir(_run(UnusedBoolInputStateAccumulator().__call__), "unused_bool"))
     assert model._lir.bool_inputs  # an unused boolean input is still a port and a boolean register load
     assert float(model.run(False, 2.0)[0]) == 3.0
     assert float(model.run(True, 4.0)[0]) == 8.0
@@ -733,11 +764,11 @@ def test_run_drains_in_flight_transaction_before_presenting_new_inputs() -> None
             self.total = self.total + x
             return self.total
 
-    reference = build_model(build(_run(StateAccumulator().__call__), "acc_ref", fetch_stages=3))
+    reference = build_model(build_lir(_run(StateAccumulator().__call__), "acc_ref"))
     assert float(reference.run(1.0)[0]) == 1.0
     assert float(reference.run(2.0)[0]) == 3.0  # state carries across transactions
 
-    model = build_model(build(_run(StateAccumulator().__call__), "acc", fetch_stages=3))
+    model = build_model(build_lir(_run(StateAccumulator().__call__), "acc"))
     model.set_inputs(1.0)
     model.tick(in_valid=True, out_ready=False)  # accept x=1; the transaction is now in flight (in_ready is False)
     assert not model.in_ready and not model._pending  # mid-flight, and the accumulate op has not yet sampled x=1
@@ -775,14 +806,14 @@ def test_model_unrolled_for_loop_newton_reciprocal() -> None:
             y = y * (2.0 - x * y)
         return y
 
-    model = build_model(build(_run(reciprocal), "newton", fetch_stages=3))
+    model = build_model(build_lir(_run(reciprocal), "newton"))
     assert len(model._lir.blocks) == 1  # fully unrolled to a single straight-line block
     for x in [0.5, 0.75, 1.0, 1.3, 1.7, 2.0]:  # the restricted domain where this 4-step Newton seed converges
         assert math.isclose(float(model.run(x)[0]), 1.0 / x, rel_tol=1e-5)
 
 
 def test_model_unrolled_cordic_sin_cos() -> None:
-    model = build_model(build(_run(CordicSinCos().__call__), "cordic", fetch_stages=3))
+    model = build_model(build_lir(_run(CordicSinCos().__call__), "cordic"))
     cos_index, sin_index = [p.name for p in model.outputs].index("out_0"), [p.name for p in model.outputs].index(
         "out_1"
     )
@@ -803,7 +834,7 @@ def test_model_attribute_written_only_in_loop_is_persistent_state() -> None:
                 self.acc = self.acc + x
             return self.acc
 
-    model = build_model(build(_run(LoopAccumulator().__call__), "accum", fetch_stages=3))
+    model = build_model(build_lir(_run(LoopAccumulator().__call__), "accum"))
     assert [slot.name for slot in model._lir.float_state_slots] == ["acc"]
     reference = LoopAccumulator()
     assert float(model.run(1.0)[0]) == reference(1.0)
@@ -825,7 +856,7 @@ def test_model_state_liveout_does_not_clobber_live_in_branch() -> None:
             self.y = x  # live-out installed only at the boundary, not before the reads above
             return z
 
-    model = build_model(build(_run(LiveInClobberedByLiveOut().__call__), "f1", fetch_stages=3))
+    model = build_model(build_lir(_run(LiveInClobberedByLiveOut().__call__), "f1"))
     reference = LiveInClobberedByLiveOut()
     for x in [5.0, -1.0, 3.0]:
         assert float(model.run(x)[0]) == reference(x)
@@ -846,7 +877,7 @@ def test_model_state_phi_does_not_clobber_returned_live_in() -> None:
                 self.y = x + 10.0
             return old
 
-    model = build_model(build(_run(LiveInReadAfterPhi().__call__), "f2", fetch_stages=3))
+    model = build_model(build_lir(_run(LiveInReadAfterPhi().__call__), "f2"))
     reference = LiveInReadAfterPhi()
     for x in [2.0, 3.0, -4.0]:
         assert float(model.run(x)[0]) == reference(x)
@@ -866,7 +897,7 @@ def test_model_signed_state_liveout_persists_with_sign() -> None:
             self.y = -t
             return self.y
 
-    model = build_model(build(_run(SignedStateLiveOut().__call__), "f3", fetch_stages=3))
+    model = build_model(build_lir(_run(SignedStateLiveOut().__call__), "f3"))
     reference = SignedStateLiveOut()
     for x in [2.0, -1.0, -1.0, 4.0]:
         assert float(model.run(x)[0]) == reference(x)
@@ -882,7 +913,7 @@ def test_model_sign_conditioned_phi_arm() -> None:
             y = x
         return y
 
-    model = build_model(build(_run(neg_abs_phi), "negabs", fetch_stages=3))
+    model = build_model(build_lir(_run(neg_abs_phi), "negabs"))
     for x in [3.0, -2.5, 0.0, 7.25, -10.0]:
         assert float(model.run(x)[0]) == (-x if x > 0.0 else x)
 
@@ -913,7 +944,7 @@ def test_inplace_bool_conditional_sticky_latch() -> None:
                 self._f = self._f or x
             return self._f
 
-    lir = build(_run(BoolStickyLatch().__call__), "sticky", fetch_stages=3)
+    lir = build_lir(_run(BoolStickyLatch().__call__), "sticky")
     assert not _bool_slot(lir, "_f").needs_copy  # the phi live-out coalesced onto the slot register
     model = build_model(lir)
     reference = BoolStickyLatch()
@@ -935,7 +966,7 @@ def test_inplace_bool_unconditional_self_update() -> None:
             self._f = self._f or x
             return self._f
 
-    lir = build(_run(BoolOrSelf().__call__), "orself", fetch_stages=3)
+    lir = build_lir(_run(BoolOrSelf().__call__), "orself")
     assert not _bool_slot(lir, "_f").needs_copy
     model = build_model(lir)
     reference = BoolOrSelf()
@@ -961,7 +992,7 @@ def test_inplace_loop_preheader_arm_is_dwell_safe() -> None:
                 i = i - 1.0
             return self._s
 
-    lir = build(_run(LoopPreheaderArmInPlace().__call__), "preheaderarm", fetch_stages=3)
+    lir = build_lir(_run(LoopPreheaderArmInPlace().__call__), "preheaderarm")
     assert not _bool_slot(lir, "_s").needs_copy  # the loop phi coalesced onto the slot register
     model = build_model(lir)
     reference = LoopPreheaderArmInPlace()
@@ -988,7 +1019,7 @@ def test_inplace_write_only_slot_gap_tenant_is_dwell_safe() -> None:
                 self._w = self._x
             return self._x, self._w
 
-    lir = build(_run(WriteOnlyDwellTenant().__call__), "dwell_tenant", fetch_stages=3)
+    lir = build_lir(_run(WriteOnlyDwellTenant().__call__), "dwell_tenant")
     assert not _bool_slot(lir, "_w").needs_copy, "_w must coalesce for a gap tenant to share its slot register"
     assert any(op.issue_cycle == 0 for op in lir.blocks[lir.entry].inline_ops), "a cycle-0 entry gap tenant must arise"
     model = build_model(lir)
@@ -1010,7 +1041,7 @@ def test_inplace_float_conditional_accumulator() -> None:
                 self._acc = self._acc + x
             return self._acc
 
-    lir = build(_run(FloatCondAccum().__call__), "accum", fetch_stages=3)
+    lir = build_lir(_run(FloatCondAccum().__call__), "accum")
     assert not _float_slot(lir, "_acc").needs_copy  # the select live-out coalesced onto the slot register
     model = build_model(lir)
     reference = FloatCondAccum()
@@ -1032,7 +1063,7 @@ def test_chained_float_slots_do_not_coalesce() -> None:
             self.b = self.b + x
             return self.a
 
-    lir = build(_run(ChainedFloatSlots().__call__), "chain", fetch_stages=3)
+    lir = build_lir(_run(ChainedFloatSlots().__call__), "chain")
     assert _float_slot(lir, "a").needs_copy  # chained copy of b's live-in -- must not coalesce in place
     assert _float_slot(lir, "b").needs_copy  # tapped by a's live-out -- must not coalesce in place
     model = build_model(lir)
@@ -1058,7 +1089,7 @@ def test_inplace_multiarm_float_phi() -> None:
                 self._s = self._s - 1.0
             return self._s
 
-    lir = build(_run(MultiArmFloatPhi().__call__), "multiarm", fetch_stages=3)
+    lir = build_lir(_run(MultiArmFloatPhi().__call__), "multiarm")
     assert not _float_slot(lir, "_s").needs_copy  # the live-in is the else arm, so the live-out commits in place
     model = build_model(lir)
     reference = MultiArmFloatPhi()
@@ -1086,9 +1117,7 @@ def test_state_livein_feeding_another_slot_phi_does_not_coalesce(monkeypatch: py
             return self.x, self.w
 
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)  # keep the diamond a real branch with phis
-    lir = build(
-        _run(LiveInFeedsAnotherSlotPhi().__call__), "livein_other_slot", fetch_stages=3
-    )  # must not crash the colorer
+    lir = build_lir(_run(LiveInFeedsAnotherSlotPhi().__call__), "livein_other_slot")  # must not crash the colorer
     assert _float_slot(lir, "x").needs_copy  # x's live-in feeds w's phi -> x must stay non-coalesced (copy-back)
     model = build_model(lir)
     reference = LiveInFeedsAnotherSlotPhi()
@@ -1114,9 +1143,7 @@ def test_state_livein_feeding_unrelated_phi_does_not_coalesce(monkeypatch: pytes
             return new_y, self.x
 
     monkeypatch.setattr(if_convert_pass, "_IFCONV_MAX_OPS", 0)  # keep the diamonds real branches with phis
-    lir = build(
-        _run(LiveInFeedsUnrelatedPhi().__call__), "livein_unrelated", fetch_stages=3
-    )  # must not crash the colorer
+    lir = build_lir(_run(LiveInFeedsUnrelatedPhi().__call__), "livein_unrelated")  # must not crash the colorer
     assert _float_slot(lir, "x").needs_copy  # x's live-in feeds an unrelated phi -> x must stay non-coalesced
     model = build_model(lir)
     reference = LiveInFeedsUnrelatedPhi()
@@ -1136,7 +1163,7 @@ def test_model_while_loop_accumulates() -> None:
             i = i - 1.0
         return acc
 
-    model = build_model(build(_run(while_sum), "whilesum", fetch_stages=3))
+    model = build_model(build_lir(_run(while_sum), "whilesum"))
     for x, n in [(1.0, 3.0), (2.0, 0.0), (0.5, 5.0), (-1.0, 4.0)]:
         assert float(model.run(x, n)[0]) == pytest.approx(x * n)
 
@@ -1155,7 +1182,7 @@ def test_model_while_loop_carries_persistent_state() -> None:
                 i = i - 1.0
             return self._total
 
-    model = build_model(build(_run(WhileIntegrator().__call__), "whileint", fetch_stages=3))
+    model = build_model(build_lir(_run(WhileIntegrator().__call__), "whileint"))
     reference = WhileIntegrator()
     for x, n in [(1.0, 2.0), (3.0, 1.0), (0.5, 4.0), (2.0, 0.0)]:
         assert float(model.run(x, n)[0]) == pytest.approx(reference(x, n))
@@ -1173,7 +1200,7 @@ def test_model_for_counter_inside_while_is_loop_carried() -> None:
             i = i + 1.0
         return j
 
-    model = build_model(build(_run(for_counter_inside_while), "fciw", fetch_stages=3))
+    model = build_model(build_lir(_run(for_counter_inside_while), "fciw"))
     for x in [0.0, 1.0, 2.0, 3.0]:
         assert float(model.run(x)[0]) == for_counter_inside_while(x)
 
@@ -1236,10 +1263,8 @@ def test_model_attr_written_under_counter_gated_branch_in_while() -> None:
                 w = w - 1.0
             return self._s2
 
-    model = build_model(build(_run(CounterGatedWhileState().step), "cgws", fetch_stages=3))
-    assert "_s2" in {
-        slot.name for slot in build(_run(CounterGatedWhileState().step), "cgws", fetch_stages=3).float_state_slots
-    }
+    model = build_model(build_lir(_run(CounterGatedWhileState().step), "cgws"))
+    assert "_s2" in {slot.name for slot in build_lir(_run(CounterGatedWhileState().step), "cgws").float_state_slots}
     reference = CounterGatedWhileState()
     for a in [10.0, 9.0, 8.0, 0.0, -3.0, 12.0]:
         assert float(model.run(a)[0]) == reference.step(a)
@@ -1266,7 +1291,7 @@ def test_model_shared_constant_branch_condition() -> None:
                     y = 4.0
             return y
 
-    model = build_model(build(_run(SharedConstBranchCondition().__call__), "f4", fetch_stages=3))
+    model = build_model(build_lir(_run(SharedConstBranchCondition().__call__), "f4"))
     reference = SharedConstBranchCondition()
     for x in [1.0, -1.0, 2.0, -3.0]:
         assert float(model.run(x)[0]) == reference(x)
@@ -1296,7 +1321,7 @@ def test_model_statically_dead_attribute_write_is_not_state() -> None:
 
     kernels: list[tuple[type[DeadLoopWrite] | type[DeadIfWrite], float]] = [(DeadLoopWrite, 1.25), (DeadIfWrite, 2.5)]
     for kernel, constant in kernels:
-        lir = build(_run(kernel().__call__), "dead", fetch_stages=3)
+        lir = build_lir(_run(kernel().__call__), "dead")
         assert [slot.name for slot in lir.float_state_slots] == []  # no state slot; no crash building it
         model = build_model(lir)
         assert float(model.run(9.0)[0]) == constant  # unchanged across calls -- it never became state
@@ -1327,11 +1352,11 @@ def test_model_counter_dependent_empty_inner_loop_is_not_state() -> None:
                     self.s = self.s + x
             return self.s
 
-    dead = build(_run(CounterDependentEmptyInner().__call__), "f6dead", fetch_stages=3)
+    dead = build_lir(_run(CounterDependentEmptyInner().__call__), "f6dead")
     assert [slot.name for slot in dead.float_state_slots] == []
     assert float(build_model(dead).run(9.0)[0]) == 1.25  # builds without KeyError; y stays constant
 
-    live = build(_run(CounterDependentLiveInner().__call__), "f6live", fetch_stages=3)
+    live = build_lir(_run(CounterDependentLiveInner().__call__), "f6live")
     assert [slot.name for slot in live.float_state_slots] == ["s"]
     model, reference = build_model(live), CounterDependentLiveInner()
     for x in [1.0, 1.0, 2.0]:
@@ -1352,7 +1377,7 @@ def test_model_return_in_literal_if_arm_ends_the_scan() -> None:
             self.y = x  # unreachable: lowering stops at the return above
             return self.y
 
-    lir = build(_run(ReturnInLiteralIfArm().__call__), "f7", fetch_stages=3)
+    lir = build_lir(_run(ReturnInLiteralIfArm().__call__), "f7")
     assert [slot.name for slot in lir.float_state_slots] == []
     assert float(build_model(lir).run(5.0)[0]) == 7.0
 
@@ -1376,7 +1401,7 @@ def test_model_loop_counter_does_not_leak_across_branch_arms_in_scan() -> None:
                     self.y = x
             return self.y
 
-    lir = build(_run(CounterLeakAcrossArms().__call__), "f8", fetch_stages=3)
+    lir = build_lir(_run(CounterLeakAcrossArms().__call__), "f8")
     assert [slot.name for slot in lir.float_state_slots] == []
     assert float(build_model(lir).run(1.0)[0]) == 1.0  # y stays the reset constant
 
@@ -1396,7 +1421,7 @@ def test_model_chained_state_copy_delay_line() -> None:
             self.c = self.c + x
             return out
 
-    model = build_model(build(_run(DelayLine().__call__), "delay", fetch_stages=3))
+    model = build_model(build_lir(_run(DelayLine().__call__), "delay"))
     reference = DelayLine()
     for x in [1.0, 1.0, 2.0, 3.0, -1.0]:
         assert float(model.run(x)[0]) == reference(x)  # out[n] == c[n-1]
@@ -1407,8 +1432,15 @@ def test_synthesis_result_reports_latency_metric() -> None:
     # kernel's max is unbounded for now (a branch can shortcut the PC), reported as None alongside the min lower bound.
     import holoso
 
-    ops = OpConfig(
-        FAddOperator(FMT), FMulOperator(FMT), FDivOperator(FMT), FMulILog2OperatorFamily(FMT), FCmpOperator(FMT)
+    ops = Options(
+        OperatorOptions(
+            fadd=FAddOptions(),
+            fmul=FMulOptions(),
+            fdiv=FDivOptions(),
+            fmul_ilog2=FMulILog2Options(),
+            fcmp=FCmpOptions(),
+        ),
+        ffmt=FMT,
     )
 
     def straight_line(a: float, b: float) -> float:
@@ -1434,7 +1466,7 @@ def test_model_handle_round_trips_through_pickle() -> None:
     # generated testbench embeds it as a pickle blob). After a round trip it must elaborate to a simulator that runs
     # identically to one elaborated from the original handle -- both start from reset and advance their persistent
     # (stateful IIR) registers in step over the same input sequence.
-    handle = generate(build(_run(IIR1LPF().__call__), "iir1_lpf", fetch_stages=3))
+    handle = generate(build_lir(_run(IIR1LPF().__call__), "iir1_lpf"))
     restored = pickle.loads(pickle.dumps(handle)).elaborate()
     fresh = handle.elaborate()
     for v in (1.0, 2.0, 3.0, 4.0, 5.0):
@@ -1450,7 +1482,7 @@ def test_model_boolean_connectives_and_chained_and_ternary_are_exact() -> None:
         clamp = hi if x > hi else (lo if x < lo else x)  # nested ternary
         return (deadband, gate, outside, inverted, clamp)
 
-    model = build_model(build(_run(kernel), "bool_kernel", fetch_stages=3))
+    model = build_model(build_lir(_run(kernel), "bool_kernel"))
     for x in (-2.0, -1.0, 0.0, 0.5, 1.0, 1.5, 2.0):
         got = tuple(float(v) for v in model.run(x, 0.0, 1.0))
         ref = tuple(float(v) for v in evaluate_reference(kernel, {"x": x, "lo": 0.0, "hi": 1.0}))
@@ -1463,7 +1495,7 @@ def test_model_bool_cast_matches_float_nonzero() -> None:
     def kernel(x: float, y: float) -> float:
         return y if bool(x) else 0.0
 
-    model = build_model(build(_run(kernel), "bool_cast", fetch_stages=3))
+    model = build_model(build_lir(_run(kernel), "bool_cast"))
     for x in (0.0, -0.0, 0.5, -0.5, 1.0, -1.0, 123.0, 2.0**-20):
         got = float(model.run(x, 7.0)[0])
         ref = 7.0 if float(FloatValue.from_float(FMT, x)) != 0.0 else 0.0
@@ -1478,7 +1510,7 @@ def test_model_cross_domain_cast_chain_is_exact() -> None:
         cast = float(x < 0.0)  # branch-free bool->float
         return (gate, cast)
 
-    model = build_model(build(_run(kernel), "cross_domain", fetch_stages=3))
+    model = build_model(build_lir(_run(kernel), "cross_domain"))
     for x in (-2.0, -1.0, 0.0, 1.0, 2.0):
         got = tuple(float(v) for v in model.run(x, 5.0))
         ref = tuple(float(v) for v in evaluate_reference(kernel, {"x": x, "k": 5.0}))
@@ -1493,7 +1525,7 @@ def test_model_bool_cast_of_underflowing_constant_folds_at_host_precision() -> N
     def kernel(a: float) -> float:
         return a if bool(2.0**-200) else -a
 
-    model = build_model(build(_run(kernel), "tiny_bool", fetch_stages=3))
+    model = build_model(build_lir(_run(kernel), "tiny_bool"))
     for a in (1.0, -2.0, 3.5):
         assert float(model.run(a)[0]) == a
 
@@ -1518,7 +1550,7 @@ def test_statically_folded_branch_does_not_create_a_phantom_state_slot() -> None
     hir = lower(K().__call__).hir
     assert [slot.name for slot in hir.state_slots] == ["x"]  # y is not a phantom slot
     assert len(hir.blocks) == 1  # the guard folded; no branch
-    model = build_model(build(_run(K().__call__), "phantom_if", fetch_stages=3))
+    model = build_model(build_lir(_run(K().__call__), "phantom_if"))
     assert float(model.run(2.0)[0]) == 2.0
     assert float(model.run(3.0)[0]) == 5.0  # the accumulation is exact in this format
 
@@ -1549,7 +1581,7 @@ def test_a_connective_guard_over_a_runtime_operand_keeps_its_dead_arm_alive() ->
 
     hir = lower(K().__call__).hir
     assert [slot.name for slot in hir.state_slots] == ["x", "y"]
-    model = build_model(build(_run(K().__call__), "connective_if", fetch_stages=3))
+    model = build_model(build_lir(_run(K().__call__), "connective_if"))
     reference = K()
     for u in (2.0, 3.0, -1.0):
         assert float(model.run(u)[0]) == reference(u)  # the phantom slot changes no answer
@@ -1577,7 +1609,7 @@ def test_folded_branch_in_a_loop_body_does_not_carry_a_phantom_attribute() -> No
 
     hir = lower(K().__call__).hir
     assert [slot.name for slot in hir.state_slots] == ["acc"]  # dead is not carried
-    model = build_model(build(_run(K().__call__), "phantom_loop", fetch_stages=3))
+    model = build_model(build_lir(_run(K().__call__), "phantom_loop"))
     assert float(model.run(1.0)[0]) == 3.0
 
 
@@ -1642,7 +1674,7 @@ def test_aliased_slot_with_phi_live_in_builds(monkeypatch: pytest.MonkeyPatch) -
     for cls in (Forward, Reversed):
         model, interpreter = build_model_and_interpreter(cls().__call__, OPS, cls.__name__)
         assert_model_equals_interpreter(model, interpreter, vectors, cls.__name__)
-    build(_run(InputPhi().__call__), "input_phi_alias", fetch_stages=3)  # phi-of-inputs shape must compile
+    build_lir(_run(InputPhi().__call__), "input_phi_alias")  # phi-of-inputs shape must compile
 
 
 def test_polar_example_round_trip_and_native_reference() -> None:
@@ -1650,9 +1682,9 @@ def test_polar_example_round_trip_and_native_reference() -> None:
     # conversion against native math (approximate), and a round trip that must recover the input away from the origin.
     # Operator correctness lives in the scalar suite; this pins only the vector I/O and the two-kernel composition.
     fmt = holoso.FloatFormat(8, 36)
-    ops = default_ops(fmt)
-    to_model = holoso.synthesize(polar.to_polar, ops=ops).numerical_model.elaborate()
-    from_model = holoso.synthesize(polar.from_polar, ops=ops).numerical_model.elaborate()
+    options = default_options(fmt)
+    to_model = holoso.synthesize(polar.to_polar, options).numerical_model.elaborate()
+    from_model = holoso.synthesize(polar.from_polar, options).numerical_model.elaborate()
     rng = np.random.default_rng(0x901A5)
     for _ in range(64):
         x, y = (float(v) for v in rng.uniform(-8.0, 8.0, size=2))

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -85,7 +85,7 @@ def test_equal_temperament_default_sweep_has_no_log2_sidebands() -> None:
 
 
 def _run(target: Callable[..., object]) -> Mir:
-    return lower_to_mir(optimize(lower(target).hir), OPS)
+    return lower_to_mir(optimize(lower(target).hir), OPS, FMT)
 
 
 def test_model_exact_integer_comparison_is_not_folded_via_float() -> None:
@@ -391,7 +391,7 @@ def test_model_uses_exact_ilog2_for_wide_supported_shift() -> None:
             ffmt=fmt,
         )
     )
-    model = build_model(build_lir(lower_to_mir(optimize(lower(f).hir), ops), "f"))
+    model = build_model(build_lir(lower_to_mir(optimize(lower(f).hir), ops, fmt), "f"))
     assert model.run(FloatValue.from_float(fmt, 0.5))[0] == FloatValue.from_float(fmt, 8.0)
 
 
@@ -436,7 +436,7 @@ def test_model_is_bit_exact_for_wide_zkf_multiply_regression() -> None:
             ffmt=fmt,
         )
     )
-    mir = lower_to_mir(optimize(lower(f).hir), ops)
+    mir = lower_to_mir(optimize(lower(f).hir), ops, fmt)
     model = build_model(build_lir(mir, "f"))
     got = model.run(
         FloatValue.from_bits(fmt, 0x42BF30E6505),
@@ -1616,7 +1616,7 @@ def test_folded_branch_in_a_loop_body_does_not_carry_a_phantom_attribute() -> No
 def test_merged_state_slots_preserve_behaviour() -> None:
     # The slot drop must not change behaviour: drive PFD across many transactions and confirm the model still agrees
     # with the schedule-independent MIR interpreter (blind to LIR faults), so the merged state persists correctly.
-    model, interpreter = build_model_and_interpreter(PhaseFrequencyDetector().__call__, OPS, "pfd_merge")
+    model, interpreter = build_model_and_interpreter(PhaseFrequencyDetector().__call__, OPS, "pfd_merge", FMT)
     vectors: list[list[FloatValue | bool]] = [
         [True, False, False],  # reference leads -> up
         [False, False, False],  # hold up
@@ -1672,7 +1672,7 @@ def test_aliased_slot_with_phi_live_in_builds(monkeypatch: pytest.MonkeyPatch) -
 
     vectors: list[list[FloatValue | bool]] = [[True], [False], [True], [True], [False], [False], [True]]
     for cls in (Forward, Reversed):
-        model, interpreter = build_model_and_interpreter(cls().__call__, OPS, cls.__name__)
+        model, interpreter = build_model_and_interpreter(cls().__call__, OPS, cls.__name__, FMT)
         assert_model_equals_interpreter(model, interpreter, vectors, cls.__name__)
     build_lir(_run(InputPhi().__call__), "input_phi_alias")  # phi-of-inputs shape must compile
 

--- a/tools/synth_compare.py
+++ b/tools/synth_compare.py
@@ -35,6 +35,7 @@ from holoso._lir import build  # noqa: E402
 from holoso._mir import lower as lower_to_mir  # noqa: E402
 from synth import build_compiler_ooc_design  # noqa: E402
 from synth.flows import make_flow  # noqa: E402
+from tests._modelref import DEFAULT_FETCH_STAGES, DEFAULT_TUNING, build_ops  # noqa: E402
 from tests._synth_targets import TARGETS  # noqa: E402
 
 # Per-flow resource-primitive names for the LUT/FF/DSP/BRAM report columns; each tool names them differently.
@@ -61,7 +62,12 @@ def capture(out_path: str) -> None:
             "ops": repr(target.ops),
         }
         try:
-            lir = build(lower_to_mir(optimize(lower(target.kernel()).hir), target.ops), target.name, fetch_stages=3)
+            lir = build(
+                lower_to_mir(optimize(lower(target.kernel()).hir), build_ops(target.ops)),
+                target.name,
+                DEFAULT_FETCH_STAGES,
+                DEFAULT_TUNING,
+            )
             row["min_ii"] = lir.min_initiation_interval
             row["last_pc"] = lir.last_pc
             flow = make_flow(target.flow, target.target_frequency_MHz)

--- a/tools/synth_compare.py
+++ b/tools/synth_compare.py
@@ -31,11 +31,11 @@ sys.path.insert(0, str(REPO))
 import holoso  # noqa: E402
 from holoso._eel import lower  # noqa: E402
 from holoso._hir import optimize  # noqa: E402
-from holoso._lir import build  # noqa: E402
+from holoso._lir import RegallocTuning, build  # noqa: E402
 from holoso._mir import lower as lower_to_mir  # noqa: E402
 from synth import build_compiler_ooc_design  # noqa: E402
 from synth.flows import make_flow  # noqa: E402
-from tests._modelref import DEFAULT_FETCH_STAGES, DEFAULT_TUNING, build_ops  # noqa: E402
+from tests._modelref import build_ops  # noqa: E402
 from tests._synth_targets import TARGETS  # noqa: E402
 
 # Per-flow resource-primitive names for the LUT/FF/DSP/BRAM report columns; each tool names them differently.
@@ -59,14 +59,18 @@ def capture(out_path: str) -> None:
             "example": target.example,
             "flow": target.flow.value,
             "target_MHz": target.target_frequency_MHz,
-            "ops": repr(target.ops),
+            "ops": repr(target.ops.operator),
         }
         try:
             lir = build(
-                lower_to_mir(optimize(lower(target.kernel()).hir), build_ops(target.ops)),
+                lower_to_mir(optimize(lower(target.kernel()).hir), build_ops(target.ops), target.ops.ffmt),
                 target.name,
-                DEFAULT_FETCH_STAGES,
-                DEFAULT_TUNING,
+                target.ops.ucode_fetch_stages,
+                RegallocTuning(
+                    effort=target.ops.regalloc_effort,
+                    reuse_write_cap=target.ops.regalloc_reuse_write_cap,
+                    register_price=target.ops.regalloc_register_price,
+                ),
             )
             row["min_ii"] = lir.min_initiation_interval
             row["last_pc"] = lir.last_pc


### PR DESCRIPTION
The public configuration surface becomes a single `Options` dataclass; no hardware operator type is exported anymore.

```python
options = holoso.Options(
    holoso.OperatorOptions(
        fadd=holoso.FAddOptions(stage_decode=1),
        fmul=holoso.FMulOptions(),
        fdiv=holoso.FDivOptions(),
        fmul_ilog2=holoso.FMulILog2Options(),
        fcmp=holoso.FCmpOptions(),
    ),
    ffmt=holoso.FloatFormat(6, 18),
    wmultiplier=18,
)
holoso.synthesize(kernel, options)
```

`Options` carries the float format, the integer width, the DSP width hint, the controller fetch depth, the register-allocator knobs, and one options object per operator. `synthesize` decomposes it at the top and hands each pass its own narrow configuration.

Every operator is optional; there is no mandatory core. An unconfigured operator is not built, and a kernel that needs it is refused at MIR lowering.

The register-allocator knobs (effort, write-select cap, register price) and the fetch depth are real parameters threaded into `_lir` rather than environment reads inside the allocator; the environment overrides survive as the defaults of the corresponding public fields.

`wmultiplier` is newly plumbed through to the six operators whose RTL takes `WMULTIPLIER` (fmul, ffma, fexp2, flog2, fsincos, fatan2); it was previously unreachable from Holoso.

Integer operator knobs (`imul`) are declared in anticipation of integer support -- not added here.