### PR TITLE
Schedule tail installs exactly instead of node-kind-conservatively

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -471,12 +471,13 @@ back-edge is a jump to a lower address; each block's terminator redirects the fe
 for a branch, reads the condition's 1-bit register.
 
 A block's terminator offset is the latest cycle a value still lands in its frame -- it must cover every landing the
-block does not forward to a successor. A tail install costs an extra terminator cycle only when its source is an
-operator result committing at the block's makespan (its own last work, or conservatively any operator result from
-outside the block); a
-resident source (constant, input, state read, phi result) fires at the makespan, read-first at the boundary. A source
-register that a sibling install writes is always a phi's, hence resident, hence read strictly before any sibling's
-write lands -- the invariant that keeps cross-referencing loop-carried phis (a swap) correct. Cross-block software
+block does not forward to a successor, tail installs included. An install's source is classified exactly: a source
+scheduled in the block commits locally, and only the block's own last-committing work pushes the install (and the
+drain) one step past the work makespan; a source arriving as an in-flight spill read-gates the install at its
+landing without a push; and everything else -- constants, inputs, state reads, phis, and foreign results that have
+already landed -- is settled at entry, so the install fires at the makespan, read-first at the boundary. A source
+register that a sibling install writes is always settled, hence read strictly before any sibling's write lands --
+the invariant that keeps cross-referencing loop-carried phis (a swap) correct. Cross-block software
 pipelining then shrinks the terminator offset down to the issue-side envelope -- the latest PC at which the block
 still drives a control word -- whenever the block carries no installs and every successor is single-predecessor, so
 a spill cannot reach a wrong path:

--- a/holoso/__init__.py
+++ b/holoso/__init__.py
@@ -56,5 +56,5 @@ FSqrtOptions = _operators.FSqrtOperator.Options
 FToIntOptions = _operators.FToIntOperator.Options
 IMulOptions = _operators.IMulOperator.Options
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __url__ = "https://holoso.digital"

--- a/holoso/_lir/_bankalloc.py
+++ b/holoso/_lir/_bankalloc.py
@@ -25,7 +25,7 @@ from .._operators import BoolInversion, HardwareOperator, PooledHardwareOperator
 from .._value import WideValue
 from .._util import ValueId
 from ._ir import *
-from ._mir_facts import const_branch_conditions, mir_rpo, phi_arm_out, succ_map, value_resident_at_entry
+from ._mir_facts import const_branch_conditions, mir_rpo, phi_arm_out, succ_map
 from ._liveness import BankLiveness, compute_interference
 from ._schedule import Schedule
 from ._regalloc import Producer, RegallocTuning
@@ -94,44 +94,52 @@ def layout_and_allocate(
     return _LayoutAllocation(overlap, inst_of, instances, consts, const_pool, alloc)
 
 
-def install_source_commit(sched: Schedule, source_node: MirNode, source: ValueId) -> int | None:
+def install_source_commit(
+    sched: Schedule, source: ValueId, inflight: Mapping[ValueId, int], fetch_lag: int
+) -> int | None:
     """
-    A tail install source's commit cycle in the installing block's own frame, None for a block-entry-RESIDENT source --
-    exactly `install_issue_cycle`'s contract. The lone encoding of the residency-to-commit rule, shared by the push
-    classification, the interference residence, and the LIR copy placement, so the three cannot drift apart (a drift
-    here recreates the placement-disagreement class of the phi-swap miscompile).
+    A tail install source's commit cycle in the installing block's own frame, None for a source SETTLED before the
+    block's first step -- exactly `install_issue_cycle`'s contract. A source scheduled in this block commits at its
+    own commit cycle. One spilled in past an overlapped predecessor boundary (`inflight`, the scheduler's own
+    `livein_landing`) is charged the virtual commit whose landing is its carried landing cycle, so the install's fire
+    step cannot precede that landing; the spill bound (a received spill lands at successor-local <= fetch_lag,
+    enforced by the issue-side envelope's word floors) keeps that virtual commit negative, so a spilled source never
+    pushes the install past the work makespan -- asserted, so a future envelope change that breaks the bound fails
+    loudly instead of firing an install before its source lands. Everything else -- a constant, an input, a state
+    read, a phi, or a foreign result already landed -- is settled at entry. The lone encoding of the residency rule,
+    shared by the push classification, the interference residence, and the LIR copy placement, so the three cannot
+    drift apart (a drift here recreates the placement-disagreement class of the phi-swap miscompile).
     """
-    return None if value_resident_at_entry(source_node) else sched.commit_or_makespan(source)
-
-
-def _install_pushes_makespan(sched: Schedule, source_node: MirNode, source: ValueId) -> bool:
-    """
-    Whether a tail install of `source` lands PAST the work makespan -- the per-install +1 drain. True only for a
-    COMPUTED source that is the block's own last-committing work (the install fires one step after to read-first it);
-    an earlier-committing or block-entry-resident source fits at the makespan. Decided through the one
-    `install_issue_cycle` so this classification, the LIR placement, and the interference residence cannot drift.
-    """
-    return install_issue_cycle(sched.makespan, install_source_commit(sched, source_node, source)) > sched.makespan
+    if source in sched.issue_cycle:
+        return sched.commit_cycle(source)
+    landing = inflight.get(source)
+    if landing is not None:
+        commit = landing - fetch_lag - READ_FIRST_EDGE
+        assert commit < 0, f"received spill lands at {landing}, past the fetch lag: the spill bound is broken"
+        return commit
+    return None
 
 
 def actual_install_blocks(
-    alloc: Allocation, wide_mir: MirWideView, bool_mir: MirBoolView, block_sched: Mapping[int, Schedule]
+    alloc: Allocation,
+    block_sched: Mapping[int, Schedule],
+    block_inflight: Mapping[int, Mapping[ValueId, int]],
+    fetch_lag: int,
 ) -> dict[int, bool]:
     """
     The post-coalescing install classification (the refinement `block_has_install` seeds): each block that actually
-    installs at its tail, mapped to whether any of its installs lands past the work makespan -- a computed source that
-    is the block's own last work, so the install must read-first it and the block pays the +1 drain (`True`). An
-    install whose source commits earlier, or is block-entry resident per `value_resident_at_entry` (including the
-    const branch materialization already in `alloc.bool_writes`), fits at the makespan (`False`). How narrowing
-    and regrowth of this classification drive the layout is the caller's protocol (the install fixpoint in the
-    builder).
+    installs at its tail, mapped to whether any of its installs issues past the work makespan, decided through the
+    same `install_source_commit` + `install_issue_cycle` pair as the LIR placement and the interference residence,
+    so the three cannot drift. How narrowing and regrowth of this classification drive the layout is the caller's
+    protocol (the install fixpoint in the builder).
     """
     install: dict[int, bool] = {}
-    for nodes, bank_installs in ((wide_mir.nodes, alloc.wide_copies), (bool_mir.nodes, alloc.bool_writes)):
+    for bank_installs in (alloc.wide_copies, alloc.bool_writes):
         for bid, entries in bank_installs.items():
             sched = block_sched[bid]
             for entry in entries:
-                pushes = _install_pushes_makespan(sched, nodes[entry.source], entry.source)
+                commit = install_source_commit(sched, entry.source, block_inflight[bid], fetch_lag)
+                pushes = install_issue_cycle(sched.makespan, commit) > sched.makespan
                 install[bid] = install.get(bid, False) or pushes
     return install
 
@@ -384,9 +392,9 @@ class _InterferenceBuilder:
     phi_block: dict[ValueId, int]
     arm_out: dict[int, frozenset[ValueId]]
     inflight_defs: dict[int, dict[ValueId, int]]
-    # block -> phi dest -> its arm source's commit cycle in THIS block's frame, None for a block-entry-resident source
-    # (`install_issue_cycle`'s contract), so the interference residence matches the LIR copy's placement and cannot
-    # drift onto a foreign block's frame.
+    # block -> phi dest -> its arm source's commit cycle in THIS block's frame, None for a source settled before the
+    # block's first step (`install_issue_cycle`'s contract), so the interference residence matches the LIR copy's
+    # placement and cannot drift onto a foreign block's frame.
     install_source: dict[int, dict[ValueId, int | None]]
     fetch_lag: int
 
@@ -460,14 +468,14 @@ def _allocate_bank(
     boundary_base = bank.boundary_base(mir, values, ret_block)
 
     # Per block, each phi dest whose arm originates there -> its source's commit cycle in the PREDECESSOR's own frame
-    # (where the install fires, not the source's home block), None for a block-entry-resident source that needs no
-    # read-first sampling. The same rule build and actual_install_blocks apply, so the interference residence cannot
-    # drift onto a foreign block's frame.
+    # (where the install fires, not the source's home block), None for a source settled before the block's first
+    # step. The same rule build and actual_install_blocks apply, so the interference residence cannot drift onto a
+    # foreign block's frame.
     install_source: dict[int, dict[ValueId, int | None]] = {}
     for vid, phi in phi_nodes.items():
         for pred, value, _conditioner in phi.arms:
             install_source.setdefault(pred, {})[vid] = install_source_commit(
-                block_sched[pred], view.nodes[value], value
+                block_sched[pred], value, block_inflight[pred], fetch_lag
             )
 
     interference = _InterferenceBuilder(
@@ -639,7 +647,7 @@ def _allocate(
     Assign wide and boolean registers across the CFG. Both banks are colored by hardware-frame liveness, reusing
     registers across mutually-exclusive and non-overlapping live ranges. A phi is resolved by installing each arm's
     value into the phi's register with a copy at the predecessor's tail; copies sharing a fire step are a parallel
-    (read-then-write) bundle, and placement keeps a swap correct (see `value_resident_at_entry`).
+    (read-then-write) bundle, and placement keeps a swap correct (see `install_issue_cycle`).
     `block_makespan` (install-inclusive) and `block_term_offset` (the drained boundary, or the overlap-shrunk
     terminator) come from the overlap layout, so the liveness boundary matches the laid-out block spans exactly.
     `block_inflight` carries each block's received cross-block spills (split per bank), reserving a spilled value's

--- a/holoso/_lir/_build.py
+++ b/holoso/_lir/_build.py
@@ -136,10 +136,11 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int, tuning: RegallocT
                     f"block {mir_block.id} branches on a phi that takes an arm from the same block; the install "
                     f"would overwrite the condition before the branch reads it"
                 )
-    # The phi-residency classification (`value_resident_at_entry`) rests on every phi-bearing block being
-    # multi-predecessor, which is what keeps overlap spills out of phi registers; a future pass emitting a phi into a
-    # single-predecessor block would silently void that argument (the sibling-install tripwire does not read-gate
-    # installs against in-flight landings), so the reliance is machine-checked here.
+    # The phi-residency premise -- a phi's register settles before any frame that reads it begins, so a phi source
+    # is always settled (`install_source_commit`) -- rests on every phi-bearing block being multi-predecessor, which
+    # is what keeps overlap spills out of phi registers; a future pass emitting a phi into a single-predecessor block
+    # would silently void that argument (the sibling-install tripwire does not read-gate installs against in-flight
+    # landings), so the reliance is machine-checked here.
     pred_edges = pred_count(mir)
     for mir_block in mir.blocks:
         assert (
@@ -149,7 +150,7 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int, tuning: RegallocT
     # Schedule every block in reverse-postorder (a block after its forward-edge predecessors) and lay out each block's
     # terminator offset, with cross-block software pipelining: a block whose successors are all single-predecessor
     # shrinks its terminator below the drained boundary and spills its in-flight results into the successor, which
-    # inherits the busy/landing residue. The +1-install drain keeps install-bearing blocks unshrunk, matching makespan.
+    # inherits the busy/landing residue. The install drain keeps install-bearing blocks unshrunk, matching makespan.
     #
     # The install set is computed to a fixpoint. `block_has_install` marks a block install-bearing from the CFG shape
     # (any phi arm originates in it), but a block whose every arm COALESCES onto the merged register installs nothing,
@@ -181,7 +182,7 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int, tuning: RegallocT
         result = layout_and_allocate(
             mir, wide_mir, bool_mir, pool, has_install_blocks, has_state_copy, fetch_lag, tuning
         )
-        raw = actual_install_blocks(result.alloc, wide_mir, bool_mir, result.overlap.block_sched)
+        raw = actual_install_blocks(result.alloc, result.overlap.block_sched, result.overlap.block_inflight, fetch_lag)
         # The two derivations of install-bearing -- the CFG-shape seed and the post-allocation copies -- must agree on
         # the key universe: a block outside the seed can never install, so a wider `raw` means the derivations
         # drifted, which must fail loudly rather than be absorbed as a silent permanent pin. On the FIRST round the
@@ -262,19 +263,19 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int, tuning: RegallocT
             )
         ]
         work_makespan = sched.makespan
-        # A None commit from `install_source_commit` is a block-entry-resident source needing no read-first
-        # sampling. The placement (`install_issue_cycle`) charges the +1 only for a computed source committing at
-        # the makespan; a resident or earlier-committing computed source pays none.
+        inflight = overlap.block_inflight[block.id]
+        # Placement per install through the one `install_source_commit` + `install_issue_cycle` pair (shared with
+        # the push classification and the interference residence, so the three cannot drift).
         wide_copies = []
         for c in alloc.wide_copies.get(block.id, []):
             src = wide_operand(wide_mir, c.source, c.conditioner, alloc, const_pool)
-            commit = install_source_commit(sched, wide_mir.nodes[c.source], c.source)
+            commit = install_source_commit(sched, c.source, inflight, fetch_lag)
             issue = install_issue_cycle(work_makespan, commit)
             wide_copies.append(WideCopy(RegRef(c.dst), src, issue, commit is None))
         bool_writes = []
         for w in alloc.bool_writes.get(block.id, []):
             bsrc = bool_operand(bool_mir, w.source, alloc, w.inversion)
-            commit = install_source_commit(sched, bool_mir.nodes[w.source], w.source)
+            commit = install_source_commit(sched, w.source, inflight, fetch_lag)
             bool_writes.append(
                 BoolWrite(BoolRegRef(w.dst), bsrc, install_issue_cycle(work_makespan, commit), commit is None)
             )
@@ -302,9 +303,11 @@ def _build_program(mir: Mir, module_name: str, fetch_lag: int, tuning: RegallocT
             landing <= term_offset for landing in install_landings
         ), f"block {block.id}: a phi-arm install lands at {max(install_landings)} past the terminator {term_offset}"
         # A tail install must read its source register strictly before a sibling install's write to that register
-        # lands (see `value_resident_at_entry` for why placement guarantees this): the structural tripwire for a
-        # placement regression, which the value cosim shares with the model and cannot see. Cross-bank pairs are inert
-        # (RegRef never equals BoolRegRef), so one check serves both banks.
+        # lands. Placement guarantees this because a sibling-written source register is always a settled one -- a
+        # non-settled source is live through the boundary (`phi_arm_out`), so interference keeps every sibling install
+        # destination off its register -- and settled installs share one unpushed fire step (`install_issue_cycle`).
+        # The structural tripwire for a placement regression, which the value cosim shares with the model and cannot
+        # see. Cross-bank pairs are inert (RegRef never equals BoolRegRef), so one check serves both banks.
         for writer in installs:
             for reader in installs:
                 if reader.source.source == writer.dst:

--- a/holoso/_lir/_ir.py
+++ b/holoso/_lir/_ir.py
@@ -132,18 +132,18 @@ def install_landing(fire_step: int) -> int:
 
 def install_issue_cycle(work_makespan: int, source_commit: int | None) -> int:
     """
-    The scheduler-frame placement of a block's tail install; `source_commit` is None for a block-entry-RESIDENT
-    source (per `value_resident_at_entry`: a constant, input, state read, or phi result), which needs no read-first
-    sampling. The install sits at the work makespan -- landing read-first at the boundary, after every in-block read,
-    the latest placement (minimal destination residence). It is pushed one step past only when a COMPUTED source
-    commits AT the makespan, which the install must fire after to read-first (`source_commit + READ_FIRST_EDGE` then
-    exceeds the makespan): either the block's own last-committing op, or -- conservatively -- an operator result not
-    scheduled in this block (a possible overlap spill), which the callers pass `source_commit == work_makespan` so
-    the placement never reads off a foreign frame. A resident source and a copy sourcing an EARLIER in-block op stay
-    at the makespan and pay no terminator cycle; keeping phi sources unpushed is load-bearing for the same-step
-    parallel-bundle contract cross-referencing loop-header phis rely on. The per-install dual of
-    `install_inclusive_makespan` (which carries the +1 into the block makespan exactly when an install lands past the
-    makespan), so the placement and the drain agree and an install cannot land past its block's terminator.
+    The scheduler-frame placement of a block's tail install; `source_commit` is None for a SETTLED source (per
+    `install_source_commit`: a constant, input, state read, phi result, or a foreign result already landed), which
+    needs no read-first sampling. The install sits at the work makespan -- landing read-first at the boundary, after
+    every in-block read, the latest placement (minimal destination residence). It is pushed one step past only when
+    a locally COMPUTED source commits AT the makespan, which the install must fire after to read-first
+    (`source_commit + READ_FIRST_EDGE` then exceeds the makespan) -- the block's own last-committing op. A
+    spilled-in source carries a NEGATIVE virtual commit (the inverse of its landing; see `install_source_commit`),
+    so the same `max` places its fire at or after that landing without a push. A settled source and a copy sourcing
+    an EARLIER in-block op stay at the makespan and pay no terminator cycle; keeping them unpushed is load-bearing
+    for the same-step parallel-bundle contract cross-referencing loop-header phis rely on. The per-install dual of
+    `install_inclusive_makespan` (which carries the +1 into the block makespan exactly when an install issues past
+    the work makespan), so the placement and the drain agree and an install cannot land past its block's terminator.
     """
     if source_commit is None:
         return work_makespan
@@ -498,21 +498,18 @@ class BoolOutputWire(OutputWire):
 class WideCopy:
     """
     A pc-gated move installing a phi arm's value into the merged register at a predecessor's tail: `dst`
-    takes `source` on the block-relative `issue_cycle`. Used when a phi arm is not an operator result that can be
-    coalesced directly onto the merged register (e.g. an input, a constant, or a value defined in another block).
-    `resident_source` records whether `source` is available at block entry (`value_resident_at_entry`, which a
-    `RegRef` operand alone cannot reveal) rather than computed -- informational; the placement (`issue_cycle`) is
-    `install_issue_cycle`'s, pushed past the work makespan only for a computed source committing there.
+    takes `source` on the block-relative `issue_cycle` (placed by `install_issue_cycle`). Used when a phi arm
+    cannot coalesce onto the merged register. `settled_source` records whether `install_source_commit` answered
+    None -- which a `RegRef` operand alone cannot reveal -- informational, consumed by tests only.
     """
 
     dst: RegRef
     source: WideOperand
     issue_cycle: int
-    resident_source: bool
+    settled_source: bool
 
     @property
     def is_const(self) -> bool:
-        """A literal-constant install (one kind of resident source); meaningful where the literal itself matters."""
         return isinstance(self.source.source, WideConstRef)
 
     def fire_step(self, fetch_lag: int) -> int:
@@ -526,19 +523,16 @@ class WideCopy:
 class BoolWrite:
     """
     A boolean register install of a phi arm (a bool const or another bool register, with the arm's folded inversion)
-    on a block-relative cycle. `resident_source` records whether `source` is available at block entry
-    (`value_resident_at_entry`) rather than computed -- informational; the placement is `install_issue_cycle`'s
-    (see WideCopy).
+    on a block-relative cycle; see WideCopy.
     """
 
     dst: BoolRegRef
     source: BoolOperand
     issue_cycle: int
-    resident_source: bool
+    settled_source: bool
 
     @property
     def is_const(self) -> bool:
-        """A literal-constant install (one kind of resident source); meaningful where the literal itself matters."""
         return isinstance(self.source.source, BoolConstRef)
 
     def fire_step(self, fetch_lag: int) -> int:
@@ -589,7 +583,7 @@ class LirBlock:
     the block (0 if it has none). `term_offset` is the block-relative fetch cycle at which the terminator redirects
     the PC -- the block's boundary step -- and is the single source of truth for the terminator PC (the successor
     frame begins one step later, at `term_pc + 1`). For a block that drains (a multi-predecessor successor or a
-    phi/const install) it is the latest cycle a value LANDS in the block's frame -- taken per landing event (every
+    tail install) it is the latest cycle a value LANDS in the block's frame -- taken per landing event (every
     result, pooled or inline, wide or boolean, lands at the one bank-independent `landing_cycle`) -- but cross-block
     software pipelining shrinks it to the issue-side envelope when the block's in-flight results may spill into
     single-predecessor successors -- so a consumer reads it here rather than re-deriving the boundary.
@@ -1069,8 +1063,8 @@ class Lir:
         an early non-coalesced slot writeback) fires and samples its source on the copy step but lands its destination
         one PC later via `install_landing` -- the same +1 the model commits. A boundary install reads-then-writes
         at the boundary and lands there. Residence is then resolved per basic block by `_cfg_residence` (CFG-aware
-        register liveness), so a value live on two mutually-exclusive arms that rejoin at a merge stays resident on BOTH
-        arms. The result is cycle-exact to the numerical model on every register and every path.
+        register liveness), so a value live on two mutually-exclusive arms that rejoin at a merge stays resident on
+        BOTH arms. The result is cycle-exact to the numerical model on every register and every path.
         """
         present = self.initiation_interval  # hardware-frame present / boundary step
         defs: dict[RegRef, list[int]] = {}
@@ -1125,8 +1119,8 @@ class Lir:
         boundary where a slot's live-out must persist for the next initiation. A boolean result that spills past an
         overlap-shrunk terminator is stamped on every successor arm via `write_landing_pcs`, exactly as the numerical
         model re-keys it; a phi/boolean write lands its destination one PC after its fire step via `install_landing`
-        (the model's +1), while a boolean slot always installs read-first at the boundary. Residence is resolved by the
-        same per-block `_cfg_residence` as reg_liveness, so a spilled or merged boolean is cycle-exact too.
+        (the model's +1), while a boolean slot always installs read-first at the boundary. Residence is resolved by
+        the same per-block `_cfg_residence` as reg_liveness, so a spilled or merged boolean is cycle-exact too.
         """
         present = self.initiation_interval
         defs: dict[BoolRegRef, list[int]] = {}

--- a/holoso/_lir/_layout.py
+++ b/holoso/_lir/_layout.py
@@ -35,12 +35,10 @@ def _value_word_and_landing(mir: Mir, vid: ValueId, issue: int, fetch_lag: int) 
 
 def install_inclusive_makespan(work_makespan: int, install_pushes_makespan: bool) -> int:
     """
-    The block makespan inclusive of its tail install: a block whose install lands PAST the work makespan is one higher.
-    That happens only for a computed source that is the block's own last-committing work, which the install must fire
-    one step after to read-first it. A tail whose every install fits at the makespan -- a block-entry-resident source,
-    or a computed source committing before the last work -- adds no step. The single owner of this `+1` so the overlap
-    layout's boundary derivation and the per-block LirBlock makespan cannot disagree on it (the dual of the per-install
-    `install_issue_cycle`).
+    The block makespan inclusive of its tail install: one higher for a block whose install issues past the work
+    makespan (a source that is the block's own last-committing work; see `install_issue_cycle`, this function's
+    per-install dual). The single owner of this `+1` so the overlap layout's boundary derivation and the per-block
+    LirBlock makespan cannot disagree on it.
     """
     return work_makespan + (1 if install_pushes_makespan else 0)
 
@@ -163,23 +161,19 @@ def schedule_with_overlap(
         overlaps = bool(targets) and not has_install and all(preds[target] == 1 for target in targets)
         # The drained boundary is the latest cycle a value LANDS in this block's frame, taken per op -- a pooled result
         # and an inline result both write the array combinationally and land at the same bank-independent cycle. Three
-        # landings are INVISIBLE to the op schedule and are added explicitly: (1) a phi tail install -- one whose source
-        # is the block's own LAST work lands a step past it at the drain boundary `boundary_step(makespan)` (the
-        # makespan install-inclusive), while an install fitting at the makespan (a resident source, or a computed
-        # source committing before the last work) lands at `landing_cycle(sched.makespan)` within the work
-        # boundary, paying neither the +1 step nor the later drain; (2) a NON-coalesced state slot's read-first boundary
-        # copy lands at `boundary_step(sched.makespan)` -- its source is among the op landings, but the copy adds the
-        # fetch-pipeline; `has_state_copy` flags whether the lone Ret block has one, decided by the coalescing
+        # landings are INVISIBLE to the op schedule and are added explicitly: (1) a phi tail install lands read-first at
+        # `boundary_step(makespan)`, the makespan install-inclusive (one past the work makespan only when a source is
+        # the block's own last work; see `install_issue_cycle`); (2) a NON-coalesced state slot's read-first
+        # boundary copy lands at `boundary_step(sched.makespan)` -- its source is among the op landings, but the copy
+        # adds the fetch-pipeline; `has_state_copy` flags whether the lone Ret block has one, decided by the coalescing
         # fixpoint -- a coalesced slot writes its register in place and needs no copy, so the charge usually clears
         # (the fixpoint may latch it back on); (3) the entry's input loads land on cycle 1.
         work_drain = max(
             (_value_word_and_landing(mir, vid, issue, fetch_lag)[1] for vid, issue in sched.issue_cycle.items()),
             default=0,
         )
-        if install_pushes_makespan:
+        if has_install:
             work_drain = max(work_drain, boundary_step(makespan, fetch_lag))
-        elif has_install:
-            work_drain = max(work_drain, landing_cycle(sched.makespan, fetch_lag))
         if bid == mir.ret_block and has_state_copy:
             work_drain = max(work_drain, boundary_step(sched.makespan, fetch_lag))
         if bid == mir.entry:

--- a/holoso/_lir/_liveness.py
+++ b/holoso/_lir/_liveness.py
@@ -67,10 +67,9 @@ class BankLiveness:
     reads: dict[int, list[tuple[ValueId, int]]] = field(default_factory=dict)  # block -> [(value, read cycle)]
     boundary_users: dict[int, frozenset[ValueId]] = field(default_factory=dict)  # block -> boundary-read values
     arm_out: dict[int, frozenset[ValueId]] = field(default_factory=dict)  # block -> phi-arm values live out of it
-    # block -> {phi dest installed at its tail: the install's block-local FIRE step}. The fire step is per install, not
-    # per block: a computed-source copy fires at its copy step, an install of a block-entry-resident source
-    # (`value_resident_at_entry`) one read-first edge earlier, so its destination register is occupied from the true
-    # (earlier) write cycle and a tenant cannot be clobbered.
+    # block -> {phi dest installed at its tail: the install's block-local FIRE step}. The fire step is per install,
+    # not per block (`install_issue_cycle`), so the destination register is occupied from the true (earliest) write
+    # cycle and a tenant cannot be clobbered.
     installs: dict[int, dict[ValueId, int]] = field(default_factory=dict)
     # Cross-block overlap: per block, a predecessor value whose in-flight write SPILLS past the predecessor's shrunk
     # terminator and lands in THIS block, mapped to its block-local landing cycle. The spilled write fires

--- a/holoso/_lir/_mir_facts.py
+++ b/holoso/_lir/_mir_facts.py
@@ -9,14 +9,10 @@ from .._mir import (
     Mir,
     MirBoolView,
     MirBranch,
-    MirConst,
-    MirInput,
     MirJump,
-    MirNode,
     MirOperation,
     MirPhi,
     MirRet,
-    MirStateRead,
     MirWideView,
 )
 from .._util import ValueId
@@ -26,27 +22,6 @@ def mir_operation(mir: Mir, vid: ValueId) -> MirOperation:
     node = mir.nodes[vid]
     assert isinstance(node, MirOperation)
     return node
-
-
-def value_resident_at_entry(node: MirNode) -> bool:
-    """
-    Whether a value is resident in its register from a block's first step rather than produced by the block's own work:
-    a literal constant, an input load, a persistent-state read, or a phi result. A phi is entry-resident in any
-    frontend-generated (well-formed, dominance-respecting) MIR: its register settles before any frame that reads it
-    begins -- install-bearing predecessors drain rather than overlap, multi-predecessor blocks receive no spills, and a
-    phi is never itself an in-flight spill. Residency decides a tail install's PLACEMENT (`install_issue_cycle`):
-    every resident-source install sits AT the work makespan, so installs that read each other's registers (the
-    cross-referencing loop-header phis of `a, b = b, a + x`) share one fire step, where both backends resolve them as
-    a read-then-write parallel bundle; classifying a phi as computed instead pushes its install one step past its
-    siblings, which then read an already-overwritten source. An operator result stays NOT entry-resident: locally it
-    genuinely lands mid/late-block, and a foreign one may arrive as an overlap spill; its conservative pushed placement
-    is harmless because an operator-result source is live through the boundary (`phi_arm_out`), so interference keeps
-    every sibling install destination off its register. The lone source of this residency fact, shared by the install
-    seed, the post-coalescing refinement, the builder, and the allocator residence, so they cannot drift. The positive
-    test means a future node kind defaults to non-resident -- the safe direction (the conservative computed-source
-    treatment).
-    """
-    return isinstance(node, (MirConst, MirInput, MirStateRead, MirPhi))
 
 
 def succ_map(mir: Mir) -> dict[int, list[int]]:
@@ -130,23 +105,21 @@ def const_branch_conditions(mir: Mir, bool_mir: MirBoolView) -> dict[int, ValueI
 
 def block_has_install(mir: Mir, wide_mir: MirWideView, bool_mir: MirBoolView) -> dict[int, bool]:
     """
-    Each install-bearing block mapped to whether it carries a COMPUTED-source install -- a wide copy or a bool write
-    whose source is an operator result rather than block-entry RESIDENT (a literal constant, including a phi-arm const
-    arm or a const branch condition, an input, a state read, or a phi result). This is the
-    CONSERVATIVE seed for the makespan +1: a computed source MIGHT be the block's own last work, which the install must
-    fire one step past to read-first (pushing the makespan); the fixpoint's `actual_install_blocks` narrows it to the
-    blocks that actually push, once the schedule is known. Determinable from the MIR shape before register assignment
-    (`value_resident_at_entry`), conservatively: an arm is assumed not to coalesce, so a computed-source arm marks the
-    block even if it later coalesces away (the fixpoint then narrows it). The liveness boundary and the layout share
-    this classification so the per-block makespan and drain agree.
+    Each install-bearing block mapped to whether it carries an install whose source is the block's OWN operation --
+    the only source kind that can commit at the work makespan and push the install one step past it
+    (`install_issue_cycle`); everything else (a constant, including a const branch condition, an input, a state
+    read, a phi, or a value computed in another block) never pushes. This is the CONSERVATIVE seed for that +1: an
+    arm is assumed not to coalesce, so a local-source arm marks its block even if it later coalesces away, and the
+    fixpoint's `actual_install_blocks` narrows the bit to the blocks whose source really is the last work, once the
+    schedule is known. The liveness boundary and the layout share this classification so the per-block makespan and
+    drain agree.
     """
+    local_ops = {block.id: set(block.operations) for block in mir.blocks}
     install: dict[int, bool] = {}
-    for phi in wide_mir.phi_nodes.values():
-        for pred, value, _conditioner in phi.arms:
-            install[pred] = install.get(pred, False) or not value_resident_at_entry(wide_mir.nodes[value])
-    for phi in bool_mir.phi_nodes.values():
-        for pred, value, _conditioner in phi.arms:
-            install[pred] = install.get(pred, False) or not value_resident_at_entry(bool_mir.nodes[value])
+    for phi_nodes in (wide_mir.phi_nodes, bool_mir.phi_nodes):
+        for phi in phi_nodes.values():
+            for pred, value, _conditioner in phi.arms:
+                install[pred] = install.get(pred, False) or value in local_ops[pred]
     for block_id in const_branch_conditions(mir, bool_mir):
-        install.setdefault(block_id, False)  # a const branch materializes a literal: a resident source, never pushing
+        install.setdefault(block_id, False)  # a const branch materializes a literal: a settled source, never pushing
     return install

--- a/holoso/_lir/_schedule.py
+++ b/holoso/_lir/_schedule.py
@@ -53,17 +53,6 @@ class Schedule:
     def commit_cycle(self, vid: ValueId) -> int:
         return self.issue_cycle[vid] + self.latency[vid]
 
-    def commit_or_makespan(self, vid: ValueId) -> int:
-        """
-        A tail install's source commit as seen from the install's own (predecessor) block: `vid`'s commit if it is
-        scheduled here, else this block's makespan. A source with no local commit -- a block-entry-resident value, a
-        phi, or a value computed in another block -- falls back to the makespan; a resident install then stays at the
-        makespan while a computed one (coincident with the makespan) is pushed one step past it. The single rule the
-        LIR copy, the interference residence, and the makespan classification share, so the install's placement cannot
-        drift onto a foreign block's coordinate frame.
-        """
-        return self.commit_cycle(vid) if vid in self.issue_cycle else self.makespan
-
 
 def _op(nodes: dict[ValueId, MirNode], vid: ValueId) -> MirOperation:
     node = nodes[vid]

--- a/tests/_modelref.py
+++ b/tests/_modelref.py
@@ -282,6 +282,13 @@ def fcmp_s1_options(fmt: FloatFormat) -> Options:
     return dataclasses.replace(options, operator=operator)
 
 
+def staged_fadd_options(fmt: FloatFormat) -> Options:
+    """The default config with only the adder's decode stage raised, guaranteeing an fadd latency of at least 2."""
+    options = default_options(fmt)
+    operator = dataclasses.replace(options.operator, fadd=FAddOptions(stage_decode=1))
+    return dataclasses.replace(options, operator=operator)
+
+
 def fcmp_s1_mir(fmt: FloatFormat) -> MirOptions:
     return mir_options(fcmp_s1_options(fmt))
 
@@ -554,7 +561,7 @@ def bool_phi_swap_computed_loop(x: bool, n: float) -> tuple[bool, bool]:
 def branchy_swap_mixed_arm_loop(x: float, d: float, n: float) -> tuple[float, float]:
     """
     A loop whose header phis mix arm kinds across a real in-body branch (the unspeculatable division keeps it a
-    branch): one diamond arm carries computed values, the other a phi-sourced pair. Once phi sources are resident, a
+    branch): one diamond arm carries computed values, the other a phi-sourced pair. Phi sources being settled, a
     block's push classification narrows after its computed arm coalesces, and the next allocation round's coalescing
     holds that arm TRANSIENTLY de-coalesced -- its install past the shortened boundary -- so this kernel pins that the
     interference residence tolerates the transient (the failure mode is a loud residence assert at build time, not a

--- a/tests/_synth_targets.py
+++ b/tests/_synth_targets.py
@@ -570,11 +570,13 @@ TARGETS: list[SynthTarget] = [
     # imu_fusion: the fusion capstone -- three norm/rsqrt chains (fsqrt/fdiv, one feeding the coarse alignment), the
     # sorter-backed clamp, and real gate branches over the heaviest register pressure in the matrix, in the plain and
     # the ffma-contracted datapaths. The native root retired the wall these rows used to close against (the flog2
-    # Horner pmul), and the three plain rows plus the ffma Vivado row keep closing on their old datapath knobs. The
-    # two ffma ECP5 rows each needed one more stage once that wall left. On yosys the deepest path is now the
-    # sorter's compare cone entered straight off the register file, which fsort stage_input splits; on diamond it is
-    # the fadd normalize/pack tail into the register file, which fadd stage_pack splits -- and that row's fadd
-    # stage_output stays, since removing it only exposes the same tail one stage earlier.
+    # Horner pmul); the two ffma ECP5 rows each needed one more stage once that wall left. On yosys the deepest path
+    # is the sorter's compare cone entered straight off the register file, which fsort stage_input splits; on diamond
+    # it is the fadd normalize/pack tail into the register file, which fadd stage_pack splits -- and the plain
+    # diamond row's fadd stage_output stays, since removing it only exposes the same tail one stage earlier. The
+    # exact install scheduling shifted the plain diamond and ffma Vivado rows a hair under their fences (12 and
+    # 19 ps): the diamond miss was a lone controller clock-enable route, re-closed by splitting the fadd pack tail;
+    # the Vivado miss was the fadd subtract-normalize cone, which fadd stage_normalize splits.
     for_example(
         "imu_fusion",
         FlowId.YOSYS_ECP5,
@@ -595,7 +597,7 @@ TARGETS: list[SynthTarget] = [
         100,
         op_config(
             F_e6m18,
-            fadd=FAddOptions(stage_input=1, stage_normalize=1, stage_output=1),
+            fadd=FAddOptions(stage_input=1, stage_normalize=1, stage_pack=1, stage_output=1),
             fmul=FMulOptions(stage_input=1, stage_pack=1),
             fmul_ilog2=FMulILog2Options(stage_input=1),
             fsqrt=FSqrtOptions(),
@@ -655,7 +657,7 @@ TARGETS: list[SynthTarget] = [
         150,
         op_config(
             F_e6m18,
-            fadd=FAddOptions(stage_output=1),
+            fadd=FAddOptions(stage_normalize=1, stage_output=1),
             fmul=FMulOptions(stage_input=1, stage_pack=1),
             fsqrt=FSqrtOptions(),
             fsort=FSortOptions(),

--- a/tests/test_install_landing.py
+++ b/tests/test_install_landing.py
@@ -16,12 +16,14 @@ import pytest
 import holoso
 from holoso import FloatFormat, FloatValue
 from holoso._eel import lower as lower_frontend
-from holoso._lir import BoolWrite, InlineScheduledOp, Lir, LirBlock, PooledScheduledOp, WideCopy
+from holoso._lir import boundary_step, landing_cycle
+from holoso._lir import BoolWrite, InlineScheduledOp, Lir, LirBlock, PooledScheduledOp, RegRef, WideCopy
 from holoso._mir import lower as lower_to_mir
 
 from ._examples import SPECS, ExampleSpec
 from ._modelref import (
     assert_model_equals_interpreter,
+    staged_fadd_options,
     build_lir,
     build_model_and_interpreter,
     mir_options,
@@ -65,10 +67,10 @@ def test_phi_arm_installs_land_within_their_block(spec: ExampleSpec) -> None:
 def test_targets_still_exercise_constant_installs(name: str) -> None:
     """
     uart_rx and uart_tx are kernels behind this work: their boolean live-outs ({b3,b4,b5} <- False, True on a
-    parity/frame error) and other arms install literal constants with no source to sample, so they fire inline-class and
-    land one cycle earlier than a computed-source copy. Pin that these kernels still emit constant phi-arm installs, so
-    a kernel-shape change cannot quietly make the recovered-cycle freezes meaningless. The inline-class timing itself is
-    pinned end-to-end -- by those frozen lengths (uart_rx 51, uart_tx 37 in test_latency_freeze), by the
+    parity/frame error) and other arms install literal constants with no source to sample, so they fire at the work
+    makespan with no read-first push. Pin that these kernels still emit constant phi-arm installs, so a kernel-shape
+    change cannot quietly make the recovered-cycle freezes meaningless. The settled timing itself is pinned
+    end-to-end -- by those frozen lengths (uart_rx 51, uart_tx 37 in test_latency_freeze), by the
     landing <= terminator structural invariant above, and by RTL cosim -- not by re-deriving the install's own helpers.
     """
     spec = next(s for s in SPECS if s.name == name)
@@ -79,9 +81,9 @@ def test_targets_still_exercise_constant_installs(name: str) -> None:
 
 class _InputArmSource:
     """
-    A phi arm that passes an INPUT through: `b` is resident at block entry, so the install is inline-class, and
-    `b` is read past the merge so the arm cannot coalesce. Dedicated rather than probed off a bundled example,
-    whose shape may drift.
+    A phi arm that passes an INPUT through: `b` is settled at block entry, so the install needs no read-first
+    sampling, and `b` is read past the merge so the arm cannot coalesce. Dedicated rather than probed off a bundled
+    example, whose shape may drift.
     """
 
     def __call__(self, c: bool, a: float, b: float) -> float:
@@ -92,13 +94,13 @@ class _InputArmSource:
         return y * b
 
 
-def test_resident_register_source_install_is_inline_class() -> None:
+def test_input_sourced_install_is_settled() -> None:
     """
     The generalization beyond literal constants: a register source resident at block entry has nothing to
-    read-first, so the install is classified inline-class (`resident_source`) and fires one cycle earlier than a
-    computed-source copy -- exactly like a constant. Pin that an INPUT-sourced install is present and so classified,
-    matched by its source register against the input loads -- phi-sourced installs are also resident, so a
-    resident-and-non-const filter alone could pass through a phi while the input path regressed. Constant,
+    read-first, so the install is classified settled (`settled_source`) and fires at the work makespan with no
+    read-first push -- exactly like a constant. Pin that an INPUT-sourced install is present and so classified,
+    matched by its source register against the input loads -- phi-sourced installs are also settled, so a
+    settled-and-non-const filter alone could pass through a phi while the input path regressed. Constant,
     input-register, and state-read installs are three distinct mechanisms; the other two have their own pins.
     """
     fmt = FloatFormat(8, 36)
@@ -111,23 +113,22 @@ def test_resident_register_source_install_is_inline_class() -> None:
         x
         for b in lir.blocks
         for x in _phi_arm_installs(b)
-        if x.resident_source and not x.is_const and x.source.source in input_regs
+        if x.settled_source and not x.is_const and x.source.source in input_regs
     ]
-    assert input_sourced, "the input-sourced resident install is gone, or the predicate regressed"
+    assert input_sourced, "the input-sourced settled install is gone, or the predicate regressed"
 
 
 def test_computed_copy_not_last_work_fits_at_work_makespan() -> None:
     """
     A computed-source phi-arm copy whose source is NOT the block's last-committing work installs at the work makespan
     (landing read-first at the boundary), not one step past it. recip_newton's loop body is the canonical case: the
-    copy y <- y_next sources y_next, while delta = y_next - y is the block's last work, so the conservative pin used to
-    charge a terminator cycle per iteration. Assert the block makespan now equals the work makespan (no +1) -- this
-    fails with the old `work_makespan + 1` pin -- with read-first/value correctness pinned by the example-reference
-    and cosim suites. (Here y_next feeds the later delta, so it is not the block's last work; install_issue_cycle's
-    in-block +1 still triggers for a copy whose source IS the last work -- a shape this kernel does not exercise.)
+    copy y <- y_next sources y_next, while delta = y_next - y is the block's last work. Assert the block makespan
+    equals the work makespan (no +1), with read-first/value correctness pinned by the example-reference and cosim
+    suites. (y_next feeds the later delta, so it is not the block's last work; install_issue_cycle's in-block +1
+    triggers only for a copy whose source IS the last work, pinned below.)
     """
     lir = _build(next(s for s in SPECS if s.name == "recip_newton"))
-    bodies = [b for b in lir.blocks if any(not c.resident_source for c in b.wide_copies)]
+    bodies = [b for b in lir.blocks if any(not c.settled_source for c in b.wide_copies)]
     assert bodies, "recip_newton no longer has a computed-source phi-arm copy; the kernel shape changed"
     for b in bodies:
         work = max((op.commit_cycle for op in _block_ops(b)), default=0)
@@ -142,7 +143,7 @@ class _HoldOrUpdateBool:
     """
     A boolean state held on one arm and updated on the other: `out` takes the STATE READ `self.s` when `c` is
     false and `a and b` when true. No bundled example installs a state read as a phi arm, so this pins the third
-    entry-resident source kind (after constants and inputs).
+    settled source kind (after constants and inputs).
     """
 
     def __init__(self) -> None:
@@ -156,12 +157,12 @@ class _HoldOrUpdateBool:
         return out, self.s
 
 
-def test_state_read_sourced_install_is_inline_class() -> None:
+def test_state_read_sourced_install_is_settled() -> None:
     """
-    A phi arm that is a STATE READ is resident at block entry (the slot register holds it from the start), so its tail
-    install is inline-class -- the generalization's third source kind. A zero if-conversion budget keeps the diamond a
-    real branch, so the hold arm installs `self.s` by a pc-gated bool write rather than collapsing to a select.
-    Pin both that the install is so classified (a non-const resident-source bool write) and -- the black-box teeth --
+    A phi arm that is a STATE READ is resident at block entry (the slot register holds it from the start), so its
+    tail install is settled -- the generalization's third source kind. A zero if-conversion budget keeps the diamond
+    a real branch, so the hold arm installs `self.s` by a pc-gated bool write rather than collapsing to a select.
+    Pin both that the install is so classified (a non-const settled bool write) and -- the black-box teeth --
     that the held value is the OLD state across a hold/update sweep, which an early-read or clobbered state-read
     install would corrupt (the model vs a fresh Python reference, schedule-independent).
     """
@@ -170,8 +171,8 @@ def test_state_read_sourced_install_is_inline_class() -> None:
         lower_to_mir(lower_frontend(_HoldOrUpdateBool().__call__, DEFAULT_UNROLL_MAX_TRIPS).hir, mir_options(options)),
         "hold_or_update_bool",
     )
-    resident_non_const = [x for b in lir.blocks for x in b.bool_writes if x.resident_source and not x.is_const]
-    assert resident_non_const, "the state-read phi arm did not install as a resident-source bool write"
+    settled_non_const = [x for b in lir.blocks for x in b.bool_writes if x.settled_source and not x.is_const]
+    assert settled_non_const, "the state-read phi arm did not install as a settled bool write"
 
     model = holoso.synthesize(
         _HoldOrUpdateBool().__call__, options, name="hold_or_update_bool"
@@ -183,10 +184,10 @@ def test_state_read_sourced_install_is_inline_class() -> None:
 
 class _LiveThroughArm:
     """
-    A non-coalesced phi arm whose source is computed in ANOTHER block: a deep entry chain `x` feeds the pass-through
-    `else` arm, and `x` is used past the merge so it interferes with the phi and the arm cannot coalesce. No bundled
-    example has this cross-block-source shape; it exists to pin that such an install's interference residence is placed
-    in the install's own predecessor frame, not the source's defining-block frame.
+    A non-coalesced phi arm whose source SPILLS IN: the overlapping entry's deep chain keeps `x` in flight past the
+    entry's shrunk terminator, so it lands inside the pass-through `else` arm's own frame; `x` is used past the
+    merge so it interferes with the phi and the arm cannot coalesce. No bundled example has this in-flight-source
+    shape.
     """
 
     def __call__(self, c: bool, a: float, b: float) -> float:
@@ -202,14 +203,16 @@ class _LiveThroughArm:
         return y * x  # x is used past the merge, so it interferes with y's phi and the arm does not coalesce
 
 
-def test_cross_block_source_install_residence_stays_in_predecessor_frame() -> None:
+def test_cross_block_source_install_read_gates_on_the_spilled_landing() -> None:
     """
-    The interference residence of a non-coalesced phi-arm install is placed in the install's own predecessor frame, not
-    the source's defining-block frame. The deep entry chain makes the two frames diverge, so this drives a cross-block-
-    source install through the build's `_install_fire` residence assert (keeping that assert live) and pins value
-    correctness via the schedule-independent model-vs-interpreter differential below. Reintroducing the foreign frame --
-    reading the source's home-block commit instead of the predecessor's `commit_or_makespan` -- makes the modeled
-    install land far past the predecessor's terminator, and the assert raises (verified by injecting that lookup).
+    The directed pin for an install whose source arrives as an IN-FLIGHT SPILL: the overlapping entry's deep chain
+    spills `x` past its shrunk terminator, landing at the pass-through arm's local step 1, and the arm's install
+    sources it. The classification must be exact -- in-flight (not settled), read-gated at the spilled landing, and
+    NOT pushed past the work makespan (the virtual commit is negative, so the install issues at the makespan and its
+    fire strictly follows the landing here; the fire == landing equality boundary has its own shape elsewhere).
+    Value correctness rides the schedule-independent model-vs-interpreter differential below; the interference
+    residence shares the same single `install_source_commit`, so the placement pinned here is also the residence's
+    frame.
     """
     fmt = FloatFormat(8, 36)
     ops = default_mir(fmt)
@@ -217,13 +220,15 @@ def test_cross_block_source_install_residence_stays_in_predecessor_frame() -> No
     lir = build_lir(
         lower_to_mir(lower_frontend(kernel, DEFAULT_UNROLL_MAX_TRIPS).hir, ops),
         "live_through_arm",
-    )  # raises on the off-frame drift
-    cross = [c for blk in lir.blocks for c in blk.wide_copies if not c.resident_source]
-    assert cross, "the kernel no longer exercises a non-coalesced cross-block-source install; the shape changed"
+    )
+    cross = [(blk, c) for blk in lir.blocks for c in blk.wide_copies if not c.settled_source and not _block_ops(blk)]
+    assert cross, "the kernel no longer exercises an in-flight-source install in an op-less arm; the shape changed"
+    for blk, c in cross:
+        assert c.issue_cycle == 0, "an in-flight source must not push the install past the (empty) work makespan"
+        assert c.landing(lir.fetch_lag) == blk.term_offset, "the install lands read-first at the drained boundary"
     for blk in lir.blocks:
         assert all(c.landing(lir.fetch_lag) <= blk.term_offset for c in blk.wide_copies)
 
-    fmt = FloatFormat(8, 36)
     model, interpreter = build_model_and_interpreter(kernel, ops, "live_through_arm", fmt)
     vectors: list[Vector] = [
         [c, FloatValue.from_float(fmt, a), FloatValue.from_float(fmt, b)]
@@ -259,8 +264,9 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
     The dual of `test_computed_copy_not_last_work_fits_at_work_makespan`: when a non-coalesced copy's source IS the
     block's last-committing work, the install must read-first one step past it, so the block makespan is the work
     makespan + 1. This pins install_issue_cycle's in-block +1 branch -- load-bearing but reached by no bundled example,
-    so a later change cannot silently drop it (miscompiling this shape) without failing here. Value correctness is held
-    by the schedule-independent model-vs-interpreter differential.
+    so a later change cannot silently drop it (miscompiling this shape) without failing here. The pushed install's
+    landing is one step past the work landing, so the block drains one terminator cycle later. Value correctness is
+    held by the schedule-independent model-vs-interpreter differential.
     """
     fmt = FloatFormat(8, 36)
     ops = default_mir(fmt)
@@ -272,10 +278,12 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
     pushed = [
         blk
         for blk in lir.blocks
-        if any(not c.resident_source for c in blk.wide_copies)
+        if any(not c.settled_source for c in blk.wide_copies)
         and blk.block_makespan == max((op.commit_cycle for op in _block_ops(blk)), default=0) + 1
     ]
     assert pushed, "no block takes the in-block +1 for a last-work copy source; the kernel shape changed"
+    for blk in pushed:
+        assert blk.term_offset == boundary_step(blk.block_makespan, lir.fetch_lag), "the push drains one step later"
     for blk in lir.blocks:
         assert all(c.landing(lir.fetch_lag) <= blk.term_offset for c in blk.wide_copies)
 
@@ -288,3 +296,86 @@ def test_computed_copy_at_last_work_takes_the_terminator_cycle() -> None:
         for b in (3.0, 1.5, 4.0, 0.25)
     ]
     assert_model_equals_interpreter(model, interpreter, vectors, "last_work_arm")
+
+
+class _DrainedForeignArm:
+    """
+    A pass-through arm whose source is computed in the ENTRY and fully lands inside the entry's own frame (the
+    entry's long tail keeps its terminator past the early product's landing), so the source is SETTLED at the arm --
+    the imu_fusion `valid == False` shape. A node-kind classification would call any foreign operator result a
+    possible in-flight spill and push the install past the (empty) work makespan, stretching the arm by a cycle.
+    """
+
+    def __call__(self, c: bool, a: float, b: float) -> tuple[float, float]:
+        x = a * b
+        z = ((x + a) * b + a) * b
+        if c:
+            y = a / b
+        else:
+            y = x
+        return y * b, z + x  # x stays live past the merge, so the pass-through arm cannot coalesce
+
+
+def test_drained_foreign_source_install_is_settled() -> None:
+    fmt = FloatFormat(8, 36)
+    ops = default_mir(fmt)
+    kernel = _DrainedForeignArm().__call__
+    lir = build_lir(lower_to_mir(lower_frontend(kernel, DEFAULT_UNROLL_MAX_TRIPS).hir, ops), "drained_foreign_arm")
+    input_regs = {load.dst for load in lir.inputs}
+    arms = [
+        (b, c)
+        for b in lir.blocks
+        if not _block_ops(b)
+        for c in b.wide_copies
+        if isinstance(c.source.source, RegRef) and c.source.source not in input_regs and not c.is_const
+    ]
+    assert arms, "the foreign-op-sourced pass-through install is gone; the kernel shape changed"
+    for blk, copy in arms:
+        assert copy.settled_source, "a fully landed foreign source must be classified settled"
+        assert copy.issue_cycle == 0, "a settled source must not push the install past the empty work makespan"
+        assert blk.term_offset == landing_cycle(0, lir.fetch_lag), "the block drains at the unpushed landing"
+
+    model, interpreter = build_model_and_interpreter(kernel, ops, "drained_foreign_arm", fmt)
+    vectors: list[Vector] = [
+        [c, FloatValue.from_float(fmt, a), FloatValue.from_float(fmt, b)]
+        for c in (True, False)
+        for a in (2.0, -1.5, 0.5)
+        for b in (3.0, 1.5, 0.25)
+    ]
+    assert_model_equals_interpreter(model, interpreter, vectors, "drained_foreign_arm")
+
+
+class _InflightEquality:
+    """
+    The public-API twin of the equality-boundary structural pin (test_schedule): with the staged fadd as the entry's
+    last op, its result spills at successor-local fetch_lag and the pass-through arm's install fires exactly AT that
+    landing. The cosim below verifies the within-cycle write-then-read equivalence of the model and the RTL at this
+    boundary, which no value-only comparison can isolate.
+    """
+
+    def __call__(self, c: bool, a: float, b: float) -> tuple[float, float]:
+        x = a + b
+        if c:
+            y = a / b
+        else:
+            y = x
+        return y * b, x
+
+
+@pytest.mark.cosim
+def test_inflight_equality_cosim() -> None:
+    """
+    RTL == model at the in-flight equality boundary in lockstep: an install firing exactly at its source's landing
+    must read the just-landed value within that cycle in both backends -- a within-cycle write-then-read agreement
+    no value-only comparison isolates.
+    """
+    from ._cosim import run_cosim  # noqa: PLC0415
+    from .hdl.hdl_float_oracle import SIMULATORS  # noqa: PLC0415
+
+    fmt = FloatFormat(8, 36)
+    eq_vectors = [{"c": c, "a": a, "b": b} for c in (True, False) for a, b in [(2.0, 4.0), (3.0, 1.5), (-1.0, 2.0)]]
+    run_cosim(
+        SIMULATORS[0],
+        holoso.synthesize(_InflightEquality().__call__, staged_fadd_options(fmt), name="inflight_equality_seam"),
+        eq_vectors,
+    )

--- a/tests/test_latency_freeze.py
+++ b/tests/test_latency_freeze.py
@@ -64,9 +64,9 @@ _FROZEN_SCHEDULE: dict[str, tuple[int, int]] = {
     "priority_encoder-e6m18": (21, 21),
     "crc32-e6m18": (45, 45),
     "lfsr16-e6m18": (12, 12),
-    # Branchy kernels whose phi-arm installs source block-entry-resident values (boolean/float live-out constants, or an
-    # input/state read) on the normal path -- the inline-class timing (no source-sample edge, no +1 step) lands each
-    # within the work makespan rather than at the copy-pipeline boundary, shrinking every downstream block base.
+    # Branchy kernels whose phi-arm installs have settled sources (boolean/float live-out constants, or an
+    # input/state read) on the normal path -- no read-first push, so each lands within the work boundary,
+    # shrinking every downstream block base.
     "uart_tx-e6m18": (12, 37),
     "uart_rx-e6m18": (6, 51),
     # The loop body's tail copy (y <- y_next) sources y_next, which is NOT the block's last work (delta = y_next - y
@@ -101,8 +101,8 @@ _FROZEN_SCHEDULE: dict[str, tuple[int, int]] = {
     "flux_observer-e8m36": (87, 87),
     # The fusion capstone: three rsqrt sites, each one native fsqrt and one fdiv (a native rsqrt operator would fold
     # the division away too), the gate and first-sample diamonds as real branches, and the clamp on the sorter.
-    "imu_fusion-e8m36": (234, 412),
-    "imu_fusion-e6m18": (207, 349),
+    "imu_fusion-e8m36": (233, 409),
+    "imu_fusion-e6m18": (206, 346),
 }
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -190,13 +190,12 @@ def _measure(name: str) -> Metrics:
 # - last_pc and max_block_span are the stage-count guards. They reflect the per-block drain tightener: the
 #   coalesced-install fixpoint -- a phi-arm predecessor whose every arm coalesces installs nothing, so its
 #   +1 install drain is dropped. The drained boundary is the latest value LANDING per op: every op -- inline (a
-#   select or a bool->float cast) or pooled -- lands at the same uniform per-op landing, and an install reading a
-#   block-entry-RESIDENT source (`value_resident_at_entry`) fires at the
-#   combinational step and drops its +1 install drain. last_pc tiles every block's span (a per-block drain regression
-#   anywhere inflates it); max_block_span localizes it to one block. These timing rules move the schedule-length
-#   guards but not nreg/bnreg/steering/copies; signal_window carries a deliberately-loosened steering arm (one freed
-#   boolean register traded for one write-select mux) -- refrozen rather than chased, since the rules are global and
-#   correctness-neutral.
+#   select or a bool->float cast) or pooled -- lands at the same uniform per-op landing, and an install with a
+#   SETTLED source (`install_source_commit`) fires at the work makespan and drops its +1 install drain. last_pc tiles
+#   every block's span (a per-block drain regression anywhere inflates it); max_block_span localizes it to one
+#   block. These timing rules move the schedule-length guards but not nreg/bnreg/steering/copies; signal_window
+#   carries a deliberately-loosened steering arm (one freed boolean register traded for one write-select mux) --
+#   refrozen rather than chased, since the rules are global and correctness-neutral.
 # - pid uses a variable sample interval: the derivative path contains a real divide, and the first-sample and saturation
 #   guards keep the kernel multi-block with one residual copy. The larger PID row is therefore a property of the example
 #   itself, not a scheduler regression to chase.

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -78,6 +78,7 @@ from ._modelref import (
     branch_boundary_kernel,
     build_model_and_interpreter,
     mir_options,
+    staged_fadd_options,
     ChainedSlots,
     COMPARATOR_OP_CASES,
     default_mir,
@@ -482,10 +483,10 @@ def test_overlapping_loop_kernel_landings_are_real_model_writes(config: Operator
 def test_bool_only_block_drains_at_the_work_boundary() -> None:
     # A drained block that does WORK carrying only boolean values at its boundary lands at boundary_step(makespan) (the
     # one bank-independent drain). The drain distinction that remains is the install's SOURCE, not its bank: a tail
-    # INSTALL whose source is COMPUTED in-block reads-first one step past the work makespan (its block_makespan absorbs
-    # the +1), so it drains one step LATER than a resident-source install that fires combinationally at the work
-    # makespan. Crash-before: a drain that ignored the install source would land a computed-source copy one PC before
-    # its read-first lands.
+    # INSTALL whose source is the block's own LAST work reads-first one step past the work makespan (its
+    # block_makespan absorbs the +1), so it drains one step LATER than a settled-source install that fires
+    # combinationally at the work makespan. Crash-before: a drain that ignored the install source would land a
+    # last-work copy one PC before its read-first lands.
 
     def is_bool_only(block: LirBlock) -> bool:  # no wide register write and no float copy at the tail
         return not block.wide_copies and not any(
@@ -504,35 +505,43 @@ def test_bool_only_block_drains_at_the_work_boundary() -> None:
     ), "pfd Ret: bool work, no install"
     assert pfd_ret.term_offset == boundary_step(pfd_ret.block_makespan, pfd.fetch_lag)
 
-    # An install-bearing bool-only block's drain tracks its install's SOURCE. A COMPUTED-source copy (the phi arm is an
-    # operator result the block produced) reads-first one step past the work makespan, so its block_makespan absorbs the
-    # +1 and the block drains one step LATER -- shrinking it would read the copy one PC before it lands. A source
-    # RESIDENT at block entry (here an input) needs no read-first: the install fires inline-class at the work makespan,
-    # so the block drains one step EARLIER, at boundary_step(makespan). Both residual installs are
-    # forced by `return r, <arm>` keeping the c-false arm live past the merge so it cannot coalesce onto the phi
-    # register; if-conversion is disabled so each diamond stays a real branch rather than collapsing to a select.
-    # (In-place state commit elided the former majority_voter sticky-fault installs.)
+    # An install-bearing bool-only block's drain tracks its install's SOURCE. A copy whose source is the block's own
+    # LAST work reads-first one step past the work makespan, so its block_makespan absorbs the +1 and the block
+    # drains one step LATER -- shrinking it would read the copy one PC before it lands. A source SETTLED at block
+    # entry (here an input) needs no read-first sampling: the install fires at the work makespan and the block drains
+    # at boundary_step(makespan). Both residual installs are forced by `return r, <arm>` keeping the c-false arm live
+    # past the merge so it cannot coalesce onto the phi register; if-conversion is disabled so each diamond stays a
+    # real branch rather than collapsing to a select. (In-place state commit elided the former majority_voter
+    # sticky-fault installs.)
 
     def bool_install_blocks(lir: Lir) -> list[LirBlock]:  # bool-only blocks carrying a tail bool install
         return [b for b in lir.blocks if b.bool_writes and is_bool_only(b)]
 
     def computed_source_install(a: bool, b: bool, c: bool) -> tuple[bool, bool]:
-        x = a and b  # COMPUTED in-block; returned so the c-false arm (= x) cannot coalesce -> a computed-source install
-        r = x
+        # The bool twin of _LastWorkArmSource: q's arm value coalesces onto q's register, so r's install in each arm
+        # sources the arm's OWN (last-committing) boolean op and cannot coalesce (r and q are both live at Ret).
         if c:
-            r = a or b
-        return r, x
+            q = a or b
+            r = q
+        else:
+            q = a and b
+            r = b
+        return r, q
 
-    computed = bool_install_blocks(
-        build_lir(_run(computed_source_install, replace(OPS, ifconv_max_ops=0)), "computed_source_install")
-    )
-    assert computed and all(
-        not w.resident_source for b in computed for w in b.bool_writes
-    ), "no computed-source bool install to exercise the later-draining case"
+    computed = [
+        b
+        for b in bool_install_blocks(
+            build_lir(_run(computed_source_install, replace(OPS, ifconv_max_ops=0)), "computed_source_install")
+        )
+        if any(not w.settled_source for w in b.bool_writes)
+    ]
+    assert computed, "no computed-source bool install to exercise the pushed-drain case"
     for block in computed:
+        work = max(op.commit_cycle for op in _block_ops(block))
+        assert block.block_makespan == work + 1, "a last-work copy source must push the block makespan by one"
         assert block.term_offset == boundary_step(
             block.block_makespan, _FETCH_LAG
-        ), "a computed-source bool install reads-first past the work makespan, draining where its block_makespan lands"
+        ), "a last-work bool install reads-first past the work makespan, draining where its block_makespan lands"
 
     def resident_source_install(a: bool, b: bool, c: bool) -> tuple[bool, bool]:
         r = a  # the c-false arm is the INPUT a (resident at block entry), returned so it cannot coalesce
@@ -544,12 +553,13 @@ def test_bool_only_block_drains_at_the_work_boundary() -> None:
         build_lir(_run(resident_source_install, replace(OPS, ifconv_max_ops=0)), "resident_source_install")
     )
     assert resident and all(
-        w.resident_source for b in resident for w in b.bool_writes
-    ), "no resident-source bool install to exercise the inline-class drain"
+        w.settled_source for b in resident for w in b.bool_writes
+    ), "no settled-source bool install to exercise the unpushed drain"
     for block in resident:
+        assert block.block_makespan == 0, "a settled source must not push the empty block's makespan"
         assert block.term_offset == boundary_step(block.block_makespan, _FETCH_LAG), (
-            "a resident-source bool install fires inline-class at the work makespan, one step under "
-            "a computed-source one"
+            "a settled-source bool install fires at the work makespan and drains at its read-first landing, "
+            "one step under a last-work one"
         )
 
 
@@ -637,11 +647,11 @@ def _const_branch_mir(ops: MirOptions) -> Mir:
 @pytest.mark.parametrize("config", COMPARATOR_OP_CASES, ids=lambda config: config.label)
 def test_const_branch_install_block_drains_to_its_inline_landing(config: OperatorCase) -> None:
     # Regression (fuzz-found B1 miscompile): a block whose branch condition is a literal installs that constant with a
-    # tail bool write. The source is entry-resident, so the write is inline-class: it fires at the combinational step
-    # and lands one read-first edge later, at the combinational landing within the work makespan -- and the block must
-    # drain to exactly that landing, where the terminator then reads the condition the following step. The drain must
-    # neither shrink below it (terminator reads a stale condition -- the original B1 bug) nor pay the wider
-    # computed-source-copy boundary. Crash-before: KeyError (model) / stale branch read (RTL).
+    # tail bool write. The source is settled, so the write fires at the work makespan and lands one read-first edge
+    # later, within the work boundary -- and the block must drain to exactly that landing, where the terminator then
+    # reads the condition the following step. The drain must neither shrink below it (terminator reads a stale
+    # condition -- the original B1 bug) nor pay the wider last-work-copy boundary. Crash-before: KeyError (model) /
+    # stale branch read (RTL).
     lir = build_lir(_const_branch_mir(config.make_mir(FMT)), f"const_branch_{config.label}")
     const_blocks = [
         b
@@ -2379,3 +2389,38 @@ def test_forced_state_copy_regrowth_latches_and_stays_correct(
     for raw in (1.0, 2.0, 3.0, 4.0, 5.0):
         x = fmt.decode(fmt.encode(raw))
         assert float(model.run(x)[0]) == reference(x)
+
+
+def test_inflight_source_install_fires_exactly_at_the_spilled_landing() -> None:
+    # The equality boundary of the in-flight source classification: the entry's LAST op is a staged (latency >= 2),
+    # error-port-free fadd, so the entry's issue-side envelope is that op's own write word (term = commit) and its
+    # result spills at successor-local fetch_lag -- the deepest a received spill can land. The op-less pass-through
+    # arm's install then fires EXACTLY at that landing (fire == landing; a read at a landing step returns the new
+    # value), with the virtual commit negative and no push. `x` is read past the merge so the arm cannot coalesce;
+    # value correctness on both paths rides the model (RTL equivalence is covered by the cosim twin in
+    # test_install_landing).
+    def passthrough(c: bool, a: float, b: float) -> tuple[float, float]:
+        x = a + b
+        if c:
+            y = a / b
+        else:
+            y = x
+        return y * b, x
+
+    lir = build_lir(_run(passthrough, mir_options(staged_fadd_options(FMT)), FMT), "inflight_equality")
+    entry = lir.blocks[lir.entry]
+    producer = next(op for op in entry.ops if op.operator.mnemonic.startswith("fadd"))
+    assert producer.latency >= 2, "the staged fadd must be deep enough for its word to set the entry envelope"
+    assert entry.term_offset == producer.commit_cycle, "the entry envelope must be the producer's own write word"
+    spilled_landing = successor_local_cycle(landing_cycle(producer.commit_cycle, lir.fetch_lag), entry.term_offset)
+    assert spilled_landing == lir.fetch_lag, "the spill must land at the deepest legal step (successor-local 2)"
+    copy = next(c for b in lir.blocks for c in b.wide_copies if not c.settled_source and not (b.ops or b.inline_ops))
+    assert copy.issue_cycle == 0, "a spilled source must not push the install (its virtual commit is negative)"
+    assert copy.fire_step(lir.fetch_lag) == spilled_landing, "the install must fire exactly at the spilled landing"
+
+    model = build_model(lir)
+    for c in (True, False):
+        for a, b in [(2.0, 4.0), (3.0, 1.5), (-1.0, 2.0)]:
+            got = [float(v) for v in model.run(c, a, b)]
+            y = a / b if c else a + b
+            assert abs(got[0] - y * b) < 1e-9 and abs(got[1] - (a + b)) < 1e-9, f"c={c} a={a} b={b}: {got}"


### PR DESCRIPTION
An install whose phi-arm source is an operator result from another basic block was conservatively treated as a possible in-flight spill and pushed one step past the work makespan, stretching its block by a cycle for nothing when the source had long landed.

Effect: imu_fusion e6m18 min II 207 -> 206 (last_pc 349 -> 346), e8m36 234 -> 233; all other frozen schedules unchanged.